### PR TITLE
fix(gpu): add VK_KHR_swapchain to required device extensions

### DIFF
--- a/crates/gpu-core/src/context.rs
+++ b/crates/gpu-core/src/context.rs
@@ -37,6 +37,8 @@ const REQUIRED_DEVICE_EXTENSIONS: &[&CStr] = &[
     ash::khr::shader_float_controls::NAME,
     // P2G shader uses spirv_std::arch::atomic_f_add() for scatter accumulation
     ash::ext::shader_atomic_float::NAME,
+    // Swapchain presentation to window surface
+    ash::khr::swapchain::NAME,
 ];
 
 /// Indices of the queue families used by the engine.


### PR DESCRIPTION
## Summary
- Adds `ash::khr::swapchain::NAME` to `REQUIRED_DEVICE_EXTENSIONS` in `gpu-core/src/context.rs`
- Fixes crash: "Unable to load create_swapchain_khr" when creating a swapchain for window presentation

Closes #29

## Test plan
- [x] `cargo build -p gpu-core` compiles
- [x] `cargo test -p gpu-core` — all 13 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)