### PR TITLE
fix(app): reduce default substeps to 4 for stability

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -34,7 +34,7 @@ use winit::{
 };
 
 /// Default number of simulation substeps per frame.
-const DEFAULT_SUBSTEPS: u32 = 16;
+const DEFAULT_SUBSTEPS: u32 = 4;
 
 /// Command-line arguments for the app.
 struct Args {


### PR DESCRIPTION
## Summary
- Reduced `DEFAULT_SUBSTEPS` from 16 to 4 in `crates/app/src/main.rs`
- Fixes simulation jitter and overly fast water movement reported in #52

Closes #52

## Test plan
- [x] `cargo build -p app` passes
- [ ] Run app and verify water no longer jitters or moves too fast
- [ ] Verify physics still looks smooth at 4 substeps

🤖 Generated with [Claude Code](https://claude.com/claude-code)