### PR TITLE
feat(client,app): FPS camera with WASD + mouse look

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -7,10 +7,13 @@
 //! For the MVP, renders a proof-of-life cycling clear color while
 //! running the GPU MPM simulation each frame.
 
+use std::collections::HashSet;
 use std::sync::Arc;
+use std::time::Instant;
 
 use anyhow::Result;
-use client::{Renderer, renderer::required_instance_extensions};
+use client::{Camera, Renderer, renderer::required_instance_extensions};
+use glam::Vec3;
 use gpu_core::VulkanContext;
 use server::GpuSimulation;
 use shared::{
@@ -18,9 +21,10 @@ use shared::{
 };
 use winit::{
     application::ApplicationHandler,
-    event::WindowEvent,
+    event::{DeviceEvent, DeviceId, ElementState, MouseButton, WindowEvent},
     event_loop::{ActiveEventLoop, EventLoop},
-    window::{Window, WindowAttributes, WindowId},
+    keyboard::PhysicalKey,
+    window::{CursorGrabMode, Window, WindowAttributes, WindowId},
 };
 
 /// Create the initial set of particles for the MVP demo.
@@ -28,8 +32,6 @@ use winit::{
 /// Stone floor at y=2..4 across the grid, and a water cube
 /// floating at y=15..20 in the center.
 fn create_initial_particles() -> Vec<Particle> {
-    use glam::Vec3;
-
     let mut particles = Vec::new();
 
     // Stone floor
@@ -75,6 +77,14 @@ struct App {
     sim: Option<GpuSimulation>,
     /// Initial particles (stored until GPU simulation is ready).
     particles: Vec<Particle>,
+    /// FPS camera for WASD + mouse look.
+    camera: Camera,
+    /// Set of currently pressed physical keys for continuous movement.
+    pressed_keys: HashSet<PhysicalKey>,
+    /// Whether the mouse cursor is captured for camera look.
+    cursor_captured: bool,
+    /// Timestamp of the last frame for delta-time calculation.
+    last_frame_time: Instant,
 }
 
 impl App {
@@ -82,12 +92,51 @@ impl App {
         let particles = create_initial_particles();
         tracing::info!("Created {} initial particles", particles.len());
 
+        // Camera looking toward grid center from corner
+        let camera = Camera::new(
+            Vec3::new(48.0, 24.0, 48.0),
+            -2.35, // yaw: looking toward origin
+            -0.3,  // pitch: slightly downward
+        );
+
         Self {
             window: None,
             ctx: None,
             renderer: None,
             sim: None,
             particles,
+            camera,
+            pressed_keys: HashSet::new(),
+            cursor_captured: false,
+            last_frame_time: Instant::now(),
+        }
+    }
+
+    /// Capture the mouse cursor for camera look control.
+    fn capture_cursor(&mut self) {
+        if let Some(window) = &self.window {
+            window.set_cursor_visible(false);
+            let _ = window.set_cursor_grab(CursorGrabMode::Confined);
+            self.cursor_captured = true;
+        }
+    }
+
+    /// Release the mouse cursor.
+    fn release_cursor(&mut self) {
+        if let Some(window) = &self.window {
+            window.set_cursor_visible(true);
+            let _ = window.set_cursor_grab(CursorGrabMode::None);
+            self.cursor_captured = false;
+        }
+    }
+
+    /// Process continuous key movement based on currently pressed keys.
+    fn update_movement(&mut self, dt: f32) {
+        let keys: Vec<PhysicalKey> = self.pressed_keys.iter().copied().collect();
+        for key in keys {
+            if let PhysicalKey::Code(code) = key {
+                self.camera.process_keyboard(code, dt);
+            }
         }
     }
 }
@@ -117,6 +166,10 @@ impl ApplicationHandler for App {
             window.inner_size().width,
             window.inner_size().height
         );
+
+        // Update camera aspect from actual window size
+        let size = window.inner_size();
+        self.camera.update_aspect(size.width, size.height);
 
         // Create Vulkan context with surface extensions
         let ctx =
@@ -190,9 +243,48 @@ impl ApplicationHandler for App {
                 if let Some(renderer) = self.renderer.as_mut() {
                     renderer.notify_resized(new_size.width, new_size.height);
                 }
+                self.camera.update_aspect(new_size.width, new_size.height);
+            }
+
+            WindowEvent::KeyboardInput { event, .. } => {
+                match event.state {
+                    ElementState::Pressed => {
+                        self.pressed_keys.insert(event.physical_key);
+                    }
+                    ElementState::Released => {
+                        self.pressed_keys.remove(&event.physical_key);
+                    }
+                }
+
+                // Escape releases cursor
+                if event.state == ElementState::Pressed {
+                    if let PhysicalKey::Code(winit::keyboard::KeyCode::Escape) =
+                        event.physical_key
+                    {
+                        self.release_cursor();
+                    }
+                }
+            }
+
+            WindowEvent::MouseInput {
+                state: ElementState::Pressed,
+                button: MouseButton::Left,
+                ..
+            } => {
+                if !self.cursor_captured {
+                    self.capture_cursor();
+                }
             }
 
             WindowEvent::RedrawRequested => {
+                // Calculate delta time
+                let now = Instant::now();
+                let dt = now.duration_since(self.last_frame_time).as_secs_f32();
+                self.last_frame_time = now;
+
+                // Process continuous movement from held keys
+                self.update_movement(dt);
+
                 if let (Some(renderer), Some(ctx), Some(sim)) =
                     (self.renderer.as_mut(), self.ctx.as_ref(), self.sim.as_ref())
                 {
@@ -220,6 +312,19 @@ impl ApplicationHandler for App {
             }
 
             _ => {}
+        }
+    }
+
+    fn device_event(
+        &mut self,
+        _event_loop: &ActiveEventLoop,
+        _device_id: DeviceId,
+        event: DeviceEvent,
+    ) {
+        if let DeviceEvent::MouseMotion { delta: (dx, dy) } = event {
+            if self.cursor_captured {
+                self.camera.process_mouse(dx as f32, dy as f32);
+            }
         }
     }
 

--- a/crates/client/src/camera.rs
+++ b/crates/client/src/camera.rs
@@ -1,0 +1,208 @@
+//! FPS camera with WASD movement and mouse look.
+//!
+//! Provides a first-person camera that tracks position, orientation (yaw/pitch),
+//! and projection parameters. Integrates with winit key codes for movement input
+//! and raw mouse deltas for look control.
+
+use glam::Vec3;
+use winit::keyboard::KeyCode;
+
+/// An FPS-style camera with position, orientation, and projection parameters.
+///
+/// Yaw 0 looks along -Z (into the screen). Pitch is clamped to +/- 89 degrees
+/// to avoid gimbal lock at the poles.
+pub struct Camera {
+    /// World-space position of the camera eye.
+    pub position: Vec3,
+    /// Horizontal rotation in radians. 0 = looking along -Z.
+    pub yaw: f32,
+    /// Vertical rotation in radians, clamped to [-89deg, 89deg].
+    pub pitch: f32,
+    /// Vertical field of view in radians.
+    pub fov: f32,
+    /// Aspect ratio (width / height).
+    pub aspect: f32,
+    /// Movement speed in units per second.
+    pub speed: f32,
+    /// Mouse sensitivity (radians per pixel of mouse delta).
+    pub sensitivity: f32,
+}
+
+impl Camera {
+    /// Create a new FPS camera at the given position and orientation.
+    ///
+    /// Uses default values: FOV = 60 degrees, speed = 10 units/s,
+    /// sensitivity = 0.003 rad/pixel, aspect = 16/9.
+    pub fn new(position: Vec3, yaw: f32, pitch: f32) -> Self {
+        Self {
+            position,
+            yaw,
+            pitch,
+            fov: 60.0_f32.to_radians(),
+            aspect: 16.0 / 9.0,
+            speed: 10.0,
+            sensitivity: 0.003,
+        }
+    }
+
+    /// Return the forward direction vector (unit length) based on yaw and pitch.
+    pub fn forward(&self) -> Vec3 {
+        Vec3::new(
+            self.yaw.sin() * self.pitch.cos(),
+            self.pitch.sin(),
+            -(self.yaw.cos()) * self.pitch.cos(),
+        )
+        .normalize()
+    }
+
+    /// Return the right direction vector (unit length), perpendicular to forward on the XZ plane.
+    pub fn right(&self) -> Vec3 {
+        Vec3::new(self.yaw.cos(), 0.0, self.yaw.sin()).normalize()
+    }
+
+    /// Process a keyboard key press for movement.
+    ///
+    /// W/S move forward/backward, A/D strafe left/right,
+    /// Space moves up, LShift moves down. Movement is scaled by `dt` (seconds).
+    pub fn process_keyboard(&mut self, key: KeyCode, dt: f32) {
+        let velocity = self.speed * dt;
+        let forward = self.forward();
+        let right = self.right();
+        let up = Vec3::Y;
+
+        match key {
+            KeyCode::KeyW => self.position += forward * velocity,
+            KeyCode::KeyS => self.position -= forward * velocity,
+            KeyCode::KeyA => self.position -= right * velocity,
+            KeyCode::KeyD => self.position += right * velocity,
+            KeyCode::Space => self.position += up * velocity,
+            KeyCode::ShiftLeft => self.position -= up * velocity,
+            _ => {}
+        }
+    }
+
+    /// Process raw mouse delta to update yaw and pitch.
+    ///
+    /// `dx` and `dy` are pixel deltas from the mouse device.
+    /// Pitch is clamped to +/- 89 degrees to prevent flipping.
+    pub fn process_mouse(&mut self, dx: f32, dy: f32) {
+        self.yaw += dx * self.sensitivity;
+        self.pitch -= dy * self.sensitivity;
+
+        let max_pitch = 89.0_f32.to_radians();
+        self.pitch = self.pitch.clamp(-max_pitch, max_pitch);
+    }
+
+    /// Return the camera eye position (same as `position`).
+    pub fn eye(&self) -> Vec3 {
+        self.position
+    }
+
+    /// Return the point the camera is looking at (`position + forward`).
+    pub fn target(&self) -> Vec3 {
+        self.position + self.forward()
+    }
+
+    /// Update the aspect ratio from window dimensions.
+    ///
+    /// Does nothing if `height` is zero to avoid division by zero.
+    pub fn update_aspect(&mut self, width: u32, height: u32) {
+        if height > 0 {
+            self.aspect = width as f32 / height as f32;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::f32::consts::PI;
+
+    #[test]
+    fn test_new_defaults() {
+        let cam = Camera::new(Vec3::ZERO, 0.0, 0.0);
+        assert!((cam.fov - 60.0_f32.to_radians()).abs() < 1e-6);
+        assert_eq!(cam.speed, 10.0);
+        assert_eq!(cam.sensitivity, 0.003);
+    }
+
+    #[test]
+    fn test_forward_at_zero_yaw() {
+        let cam = Camera::new(Vec3::ZERO, 0.0, 0.0);
+        let fwd = cam.forward();
+        // yaw=0, pitch=0 => looking along -Z
+        assert!(fwd.x.abs() < 1e-5);
+        assert!(fwd.y.abs() < 1e-5);
+        assert!((fwd.z - (-1.0)).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_forward_at_half_pi_yaw() {
+        let cam = Camera::new(Vec3::ZERO, PI / 2.0, 0.0);
+        let fwd = cam.forward();
+        // yaw=PI/2 => looking along +X
+        assert!((fwd.x - 1.0).abs() < 1e-5);
+        assert!(fwd.y.abs() < 1e-5);
+        assert!(fwd.z.abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_right_at_zero_yaw() {
+        let cam = Camera::new(Vec3::ZERO, 0.0, 0.0);
+        let r = cam.right();
+        // yaw=0 => right is +X
+        assert!((r.x - 1.0).abs() < 1e-5);
+        assert!(r.y.abs() < 1e-5);
+        assert!(r.z.abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_pitch_clamp() {
+        let mut cam = Camera::new(Vec3::ZERO, 0.0, 0.0);
+        // Large positive dy should clamp pitch
+        cam.process_mouse(0.0, -100000.0);
+        let max_pitch = 89.0_f32.to_radians();
+        assert!((cam.pitch - max_pitch).abs() < 1e-5);
+
+        cam.process_mouse(0.0, 200000.0);
+        assert!((cam.pitch - (-max_pitch)).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_target_equals_position_plus_forward() {
+        let cam = Camera::new(Vec3::new(1.0, 2.0, 3.0), 0.5, 0.2);
+        let target = cam.target();
+        let expected = cam.position + cam.forward();
+        assert!((target - expected).length() < 1e-5);
+    }
+
+    #[test]
+    fn test_update_aspect() {
+        let mut cam = Camera::new(Vec3::ZERO, 0.0, 0.0);
+        cam.update_aspect(1920, 1080);
+        assert!((cam.aspect - 1920.0 / 1080.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_update_aspect_zero_height() {
+        let mut cam = Camera::new(Vec3::ZERO, 0.0, 0.0);
+        let original = cam.aspect;
+        cam.update_aspect(1920, 0);
+        assert_eq!(cam.aspect, original);
+    }
+
+    #[test]
+    fn test_process_keyboard_forward() {
+        let mut cam = Camera::new(Vec3::ZERO, 0.0, 0.0);
+        let pos_before = cam.position;
+        cam.process_keyboard(KeyCode::KeyW, 1.0);
+        // Should have moved along forward (-Z)
+        assert!(cam.position.z < pos_before.z);
+    }
+
+    #[test]
+    fn test_eye() {
+        let cam = Camera::new(Vec3::new(5.0, 6.0, 7.0), 0.0, 0.0);
+        assert_eq!(cam.eye(), cam.position);
+    }
+}

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -6,6 +6,8 @@
 //! and frame loop. For the MVP, renders a proof-of-life clear color
 //! that changes each frame. Voxel ray tracing comes later.
 
+pub mod camera;
 pub mod renderer;
 
+pub use camera::Camera;
 pub use renderer::Renderer;


### PR DESCRIPTION
## Summary
- Add `Camera` struct in `crates/client/src/camera.rs` with position, yaw/pitch orientation, FOV, and movement/sensitivity parameters
- WASD + Space/Shift movement, mouse look with pitch clamping to +/-89 degrees
- Integrate into app event loop: cursor capture on left-click, release on Escape, continuous key tracking via `HashSet<PhysicalKey>`, raw mouse delta via `DeviceEvent::MouseMotion`
- 10 unit tests covering all public methods

Closes #38

## Test plan
- [x] `cargo build -p client -p app` passes
- [x] `cargo test -p client` -- 10 tests pass
- [ ] Manual: run `cargo run -p app`, click window to capture cursor, WASD moves camera, mouse rotates view, Escape releases cursor

🤖 Generated with [Claude Code](https://claude.com/claude-code)