### PR TITLE
feat(app): headless screenshot mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,7 @@ dependencies = [
  "client",
  "glam",
  "gpu-core",
+ "image",
  "protocol",
  "server",
  "shared",
@@ -268,6 +269,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -614,6 +621,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,6 +942,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1158,6 +1187,16 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -1578,6 +1617,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,6 +1724,12 @@ dependencies = [
  "serde",
  "shared",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "quick-error"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Errors
 thiserror = "2"
 anyhow = "1"
+# Image
+image = { version = "0.25", default-features = false, features = ["png"] }
 # Testing
 proptest = "1"
 approx = "0.5"

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -14,3 +14,4 @@ glam = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 anyhow = { workspace = true }
+image = { workspace = true }

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -6,6 +6,11 @@
 //! sets up the renderer, and runs the main event loop.
 //! For the MVP, renders a proof-of-life cycling clear color while
 //! running the GPU MPM simulation each frame.
+//!
+//! Supports headless mode for automated visual testing:
+//! ```bash
+//! cargo run -p app -- --headless --frames 100 --output screenshot.png
+//! ```
 
 use std::sync::Arc;
 
@@ -22,6 +27,37 @@ use winit::{
     event_loop::{ActiveEventLoop, EventLoop},
     window::{Window, WindowAttributes, WindowId},
 };
+
+/// Command-line arguments for the app.
+struct Args {
+    /// Run in headless mode (no window, render to PNG).
+    headless: bool,
+    /// Number of simulation frames to run in headless mode.
+    frames: u32,
+    /// Output file path for the screenshot (headless mode).
+    output: Option<String>,
+}
+
+/// Parse command-line arguments from `std::env::args`.
+fn parse_args() -> Args {
+    let args: Vec<String> = std::env::args().collect();
+    let headless = args.contains(&"--headless".to_string());
+    let frames = args
+        .iter()
+        .position(|a| a == "--frames")
+        .and_then(|i| args.get(i + 1))
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(100);
+    let output = args
+        .iter()
+        .position(|a| a == "--output")
+        .and_then(|i| args.get(i + 1).cloned());
+    Args {
+        headless,
+        frames,
+        output,
+    }
+}
 
 /// Create the initial set of particles for the MVP demo.
 ///
@@ -61,6 +97,59 @@ fn create_initial_particles() -> Vec<Particle> {
     }
 
     particles
+}
+
+/// Run the engine in headless mode: simulate, render, and save a PNG.
+fn run_headless(args: &Args) -> Result<()> {
+    tracing::info!(
+        "Headless mode: {} frames, output: {}",
+        args.frames,
+        args.output.as_deref().unwrap_or("screenshot.png")
+    );
+
+    let ctx = VulkanContext::new()?;
+    let mut sim = GpuSimulation::new(&ctx)?;
+
+    let particles = create_initial_particles();
+    tracing::info!("Created {} initial particles", particles.len());
+    sim.init_particles(&ctx, &particles)?;
+
+    // Run simulation frames
+    for i in 0..args.frames {
+        ctx.execute_one_shot(|cmd| {
+            sim.step(cmd);
+        })?;
+        if i % 10 == 0 {
+            tracing::info!("Frame {}/{}", i, args.frames);
+        }
+    }
+
+    // Render final frame
+    ctx.execute_one_shot(|cmd| {
+        sim.render(cmd, RENDER_WIDTH, RENDER_HEIGHT);
+    })?;
+
+    // Readback render output buffer
+    let pixel_count = (RENDER_WIDTH as usize) * (RENDER_HEIGHT as usize) * 4;
+    let pixels: Vec<u8> =
+        gpu_core::buffer::readback::<u8>(&ctx, sim.render_output_gpu_buffer(), pixel_count)?;
+
+    // Convert BGRA to RGBA for PNG
+    let mut rgba = pixels;
+    for pixel in rgba.chunks_exact_mut(4) {
+        pixel.swap(0, 2); // swap B and R
+    }
+
+    // Save PNG
+    let output_path = args.output.as_deref().unwrap_or("screenshot.png");
+    let img = image::RgbaImage::from_raw(RENDER_WIDTH, RENDER_HEIGHT, rgba)
+        .ok_or_else(|| anyhow::anyhow!("Failed to create image from pixel data"))?;
+    img.save(output_path)?;
+
+    tracing::info!("Screenshot saved to {}", output_path);
+
+    sim.destroy(&ctx);
+    Ok(())
 }
 
 /// Application state for the winit event loop.
@@ -240,6 +329,11 @@ fn main() -> Result<()> {
         .init();
 
     tracing::info!("VOX Engine starting");
+
+    let args = parse_args();
+    if args.headless {
+        return run_headless(&args);
+    }
 
     let event_loop = EventLoop::new()?;
     let mut app = App::new();

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -480,6 +480,14 @@ impl GpuSimulation {
         self.render_output_buffer.buffer
     }
 
+    /// Returns a reference to the render output [`GpuBuffer`].
+    ///
+    /// Useful for readback operations (e.g., headless screenshot).
+    /// The buffer contains packed BGRA u32 pixels, sized `width * height`.
+    pub fn render_output_gpu_buffer(&self) -> &GpuBuffer {
+        &self.render_output_buffer
+    }
+
     /// Record a render dispatch into the given command buffer.
     ///
     /// Ray-marches through the voxel grid and writes pixel data to the


### PR DESCRIPTION
## Summary
- Add `--headless --frames N --output path.png` CLI args to run the engine without a window
- Simulates N frames, renders the final frame, reads back the GPU buffer, converts BGRA to RGBA, and saves a PNG
- Adds `render_output_gpu_buffer()` to `GpuSimulation` for readback access
- Adds `image` crate (PNG-only) as a workspace dependency

Closes #41

## Test plan
- [x] `cargo build -p app` compiles successfully
- [x] `cargo run -p app -- --headless --frames 50 --output test.png` produces a valid 1280x720 PNG
- [x] Screenshot shows expected scene (stone floor + water cube)
- [ ] Windowed mode still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)