### PR TITLE
feat: simple voxel ray-march visualization

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -196,15 +196,21 @@ impl ApplicationHandler for App {
                 if let (Some(renderer), Some(ctx), Some(sim)) =
                     (self.renderer.as_mut(), self.ctx.as_ref(), self.sim.as_ref())
                 {
-                    // Run simulation step (separate command buffer submission)
+                    // Run simulation step + render to buffer (separate submission)
                     if let Err(e) = ctx.execute_one_shot(|cmd| {
                         sim.step(cmd);
+                        sim.render(cmd, RENDER_WIDTH, RENDER_HEIGHT);
                     }) {
-                        tracing::error!("Simulation step error: {}", e);
+                        tracing::error!("Simulation/render error: {}", e);
                     }
 
-                    // Render frame (acquire, record clear, submit, present)
-                    match renderer.draw_frame(ctx) {
+                    // Copy render output buffer to swapchain and present
+                    match renderer.draw_frame_with_buffer(
+                        ctx,
+                        sim.render_output_buffer(),
+                        RENDER_WIDTH,
+                        RENDER_HEIGHT,
+                    ) {
                         Ok(_) => {}
                         Err(e) => {
                             tracing::error!("Frame error: {}", e);

--- a/crates/client/src/renderer.rs
+++ b/crates/client/src/renderer.rs
@@ -219,6 +219,133 @@ impl Renderer {
         Ok(true)
     }
 
+    /// Render one frame by copying a pre-rendered pixel buffer to the swapchain.
+    ///
+    /// The `render_buffer` must contain `width * height` packed BGRA u32 pixels
+    /// and must have `TRANSFER_SRC` usage. Returns `Ok(true)` on success,
+    /// `Ok(false)` if skipped, or an error.
+    pub fn draw_frame_with_buffer(
+        &mut self,
+        ctx: &VulkanContext,
+        render_buffer: vk::Buffer,
+        width: u32,
+        height: u32,
+    ) -> Result<bool> {
+        if self.needs_resize {
+            self.recreate_swapchain(ctx)?;
+            self.needs_resize = false;
+        }
+
+        // Skip if minimized
+        if self.width == 0 || self.height == 0 {
+            return Ok(false);
+        }
+
+        // Begin frame (acquire swapchain image)
+        let frame_ctx = match self.frame_manager.begin_frame(ctx, &self.swapchain)? {
+            Some(fc) => fc,
+            None => {
+                self.recreate_swapchain(ctx)?;
+                return Ok(false);
+            }
+        };
+
+        let cmd = frame_ctx.command_buffer;
+        let image = self.swapchain.images[frame_ctx.image_index as usize];
+
+        // Transition image: UNDEFINED -> TRANSFER_DST_OPTIMAL
+        let barrier_to_dst = vk::ImageMemoryBarrier::default()
+            .src_access_mask(vk::AccessFlags::empty())
+            .dst_access_mask(vk::AccessFlags::TRANSFER_WRITE)
+            .old_layout(vk::ImageLayout::UNDEFINED)
+            .new_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
+            .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+            .dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+            .image(image)
+            .subresource_range(full_color_range());
+
+        unsafe {
+            ctx.device.cmd_pipeline_barrier(
+                cmd,
+                vk::PipelineStageFlags::TOP_OF_PIPE,
+                vk::PipelineStageFlags::TRANSFER,
+                vk::DependencyFlags::empty(),
+                &[],
+                &[],
+                &[barrier_to_dst],
+            );
+        }
+
+        // Copy buffer to image
+        // The buffer has width*height packed u32 pixels.
+        // The swapchain image may be a different size, so we copy the min extent.
+        let copy_width = width.min(self.swapchain.extent.width);
+        let copy_height = height.min(self.swapchain.extent.height);
+
+        let region = vk::BufferImageCopy::default()
+            .buffer_offset(0)
+            .buffer_row_length(width) // stride in pixels (our buffer row length)
+            .buffer_image_height(height)
+            .image_subresource(
+                vk::ImageSubresourceLayers::default()
+                    .aspect_mask(vk::ImageAspectFlags::COLOR)
+                    .mip_level(0)
+                    .base_array_layer(0)
+                    .layer_count(1),
+            )
+            .image_offset(vk::Offset3D { x: 0, y: 0, z: 0 })
+            .image_extent(vk::Extent3D {
+                width: copy_width,
+                height: copy_height,
+                depth: 1,
+            });
+
+        unsafe {
+            ctx.device.cmd_copy_buffer_to_image(
+                cmd,
+                render_buffer,
+                image,
+                vk::ImageLayout::TRANSFER_DST_OPTIMAL,
+                &[region],
+            );
+        }
+
+        // Transition image: TRANSFER_DST_OPTIMAL -> PRESENT_SRC_KHR
+        let barrier_to_present = vk::ImageMemoryBarrier::default()
+            .src_access_mask(vk::AccessFlags::TRANSFER_WRITE)
+            .dst_access_mask(vk::AccessFlags::empty())
+            .old_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
+            .new_layout(vk::ImageLayout::PRESENT_SRC_KHR)
+            .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+            .dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+            .image(image)
+            .subresource_range(full_color_range());
+
+        unsafe {
+            ctx.device.cmd_pipeline_barrier(
+                cmd,
+                vk::PipelineStageFlags::TRANSFER,
+                vk::PipelineStageFlags::BOTTOM_OF_PIPE,
+                vk::DependencyFlags::empty(),
+                &[],
+                &[],
+                &[barrier_to_present],
+            );
+        }
+
+        // End frame (submit + present)
+        let present_ok = self
+            .frame_manager
+            .end_frame(ctx, &self.swapchain, frame_ctx)?;
+
+        if !present_ok {
+            self.needs_resize = true;
+        }
+
+        self.frame_number += 1;
+        Ok(true)
+    }
+
     /// Recreate the swapchain (e.g., after a window resize).
     fn recreate_swapchain(&mut self, ctx: &VulkanContext) -> Result<()> {
         unsafe {

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -18,7 +18,9 @@ use gpu_core::{
     buffer::{self, GpuBuffer},
     pipeline,
 };
-use shared::{GRID_CELL_COUNT, GRID_SIZE, GridCell, MAX_PARTICLES, Particle};
+use shared::{
+    GRID_CELL_COUNT, GRID_SIZE, GridCell, MAX_PARTICLES, Particle, RENDER_HEIGHT, RENDER_WIDTH,
+};
 
 /// Compiled SPIR-V shader module bytes, included at compile time.
 const SHADER_BYTES: &[u8] = include_bytes!(env!("SHADERS_SPV_PATH"));
@@ -83,6 +85,24 @@ pub struct VoxelizePushConstants {
     pub _pad1: u32,
 }
 
+/// Push constants for the render shader.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Pod, bytemuck::Zeroable)]
+pub struct RenderPushConstants {
+    /// Render target width in pixels.
+    pub width: u32,
+    /// Render target height in pixels.
+    pub height: u32,
+    /// Grid dimension (cells per axis).
+    pub grid_size: u32,
+    /// Padding.
+    pub _pad: u32,
+    /// Camera eye position (xyz) + padding (w).
+    pub eye: glam::Vec4,
+    /// Camera target position (xyz) + padding (w).
+    pub target: glam::Vec4,
+}
+
 // ---------------------------------------------------------------------------
 // Error type
 // ---------------------------------------------------------------------------
@@ -127,6 +147,7 @@ pub struct GpuSimulation {
     particle_buffer: GpuBuffer,
     grid_buffer: GpuBuffer,
     voxel_buffer: GpuBuffer,
+    render_output_buffer: GpuBuffer,
 
     // Compute passes
     clear_grid_pass: ComputePass,
@@ -135,6 +156,7 @@ pub struct GpuSimulation {
     g2p_pass: ComputePass,
     clear_voxels_pass: ComputePass,
     voxelize_pass: ComputePass,
+    render_pass: ComputePass,
 
     // Shader module (kept alive for pipeline lifetime)
     shader_module: vk::ShaderModule,
@@ -193,14 +215,25 @@ impl GpuSimulation {
             "voxel-buffer",
         )?;
 
+        // Render output buffer: RGBA u32 per pixel, needs TRANSFER_SRC for copy to swapchain
+        let render_output_size =
+            (RENDER_WIDTH as usize * RENDER_HEIGHT as usize * mem::size_of::<u32>())
+                as vk::DeviceSize;
+        let render_output_buffer = buffer::create_device_local_buffer(
+            ctx,
+            render_output_size,
+            vk::BufferUsageFlags::STORAGE_BUFFER | vk::BufferUsageFlags::TRANSFER_SRC,
+            "render-output-buffer",
+        )?;
+
         // -- Descriptor pool --
-        // 6 passes, max 2 bindings each = up to 12 storage buffer descriptors
+        // 7 passes, max 2 bindings each = up to 14 storage buffer descriptors
         let pool_sizes = [vk::DescriptorPoolSize {
             ty: vk::DescriptorType::STORAGE_BUFFER,
-            descriptor_count: 12,
+            descriptor_count: 14,
         }];
         let descriptor_pool =
-            pipeline::create_descriptor_pool(ctx, &pool_sizes, 6, "sim-descriptor-pool")?;
+            pipeline::create_descriptor_pool(ctx, &pool_sizes, 7, "sim-descriptor-pool")?;
 
         // -- Create each compute pass --
         // Entry point names are fully qualified module paths in rust-gpu SPIR-V.
@@ -264,18 +297,30 @@ impl GpuSimulation {
             "voxelize",
         )?;
 
+        let render_pass = Self::create_pass(
+            ctx,
+            shader_module,
+            c"compute::render::render_voxels",
+            &[&voxel_buffer, &render_output_buffer],
+            mem::size_of::<RenderPushConstants>() as u32,
+            descriptor_pool,
+            "render",
+        )?;
+
         tracing::info!("GpuSimulation created successfully");
 
         Ok(Self {
             particle_buffer,
             grid_buffer,
             voxel_buffer,
+            render_output_buffer,
             clear_grid_pass,
             p2g_pass,
             grid_update_pass,
             g2p_pass,
             clear_voxels_pass,
             voxelize_pass,
+            render_pass,
             shader_module,
             descriptor_pool,
             num_particles: 0,
@@ -428,6 +473,60 @@ impl GpuSimulation {
         &self.voxel_buffer
     }
 
+    /// Returns the Vulkan buffer handle for the render output.
+    ///
+    /// The buffer contains packed BGRA u32 pixels, sized `width * height`.
+    pub fn render_output_buffer(&self) -> vk::Buffer {
+        self.render_output_buffer.buffer
+    }
+
+    /// Record a render dispatch into the given command buffer.
+    ///
+    /// Ray-marches through the voxel grid and writes pixel data to the
+    /// render output buffer. The command buffer must be in recording state.
+    /// Call this after `step()` (which populates the voxel buffer).
+    pub fn render(&self, cmd: vk::CommandBuffer, width: u32, height: u32) {
+        // Barrier: ensure voxelize writes are visible to render shader reads
+        Self::barrier(cmd, &self.device);
+
+        let push = RenderPushConstants {
+            width,
+            height,
+            grid_size: GRID_SIZE,
+            _pad: 0,
+            eye: glam::Vec4::new(48.0, 32.0, 48.0, 0.0),
+            target: glam::Vec4::new(16.0, 8.0, 16.0, 0.0),
+        };
+
+        let wg_x = (width + 7) / 8;
+        let wg_y = (height + 7) / 8;
+
+        self.dispatch(
+            cmd,
+            &self.render_pass,
+            wg_x,
+            wg_y,
+            1,
+            bytemuck::bytes_of(&push),
+        );
+
+        // Barrier: ensure render writes are complete before buffer-to-image copy
+        let memory_barrier = vk::MemoryBarrier::default()
+            .src_access_mask(vk::AccessFlags::SHADER_WRITE)
+            .dst_access_mask(vk::AccessFlags::TRANSFER_READ);
+        unsafe {
+            self.device.cmd_pipeline_barrier(
+                cmd,
+                vk::PipelineStageFlags::COMPUTE_SHADER,
+                vk::PipelineStageFlags::TRANSFER,
+                vk::DependencyFlags::empty(),
+                &[memory_barrier],
+                &[],
+                &[],
+            );
+        }
+    }
+
     // -- Internal helpers --
 
     /// Create a single compute pass: descriptor set layout, pipeline layout,
@@ -568,6 +667,7 @@ impl GpuSimulation {
             &self.g2p_pass,
             &self.clear_voxels_pass,
             &self.voxelize_pass,
+            &self.render_pass,
         ];
         for pass in passes {
             pipeline::destroy_pipeline(ctx, pass.pipeline);
@@ -607,9 +707,18 @@ impl GpuSimulation {
                 size: 0,
             },
         );
+        let render_output_buf = std::mem::replace(
+            &mut self.render_output_buffer,
+            GpuBuffer {
+                buffer: vk::Buffer::null(),
+                allocation: None,
+                size: 0,
+            },
+        );
         buffer::destroy_buffer(ctx, particle_buf);
         buffer::destroy_buffer(ctx, grid_buf);
         buffer::destroy_buffer(ctx, voxel_buf);
+        buffer::destroy_buffer(ctx, render_output_buf);
     }
 }
 
@@ -629,6 +738,8 @@ mod tests {
         assert_eq!(mem::size_of::<GridUpdatePushConstants>(), 16);
         assert_eq!(mem::size_of::<G2pPushConstants>(), 16);
         assert_eq!(mem::size_of::<VoxelizePushConstants>(), 16);
+        // RenderPushConstants: 4 u32s (16 bytes) + 2 Vec4s (32 bytes) = 48 bytes
+        assert_eq!(mem::size_of::<RenderPushConstants>(), 48);
     }
 
     #[test]

--- a/crates/shaders/src/compute/mod.rs
+++ b/crates/shaders/src/compute/mod.rs
@@ -12,6 +12,7 @@ pub mod clear_grid;
 pub mod g2p;
 pub mod grid_update;
 pub mod p2g;
+pub mod render;
 pub mod voxelize;
 
 /// Compute 1D quadratic B-spline weights for a particle at fractional position `fx`.

--- a/crates/shaders/src/compute/render.rs
+++ b/crates/shaders/src/compute/render.rs
@@ -1,0 +1,358 @@
+//! Render compute shader: ray-marches through voxel grid and writes pixels.
+//!
+//! Dispatched with (ceil(width/8), ceil(height/8), 1) workgroups.
+//! Each thread computes one pixel via DDA ray marching through the 3D voxel grid.
+
+use spirv_std::glam::{UVec3, UVec4, Vec3, Vec4};
+#[cfg(target_arch = "spirv")]
+use spirv_std::num_traits::Float;
+use spirv_std::spirv;
+
+/// Push constants for the render shader.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct RenderPushConstants {
+    /// Render target width in pixels.
+    pub width: u32,
+    /// Render target height in pixels.
+    pub height: u32,
+    /// Grid dimension (cells per axis).
+    pub grid_size: u32,
+    /// Padding.
+    pub _pad: u32,
+    /// Camera eye position (xyz) + padding (w).
+    pub eye: Vec4,
+    /// Camera target position (xyz) + padding (w).
+    pub target: Vec4,
+}
+
+/// Normalize a Vec3 without using the `length()` method (more portable for SPIR-V).
+fn normalize_vec3(v: Vec3) -> Vec3 {
+    let len_sq = v.x * v.x + v.y * v.y + v.z * v.z;
+    if len_sq < 1e-12 {
+        return Vec3::new(0.0, 1.0, 0.0);
+    }
+    let inv_len = 1.0 / len_sq.sqrt();
+    Vec3::new(v.x * inv_len, v.y * inv_len, v.z * inv_len)
+}
+
+/// Cross product of two Vec3s.
+fn cross(a: Vec3, b: Vec3) -> Vec3 {
+    Vec3::new(
+        a.y * b.z - a.z * b.y,
+        a.z * b.x - a.x * b.z,
+        a.x * b.y - a.y * b.x,
+    )
+}
+
+/// Dot product of two Vec3s.
+fn dot(a: Vec3, b: Vec3) -> f32 {
+    a.x * b.x + a.y * b.y + a.z * b.z
+}
+
+/// Compute camera ray direction for a given pixel coordinate.
+///
+/// Returns a normalized ray direction using a simple perspective camera
+/// with vertical FOV of ~60 degrees.
+fn compute_ray(
+    px: u32,
+    py: u32,
+    width: u32,
+    height: u32,
+    eye: Vec3,
+    target: Vec3,
+) -> Vec3 {
+    let w = width as f32;
+    let h = height as f32;
+
+    // Normalized device coordinates: [-1, 1]
+    let ndc_x = (2.0 * (px as f32 + 0.5) / w) - 1.0;
+    let ndc_y = 1.0 - (2.0 * (py as f32 + 0.5) / h);
+
+    // Aspect ratio
+    let aspect = w / h;
+
+    // FOV ~60 degrees -> tan(30) ~= 0.577
+    let fov_tan = 0.577;
+
+    // Camera basis
+    let forward = normalize_vec3(Vec3::new(
+        target.x - eye.x,
+        target.y - eye.y,
+        target.z - eye.z,
+    ));
+    let world_up = Vec3::new(0.0, 1.0, 0.0);
+    let right = normalize_vec3(cross(forward, world_up));
+    let up = cross(right, forward);
+
+    // Ray direction in world space
+    let dir = Vec3::new(
+        forward.x + right.x * ndc_x * aspect * fov_tan + up.x * ndc_y * fov_tan,
+        forward.y + right.y * ndc_x * aspect * fov_tan + up.y * ndc_y * fov_tan,
+        forward.z + right.z * ndc_x * aspect * fov_tan + up.z * ndc_y * fov_tan,
+    );
+
+    normalize_vec3(dir)
+}
+
+/// Pack RGBA color components (0-255) into a u32 for B8G8R8A8 swapchain format.
+///
+/// Byte order: R in lowest byte, then G, B, A (little-endian 0xAABBGGRR).
+fn pack_bgra(r: u32, g: u32, b: u32, a: u32) -> u32 {
+    // For B8G8R8A8_SRGB on little-endian: bytes are B, G, R, A
+    // But vkCmdCopyBufferToImage interprets buffer bytes linearly,
+    // so for B8G8R8A8_SRGB we need: byte0=B, byte1=G, byte2=R, byte3=A
+    // In u32 little-endian: 0xAARRGGBB
+    b | (g << 8) | (r << 16) | (a << 24)
+}
+
+/// Get color for a material ID.
+///
+/// Returns (r, g, b) as floats in [0, 1].
+fn material_color(material_id: u32) -> Vec3 {
+    if material_id == 0 {
+        // Stone: gray
+        Vec3::new(0.5, 0.5, 0.5)
+    } else if material_id == 1 {
+        // Water: blue
+        Vec3::new(0.2, 0.4, 0.9)
+    } else if material_id == 2 {
+        // Lava: orange
+        Vec3::new(1.0, 0.3, 0.0)
+    } else {
+        // Unknown: magenta
+        Vec3::new(1.0, 0.0, 1.0)
+    }
+}
+
+/// Apply simple diffuse lighting to a surface color.
+///
+/// Uses a directional light from the upper right and ambient term.
+fn apply_lighting(color: Vec3, normal: Vec3) -> Vec3 {
+    let light_dir = normalize_vec3(Vec3::new(0.4, 0.8, 0.3));
+    let ndotl = dot(normal, light_dir);
+    let diffuse = if ndotl > 0.0 { ndotl } else { 0.0 };
+
+    let ambient = 0.3;
+    let intensity = ambient + (1.0 - ambient) * diffuse;
+
+    Vec3::new(
+        color.x * intensity,
+        color.y * intensity,
+        color.z * intensity,
+    )
+}
+
+/// Perform DDA ray march through the voxel grid and write pixel color.
+///
+/// This is the main per-pixel function, separated from the entry point
+/// as required by the rust-gpu linker bug workaround (trap #4a).
+pub fn render_pixel(
+    px: u32,
+    py: u32,
+    push: &RenderPushConstants,
+    voxels: &[UVec4],
+    output: &mut [u32],
+) {
+    let width = push.width;
+    let height = push.height;
+    let grid_size = push.grid_size;
+
+    if px >= width || py >= height {
+        return;
+    }
+
+    let eye = Vec3::new(push.eye.x, push.eye.y, push.eye.z);
+    let target = Vec3::new(push.target.x, push.target.y, push.target.z);
+    let ray_dir = compute_ray(px, py, width, height, eye, target);
+
+    // DDA ray marching through voxel grid
+    let grid = grid_size as f32;
+
+    // Find entry point into the grid [0, grid_size]^3
+    // Ray: P = eye + t * dir
+    // We need to find t_enter and t_exit for the AABB [0, grid]^3
+    let mut t_min = 0.0_f32;
+    let mut t_max = 1e20_f32;
+
+    // X axis
+    if ray_dir.x.abs() > 1e-8 {
+        let t1 = (0.0 - eye.x) / ray_dir.x;
+        let t2 = (grid - eye.x) / ray_dir.x;
+        let (ta, tb) = if t1 < t2 { (t1, t2) } else { (t2, t1) };
+        t_min = if ta > t_min { ta } else { t_min };
+        t_max = if tb < t_max { tb } else { t_max };
+    } else if eye.x < 0.0 || eye.x > grid {
+        // Ray parallel to X slab and outside
+        let pixel_idx = (py * width + px) as usize;
+        output[pixel_idx] = pack_bgra(15, 15, 25, 255);
+        return;
+    }
+
+    // Y axis
+    if ray_dir.y.abs() > 1e-8 {
+        let t1 = (0.0 - eye.y) / ray_dir.y;
+        let t2 = (grid - eye.y) / ray_dir.y;
+        let (ta, tb) = if t1 < t2 { (t1, t2) } else { (t2, t1) };
+        t_min = if ta > t_min { ta } else { t_min };
+        t_max = if tb < t_max { tb } else { t_max };
+    } else if eye.y < 0.0 || eye.y > grid {
+        let pixel_idx = (py * width + px) as usize;
+        output[pixel_idx] = pack_bgra(15, 15, 25, 255);
+        return;
+    }
+
+    // Z axis
+    if ray_dir.z.abs() > 1e-8 {
+        let t1 = (0.0 - eye.z) / ray_dir.z;
+        let t2 = (grid - eye.z) / ray_dir.z;
+        let (ta, tb) = if t1 < t2 { (t1, t2) } else { (t2, t1) };
+        t_min = if ta > t_min { ta } else { t_min };
+        t_max = if tb < t_max { tb } else { t_max };
+    } else if eye.z < 0.0 || eye.z > grid {
+        let pixel_idx = (py * width + px) as usize;
+        output[pixel_idx] = pack_bgra(15, 15, 25, 255);
+        return;
+    }
+
+    if t_min > t_max || t_max < 0.0 {
+        let pixel_idx = (py * width + px) as usize;
+        output[pixel_idx] = pack_bgra(15, 15, 25, 255);
+        return;
+    }
+
+    // Start point: clamp t_min to be >= 0 (eye may be inside the grid)
+    if t_min < 0.0 {
+        t_min = 0.0;
+    }
+
+    // Entry point into the grid
+    let entry = Vec3::new(
+        eye.x + ray_dir.x * (t_min + 0.001),
+        eye.y + ray_dir.y * (t_min + 0.001),
+        eye.z + ray_dir.z * (t_min + 0.001),
+    );
+
+    // Current voxel
+    let gs = grid_size as i32;
+    let mut vx = entry.x as i32;
+    let mut vy = entry.y as i32;
+    let mut vz = entry.z as i32;
+
+    // Clamp to valid range
+    if vx < 0 { vx = 0; }
+    if vy < 0 { vy = 0; }
+    if vz < 0 { vz = 0; }
+    if vx >= gs { vx = gs - 1; }
+    if vy >= gs { vy = gs - 1; }
+    if vz >= gs { vz = gs - 1; }
+
+    // Step direction
+    let step_x: i32 = if ray_dir.x >= 0.0 { 1 } else { -1 };
+    let step_y: i32 = if ray_dir.y >= 0.0 { 1 } else { -1 };
+    let step_z: i32 = if ray_dir.z >= 0.0 { 1 } else { -1 };
+
+    // t_delta: how far along the ray to cross one voxel in each axis
+    let t_delta_x = if ray_dir.x.abs() > 1e-8 { (1.0 / ray_dir.x).abs() } else { 1e20 };
+    let t_delta_y = if ray_dir.y.abs() > 1e-8 { (1.0 / ray_dir.y).abs() } else { 1e20 };
+    let t_delta_z = if ray_dir.z.abs() > 1e-8 { (1.0 / ray_dir.z).abs() } else { 1e20 };
+
+    // t_max_axis: distance to next voxel boundary
+    let next_x = if step_x > 0 { (vx + 1) as f32 } else { vx as f32 };
+    let next_y = if step_y > 0 { (vy + 1) as f32 } else { vy as f32 };
+    let next_z = if step_z > 0 { (vz + 1) as f32 } else { vz as f32 };
+
+    let mut t_max_x = if ray_dir.x.abs() > 1e-8 { (next_x - entry.x) / ray_dir.x } else { 1e20 };
+    let mut t_max_y = if ray_dir.y.abs() > 1e-8 { (next_y - entry.y) / ray_dir.y } else { 1e20 };
+    let mut t_max_z = if ray_dir.z.abs() > 1e-8 { (next_z - entry.z) / ray_dir.z } else { 1e20 };
+
+    // DDA traversal
+    let max_steps = grid_size * 3; // sqrt(3) * grid_size roughly
+    // Track which axis was last stepped for face normal
+    let mut last_axis: u32 = 0; // 0=x, 1=y, 2=z
+
+    let mut i: u32 = 0;
+    let mut hit = false;
+    let mut hit_material: u32 = 0;
+
+    while i < max_steps {
+        // Check current voxel
+        if vx >= 0 && vx < gs && vy >= 0 && vy < gs && vz >= 0 && vz < gs {
+            let idx = (vz as u32 * grid_size * grid_size + vy as u32 * grid_size + vx as u32) as usize;
+            let voxel = voxels[idx];
+            if voxel.w > 0 {
+                hit = true;
+                hit_material = voxel.x;
+                break;
+            }
+        } else {
+            // Exited grid
+            break;
+        }
+
+        // Step to next voxel (DDA)
+        if t_max_x < t_max_y {
+            if t_max_x < t_max_z {
+                vx += step_x;
+                t_max_x += t_delta_x;
+                last_axis = 0;
+            } else {
+                vz += step_z;
+                t_max_z += t_delta_z;
+                last_axis = 2;
+            }
+        } else if t_max_y < t_max_z {
+            vy += step_y;
+            t_max_y += t_delta_y;
+            last_axis = 1;
+        } else {
+            vz += step_z;
+            t_max_z += t_delta_z;
+            last_axis = 2;
+        }
+
+        i += 1;
+    }
+
+    let pixel_idx = (py * width + px) as usize;
+
+    if hit {
+        // Determine face normal from the last DDA step axis
+        let normal = if last_axis == 0 {
+            Vec3::new(-(step_x as f32), 0.0, 0.0)
+        } else if last_axis == 1 {
+            Vec3::new(0.0, -(step_y as f32), 0.0)
+        } else {
+            Vec3::new(0.0, 0.0, -(step_z as f32))
+        };
+
+        let base_color = material_color(hit_material);
+        let lit_color = apply_lighting(base_color, normal);
+
+        // Clamp and convert to u8
+        let r = ((lit_color.x * 255.0) as u32).min(255);
+        let g = ((lit_color.y * 255.0) as u32).min(255);
+        let b = ((lit_color.z * 255.0) as u32).min(255);
+
+        output[pixel_idx] = pack_bgra(r, g, b, 255);
+    } else {
+        // Dark sky background
+        output[pixel_idx] = pack_bgra(15, 15, 25, 255);
+    }
+}
+
+/// Compute shader entry point: render voxels via ray marching.
+///
+/// Dispatched with `(ceil(width/8), ceil(height/8), 1)` workgroups.
+/// Descriptor set 0, binding 0: storage buffer of `UVec4` (voxel grid, read).
+/// Descriptor set 0, binding 1: storage buffer of `u32` (pixel output, write).
+/// Push constants: `RenderPushConstants`.
+#[spirv(compute(threads(8, 8, 1)))]
+pub fn render_voxels(
+    #[spirv(global_invocation_id)] id: UVec3,
+    #[spirv(push_constant)] push: &RenderPushConstants,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] voxels: &[UVec4],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] output: &mut [u32],
+) {
+    render_pixel(id.x, id.y, push, voxels, output);
+}


### PR DESCRIPTION
## Summary
- Add DDA ray-march compute shader (`crates/shaders/src/compute/render.rs`) that renders the voxel grid with material-based coloring (stone=gray, water=blue, lava=orange) and directional diffuse lighting
- Add render pipeline + output buffer to `GpuSimulation` in server, with `render()` and `render_output_buffer()` methods
- Add `draw_frame_with_buffer()` to client `Renderer` that copies the GPU render buffer directly to the swapchain image via `vkCmdCopyBufferToImage`
- Wire everything together in the app main loop: `sim.step()` -> `sim.render()` -> `renderer.draw_frame_with_buffer()`

Closes #36

## Test plan
- [x] `cargo build -p app` succeeds
- [x] `cargo test -p server -- --test-threads=1` passes (5/5 tests including new push constant size test)
- [x] Full workspace `cargo build` succeeds
- [ ] `cargo run -p app` shows gray floor voxels and blue water cube with lighting

🤖 Generated with [Claude Code](https://claude.com/claude-code)