### PR TITLE
feat(client,app): window + Vulkan frame loop with swapchain

### DIFF
--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -8,8 +8,9 @@ server = { workspace = true }
 client = { workspace = true }
 shared = { workspace = true, features = ["std"] }
 protocol = { workspace = true }
+gpu-core = { workspace = true }
 winit = { workspace = true }
+glam = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 anyhow = { workspace = true }
-ron = { workspace = true }

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -1,9 +1,207 @@
 //! # app
 //!
-//! Binary entry point. Creates server + client, runs the main loop.
-//! Server ticks physics at 60Hz fixed timestep.
-//! Client renders at max FPS with interpolation.
+//! Binary entry point for the VOX voxel engine.
+//!
+//! Creates a window, initializes Vulkan with surface support,
+//! sets up the renderer, and runs the main event loop.
+//! For the MVP, renders a proof-of-life cycling clear color.
+//! Simulation compute dispatches will be added once the server crate is ready.
 
-fn main() {
-    println!("vox engine — not yet implemented");
+use std::sync::Arc;
+
+use anyhow::Result;
+use winit::application::ApplicationHandler;
+use winit::event::WindowEvent;
+use winit::event_loop::{ActiveEventLoop, EventLoop};
+use winit::window::{Window, WindowAttributes, WindowId};
+
+use client::Renderer;
+use client::renderer::required_instance_extensions;
+use gpu_core::VulkanContext;
+use shared::{
+    MAT_STONE, MAT_WATER, PHASE_LIQUID, PHASE_SOLID, Particle, RENDER_HEIGHT, RENDER_WIDTH,
+};
+
+/// Create the initial set of particles for the MVP demo.
+///
+/// Stone floor at y=2..4 across the grid, and a water cube
+/// floating at y=15..20 in the center.
+fn create_initial_particles() -> Vec<Particle> {
+    use glam::Vec3;
+
+    let mut particles = Vec::new();
+
+    // Stone floor
+    for x in 2..30 {
+        for z in 2..30 {
+            for y in 2..4 {
+                particles.push(Particle::new(
+                    Vec3::new(x as f32, y as f32, z as f32),
+                    1.0,
+                    MAT_STONE,
+                    PHASE_SOLID,
+                ));
+            }
+        }
+    }
+
+    // Water cube
+    for x in 12..20 {
+        for z in 12..20 {
+            for y in 15..20 {
+                particles.push(Particle::new(
+                    Vec3::new(x as f32 + 0.5, y as f32 + 0.5, z as f32 + 0.5),
+                    1.0,
+                    MAT_WATER,
+                    PHASE_LIQUID,
+                ));
+            }
+        }
+    }
+
+    particles
+}
+
+/// Application state for the winit event loop.
+struct App {
+    /// The winit window (created on first `resumed` call).
+    window: Option<Arc<Window>>,
+    /// Vulkan context (created alongside the window).
+    ctx: Option<VulkanContext>,
+    /// Renderer (surface + swapchain + frame management).
+    renderer: Option<Renderer>,
+    /// Initial particles (stored until GPU simulation is ready).
+    _particles: Vec<Particle>,
+}
+
+impl App {
+    fn new() -> Self {
+        let particles = create_initial_particles();
+        tracing::info!("Created {} initial particles", particles.len());
+
+        Self {
+            window: None,
+            ctx: None,
+            renderer: None,
+            _particles: particles,
+        }
+    }
+}
+
+impl ApplicationHandler for App {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        // Only create the window once
+        if self.window.is_some() {
+            return;
+        }
+
+        let attrs = WindowAttributes::default()
+            .with_title("VOX Engine")
+            .with_inner_size(winit::dpi::PhysicalSize::new(RENDER_WIDTH, RENDER_HEIGHT));
+
+        let window = match event_loop.create_window(attrs) {
+            Ok(w) => Arc::new(w),
+            Err(e) => {
+                tracing::error!("Failed to create window: {}", e);
+                event_loop.exit();
+                return;
+            }
+        };
+
+        tracing::info!(
+            "Window created: {}x{}",
+            window.inner_size().width,
+            window.inner_size().height
+        );
+
+        // Create Vulkan context with surface extensions
+        let ctx = match VulkanContext::new_with_instance_extensions(required_instance_extensions()) {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::error!("Failed to create VulkanContext: {}", e);
+                event_loop.exit();
+                return;
+            }
+        };
+
+        // Create renderer (surface + swapchain)
+        let renderer = match Renderer::new(&ctx, &window) {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::error!("Failed to create Renderer: {}", e);
+                event_loop.exit();
+                return;
+            }
+        };
+
+        self.window = Some(window);
+        self.ctx = Some(ctx);
+        self.renderer = Some(renderer);
+    }
+
+    fn window_event(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        _window_id: WindowId,
+        event: WindowEvent,
+    ) {
+        match event {
+            WindowEvent::CloseRequested => {
+                tracing::info!("Close requested, shutting down");
+                // Clean up before exit
+                if let (Some(renderer), Some(ctx)) =
+                    (self.renderer.as_mut(), self.ctx.as_ref())
+                {
+                    renderer.destroy(ctx);
+                }
+                event_loop.exit();
+            }
+
+            WindowEvent::Resized(new_size) => {
+                if let Some(renderer) = self.renderer.as_mut() {
+                    renderer.notify_resized(new_size.width, new_size.height);
+                }
+            }
+
+            WindowEvent::RedrawRequested => {
+                if let (Some(renderer), Some(ctx)) =
+                    (self.renderer.as_mut(), self.ctx.as_ref())
+                {
+                    match renderer.draw_frame(ctx) {
+                        Ok(_) => {}
+                        Err(e) => {
+                            tracing::error!("Frame error: {}", e);
+                        }
+                    }
+                }
+            }
+
+            _ => {}
+        }
+    }
+
+    fn about_to_wait(&mut self, _event_loop: &ActiveEventLoop) {
+        if let Some(window) = &self.window {
+            window.request_redraw();
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    // Initialize tracing
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    tracing::info!("VOX Engine starting");
+
+    let event_loop = EventLoop::new()?;
+    let mut app = App::new();
+    event_loop.run_app(&mut app)?;
+
+    tracing::info!("VOX Engine shut down");
+    Ok(())
 }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -8,6 +8,8 @@ shared = { workspace = true, features = ["std"] }
 protocol = { workspace = true }
 gpu-core = { workspace = true }
 ash = { workspace = true }
+ash-window = { workspace = true }
+raw-window-handle = "0.6"
 glam = { workspace = true }
 bytemuck = { workspace = true }
 winit = { workspace = true }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -1,5 +1,11 @@
 //! # client
 //!
-//! Rendering and input client.
-//! Hardware ray tracing pipeline, FPS camera, keyboard/mouse input,
-//! BLAS building from brick occupancy, frame composition.
+//! Rendering and input client for the VOX voxel engine.
+//!
+//! Manages the window (via winit 0.30), Vulkan surface/swapchain,
+//! and frame loop. For the MVP, renders a proof-of-life clear color
+//! that changes each frame. Voxel ray tracing comes later.
+
+pub mod renderer;
+
+pub use renderer::Renderer;

--- a/crates/client/src/renderer.rs
+++ b/crates/client/src/renderer.rs
@@ -1,0 +1,278 @@
+//! Renderer: owns Vulkan surface, swapchain, and frame manager.
+//!
+//! For the MVP, clears the swapchain image with a color that cycles
+//! based on the frame number (proof of life). Actual voxel ray tracing
+//! rendering will be added in a later iteration.
+
+use ash::vk;
+use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
+use winit::window::Window;
+
+use gpu_core::context::VulkanContext;
+use gpu_core::frame::FrameManager;
+use gpu_core::swapchain::{Swapchain, SURFACE_INSTANCE_EXTENSIONS};
+
+/// Errors that can occur in the renderer.
+#[derive(Debug, thiserror::Error)]
+pub enum RendererError {
+    /// GPU-core error.
+    #[error("GPU error: {0}")]
+    Gpu(#[from] gpu_core::error::GpuError),
+
+    /// Window handle error.
+    #[error("Window handle error: {0}")]
+    HandleError(#[from] raw_window_handle::HandleError),
+
+    /// Vulkan result error (from ash-window surface creation).
+    #[error("Vulkan error: {0}")]
+    Vulkan(vk::Result),
+}
+
+/// Result type alias for renderer operations.
+pub type Result<T> = std::result::Result<T, RendererError>;
+
+/// Returns the instance extensions required for windowed rendering.
+///
+/// Pass these to `VulkanContext::new_with_instance_extensions`.
+pub fn required_instance_extensions() -> &'static [&'static std::ffi::CStr] {
+    SURFACE_INSTANCE_EXTENSIONS
+}
+
+/// The renderer owns the Vulkan surface, swapchain, and frame manager.
+///
+/// Create via [`Renderer::new`] after creating a `VulkanContext` with
+/// the extensions from [`required_instance_extensions`].
+pub struct Renderer {
+    surface: vk::SurfaceKHR,
+    surface_loader: ash::khr::surface::Instance,
+    swapchain: Swapchain,
+    frame_manager: FrameManager,
+    frame_number: u64,
+    needs_resize: bool,
+    width: u32,
+    height: u32,
+}
+
+impl Renderer {
+    /// Create a new renderer attached to the given window.
+    ///
+    /// The `VulkanContext` must have been created with the surface instance
+    /// extensions (see [`required_instance_extensions`]).
+    pub fn new(ctx: &VulkanContext, window: &Window) -> Result<Self> {
+        // Create surface via ash-window
+        let surface = unsafe {
+            ash_window::create_surface(
+                &ctx.entry,
+                &ctx.instance,
+                window.display_handle()?.as_raw(),
+                window.window_handle()?.as_raw(),
+                None,
+            )
+            .map_err(RendererError::Vulkan)?
+        };
+
+        let surface_loader =
+            ash::khr::surface::Instance::new(&ctx.entry, &ctx.instance);
+
+        let size = window.inner_size();
+        let width = size.width.max(1);
+        let height = size.height.max(1);
+
+        let swapchain =
+            Swapchain::new(ctx, &surface_loader, surface, width, height)?;
+
+        let frame_manager = FrameManager::new(ctx)?;
+
+        tracing::info!(
+            "Renderer initialized: {}x{}, {} swapchain images",
+            width,
+            height,
+            swapchain.images.len()
+        );
+
+        Ok(Self {
+            surface,
+            surface_loader,
+            swapchain,
+            frame_manager,
+            frame_number: 0,
+            needs_resize: false,
+            width,
+            height,
+        })
+    }
+
+    /// Mark the renderer for swapchain recreation on the next frame.
+    ///
+    /// Call this when the window is resized.
+    pub fn notify_resized(&mut self, width: u32, height: u32) {
+        self.width = width.max(1);
+        self.height = height.max(1);
+        self.needs_resize = true;
+        tracing::debug!("Resize requested: {}x{}", self.width, self.height);
+    }
+
+    /// Render one frame: acquire image, clear with a cycling color, present.
+    ///
+    /// Returns `Ok(true)` on success, `Ok(false)` if the frame was skipped
+    /// (e.g., minimized window), or an error.
+    pub fn draw_frame(&mut self, ctx: &VulkanContext) -> Result<bool> {
+        if self.needs_resize {
+            self.recreate_swapchain(ctx)?;
+            self.needs_resize = false;
+        }
+
+        // Skip drawing if window is minimized (zero extent)
+        if self.width == 0 || self.height == 0 {
+            return Ok(false);
+        }
+
+        // Begin frame (acquire swapchain image)
+        let frame_ctx = match self.frame_manager.begin_frame(ctx, &self.swapchain)? {
+            Some(fc) => fc,
+            None => {
+                // Swapchain out of date, recreate
+                self.recreate_swapchain(ctx)?;
+                return Ok(false);
+            }
+        };
+
+        let cmd = frame_ctx.command_buffer;
+        let image = self.swapchain.images[frame_ctx.image_index as usize];
+
+        // Transition image: UNDEFINED -> TRANSFER_DST_OPTIMAL
+        let barrier_to_clear = vk::ImageMemoryBarrier::default()
+            .src_access_mask(vk::AccessFlags::empty())
+            .dst_access_mask(vk::AccessFlags::TRANSFER_WRITE)
+            .old_layout(vk::ImageLayout::UNDEFINED)
+            .new_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
+            .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+            .dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+            .image(image)
+            .subresource_range(full_color_range());
+
+        unsafe {
+            ctx.device.cmd_pipeline_barrier(
+                cmd,
+                vk::PipelineStageFlags::TOP_OF_PIPE,
+                vk::PipelineStageFlags::TRANSFER,
+                vk::DependencyFlags::empty(),
+                &[],
+                &[],
+                &[barrier_to_clear],
+            );
+        }
+
+        // Clear with a cycling color (proof of life)
+        let t = self.frame_number as f32 * 0.01;
+        let clear_color = vk::ClearColorValue {
+            float32: [
+                (t.sin() * 0.5 + 0.5) * 0.2,
+                (t * 0.7).sin() * 0.5 + 0.5,
+                ((t * 1.3).sin() * 0.5 + 0.5) * 0.8,
+                1.0,
+            ],
+        };
+
+        unsafe {
+            ctx.device.cmd_clear_color_image(
+                cmd,
+                image,
+                vk::ImageLayout::TRANSFER_DST_OPTIMAL,
+                &clear_color,
+                &[full_color_range()],
+            );
+        }
+
+        // Transition image: TRANSFER_DST_OPTIMAL -> PRESENT_SRC_KHR
+        let barrier_to_present = vk::ImageMemoryBarrier::default()
+            .src_access_mask(vk::AccessFlags::TRANSFER_WRITE)
+            .dst_access_mask(vk::AccessFlags::empty())
+            .old_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
+            .new_layout(vk::ImageLayout::PRESENT_SRC_KHR)
+            .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+            .dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+            .image(image)
+            .subresource_range(full_color_range());
+
+        unsafe {
+            ctx.device.cmd_pipeline_barrier(
+                cmd,
+                vk::PipelineStageFlags::TRANSFER,
+                vk::PipelineStageFlags::BOTTOM_OF_PIPE,
+                vk::DependencyFlags::empty(),
+                &[],
+                &[],
+                &[barrier_to_present],
+            );
+        }
+
+        // End frame (submit + present)
+        let present_ok =
+            self.frame_manager.end_frame(ctx, &self.swapchain, frame_ctx)?;
+
+        if !present_ok {
+            self.needs_resize = true;
+        }
+
+        self.frame_number += 1;
+        Ok(true)
+    }
+
+    /// Recreate the swapchain (e.g., after a window resize).
+    fn recreate_swapchain(&mut self, ctx: &VulkanContext) -> Result<()> {
+        unsafe {
+            ctx.device.device_wait_idle().map_err(gpu_core::GpuError::Vulkan)?;
+        }
+
+        self.swapchain.destroy(ctx);
+
+        self.swapchain = Swapchain::new(
+            ctx,
+            &self.surface_loader,
+            self.surface,
+            self.width,
+            self.height,
+        )?;
+
+        tracing::info!(
+            "Swapchain recreated: {}x{}",
+            self.swapchain.extent.width,
+            self.swapchain.extent.height
+        );
+
+        Ok(())
+    }
+
+    /// Destroy all renderer resources. Must be called before the `VulkanContext`
+    /// is dropped.
+    pub fn destroy(&mut self, ctx: &VulkanContext) {
+        unsafe {
+            let _ = ctx.device.device_wait_idle();
+        }
+
+        self.frame_manager.destroy(ctx);
+        self.swapchain.destroy(ctx);
+
+        unsafe {
+            self.surface_loader.destroy_surface(self.surface, None);
+        }
+
+        tracing::info!("Renderer destroyed");
+    }
+
+    /// Get the current frame number.
+    pub fn frame_number(&self) -> u64 {
+        self.frame_number
+    }
+}
+
+/// Helper: full color subresource range (mip 0, layer 0).
+fn full_color_range() -> vk::ImageSubresourceRange {
+    vk::ImageSubresourceRange::default()
+        .aspect_mask(vk::ImageAspectFlags::COLOR)
+        .base_mip_level(0)
+        .level_count(1)
+        .base_array_layer(0)
+        .layer_count(1)
+}


### PR DESCRIPTION
## Summary
- **client crate**: `Renderer` struct that creates a Vulkan surface (via ash-window), manages swapchain lifecycle (create/recreate on resize/destroy), and renders a proof-of-life cycling clear color using `vkCmdClearColorImage` with proper image layout transitions
- **app crate**: winit 0.30 `ApplicationHandler` event loop that initializes tracing, creates VulkanContext with surface extensions, handles resize/close/redraw events, and drives continuous rendering
- Initial particle setup (1568 stone floor + 320 water cube particles) prepared for simulation integration

## Details
- Uses `UNDEFINED -> TRANSFER_DST_OPTIMAL -> PRESENT_SRC_KHR` layout transitions
- Swapchain recreation on resize with device idle wait
- No `unwrap()` in lib code; `thiserror` for client errors, `anyhow` in main
- All `pub` items doc-commented
- All 80 existing tests pass

## Test plan
- [x] `cargo build -p client -p app` compiles cleanly
- [x] `cargo test -p shared -p protocol -p sim-cpu -p client` — all 80 tests pass
- [ ] `cargo run -p app` — opens window with cycling color (manual verification on GPU machine)

Closes #19 (partial — window + frame loop, no voxel rendering yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)