### PR TITLE
fix: prevent stone drift in G2P, add substeps per frame

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -32,6 +32,9 @@ use winit::{
     window::{CursorGrabMode, Window, WindowAttributes, WindowId},
 };
 
+/// Default number of simulation substeps per frame.
+const DEFAULT_SUBSTEPS: u32 = 16;
+
 /// Command-line arguments for the app.
 struct Args {
     /// Run in headless mode (no window, render to PNG).
@@ -40,6 +43,8 @@ struct Args {
     frames: u32,
     /// Output file path for the screenshot (headless mode).
     output: Option<String>,
+    /// Number of simulation substeps per frame.
+    substeps: u32,
 }
 
 /// Parse command-line arguments from `std::env::args`.
@@ -56,10 +61,17 @@ fn parse_args() -> Args {
         .iter()
         .position(|a| a == "--output")
         .and_then(|i| args.get(i + 1).cloned());
+    let substeps = args
+        .iter()
+        .position(|a| a == "--substeps")
+        .and_then(|i| args.get(i + 1))
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_SUBSTEPS);
     Args {
         headless,
         frames,
         output,
+        substeps,
     }
 }
 
@@ -104,8 +116,9 @@ fn create_initial_particles() -> Vec<Particle> {
 /// Run the engine in headless mode: simulate, render, and save a PNG.
 fn run_headless(args: &Args) -> Result<()> {
     tracing::info!(
-        "Headless mode: {} frames, output: {}",
+        "Headless mode: {} frames, {} substeps/frame, output: {}",
         args.frames,
+        args.substeps,
         args.output.as_deref().unwrap_or("screenshot.png")
     );
 
@@ -116,10 +129,12 @@ fn run_headless(args: &Args) -> Result<()> {
     tracing::info!("Created {} initial particles", particles.len());
     sim.init_particles(&ctx, &particles)?;
 
-    // Run simulation frames
+    // Run simulation frames (multiple substeps per frame for faster sim)
     for i in 0..args.frames {
         ctx.execute_one_shot(|cmd| {
-            sim.step(cmd);
+            for _ in 0..args.substeps {
+                sim.step(cmd);
+            }
         })?;
         if i % 10 == 0 {
             tracing::info!("Frame {}/{}", i, args.frames);
@@ -174,10 +189,12 @@ struct App {
     cursor_captured: bool,
     /// Timestamp of the last frame for delta-time calculation.
     last_frame_time: Instant,
+    /// Number of simulation substeps per frame.
+    substeps: u32,
 }
 
 impl App {
-    fn new() -> Self {
+    fn new(substeps: u32) -> Self {
         let particles = create_initial_particles();
         tracing::info!("Created {} initial particles", particles.len());
 
@@ -198,6 +215,7 @@ impl App {
             pressed_keys: HashSet::new(),
             cursor_captured: false,
             last_frame_time: Instant::now(),
+            substeps,
         }
     }
 
@@ -377,9 +395,12 @@ impl ApplicationHandler for App {
                 if let (Some(renderer), Some(ctx), Some(sim)) =
                     (self.renderer.as_mut(), self.ctx.as_ref(), self.sim.as_ref())
                 {
-                    // Run simulation step + render to buffer (separate submission)
+                    // Run simulation substeps + render to buffer
+                    let substeps = self.substeps;
                     if let Err(e) = ctx.execute_one_shot(|cmd| {
-                        sim.step(cmd);
+                        for _ in 0..substeps {
+                            sim.step(cmd);
+                        }
                         sim.render(cmd, RENDER_WIDTH, RENDER_HEIGHT);
                     }) {
                         tracing::error!("Simulation/render error: {}", e);
@@ -441,7 +462,7 @@ fn main() -> Result<()> {
     }
 
     let event_loop = EventLoop::new()?;
-    let mut app = App::new();
+    let mut app = App::new(args.substeps);
     event_loop.run_app(&mut app)?;
 
     tracing::info!("VOX Engine shut down");

--- a/crates/shaders/src/compute/g2p.rs
+++ b/crates/shaders/src/compute/g2p.rs
@@ -151,7 +151,23 @@ pub fn gather_particle(
     new_pos.y = new_pos.y.clamp(margin, upper);
     new_pos.z = new_pos.z.clamp(margin, upper);
 
-    // Write back to particle
+    // Phase constant: solid = 0
+    let phase = particle.ids.y;
+
+    // Solids: update F and C for stress computation but skip position/velocity advection.
+    // This prevents stone floor particles from drifting toward grid cell boundaries (#45).
+    if phase == 0 {
+        particle.f_col0 = new_f0.extend(0.0);
+        particle.f_col1 = new_f1.extend(0.0);
+        particle.f_col2 = new_f2.extend(0.0);
+        particle.c_col0 = c_col0.extend(0.0);
+        particle.c_col1 = c_col1.extend(0.0);
+        particle.c_col2 = c_col2.extend(0.0);
+        apply_phase_transitions(particle);
+        return;
+    }
+
+    // Write back to particle (liquids and gases only)
     particle.pos_mass = Vec4::new(new_pos.x, new_pos.y, new_pos.z, particle.pos_mass.w);
     particle.vel_temp = Vec4::new(new_vel.x, new_vel.y, new_vel.z, particle.vel_temp.w);
     particle.f_col0 = new_f0.extend(0.0);


### PR DESCRIPTION
## Summary

- **#45 Stone drift fix:** In the G2P shader, solid particles (phase==0) now skip position and velocity updates. Only the deformation gradient F and APIC matrix C are updated for stress computation, plus phase transition checks. This prevents stone floor particles from slowly drifting toward grid cell boundaries.
- **#46 Substeps:** Simulation now runs 16 substeps per frame by default (configurable via `--substeps N`). Both windowed and headless modes use substeps, making the simulation visibly faster without changing dt.

Closes #45
Closes #46

## Test plan
- [x] `cargo build -p app` compiles successfully
- [x] `cargo test -p shared -p sim-cpu -p protocol` all pass
- [ ] `cargo run -p app -- --headless --frames 50 --output test.png` — stone should be smooth, water should fall noticeably
- [ ] Verify stone floor remains stable (no seam lines) after many frames
- [ ] Verify `--substeps` CLI argument works (e.g. `--substeps 32`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)