### PR TITLE
fix(app): correct camera default and add look_at constructor

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -225,9 +225,9 @@ fn run_headless(args: &Args) -> Result<()> {
         }
     }
 
-    // Render final frame with default camera position
-    let eye = [48.0_f32, 24.0, 48.0];
-    let target = [16.0_f32, 8.0, 16.0];
+    // Render final frame with default camera position (matching windowed mode)
+    let eye = [40.0_f32, 28.0, 40.0];
+    let target = [16.0_f32, 6.0, 16.0];
     ctx.execute_one_shot(|cmd| {
         sim.render(cmd, RENDER_WIDTH, RENDER_HEIGHT, eye, target);
     })?;
@@ -284,11 +284,10 @@ impl App {
         let particles = create_initial_particles();
         tracing::info!("Created {} initial particles", particles.len());
 
-        // Camera looking toward grid center from corner
-        let camera = Camera::new(
-            Vec3::new(48.0, 24.0, 48.0),
-            -2.35, // yaw: looking toward origin
-            -0.3,  // pitch: slightly downward
+        // Camera looking toward basin center from above-corner
+        let camera = Camera::look_at(
+            Vec3::new(40.0, 28.0, 40.0),  // eye: closer, higher for better view
+            Vec3::new(16.0, 6.0, 16.0),   // target: basin center
         );
 
         Self {

--- a/crates/client/src/camera.rs
+++ b/crates/client/src/camera.rs
@@ -45,6 +45,17 @@ impl Camera {
         }
     }
 
+    /// Create a new FPS camera positioned at `eye` looking toward `target`.
+    ///
+    /// Computes yaw and pitch from the eye-to-target direction vector.
+    /// Uses default values for FOV, speed, sensitivity, and aspect ratio.
+    pub fn look_at(eye: Vec3, target: Vec3) -> Self {
+        let dir = (target - eye).normalize();
+        let yaw = dir.x.atan2(-dir.z);
+        let pitch = dir.y.asin();
+        Self::new(eye, yaw, pitch)
+    }
+
     /// Return the forward direction vector (unit length) based on yaw and pitch.
     pub fn forward(&self) -> Vec3 {
         Vec3::new(
@@ -198,6 +209,36 @@ mod tests {
         cam.process_keyboard(KeyCode::KeyW, 1.0);
         // Should have moved along forward (-Z)
         assert!(cam.position.z < pos_before.z);
+    }
+
+    #[test]
+    fn test_look_at_direction() {
+        let eye = Vec3::new(40.0, 28.0, 40.0);
+        let target = Vec3::new(16.0, 6.0, 16.0);
+        let cam = Camera::look_at(eye, target);
+
+        // Camera target should point toward the specified target
+        let actual_target = cam.target();
+        let to_target = (target - eye).normalize();
+        let actual_dir = (actual_target - cam.position).normalize();
+        assert!(
+            (actual_dir - to_target).length() < 1e-4,
+            "look_at direction mismatch: expected {:?}, got {:?}",
+            to_target,
+            actual_dir
+        );
+    }
+
+    #[test]
+    fn test_look_at_along_negative_z() {
+        let cam = Camera::look_at(Vec3::new(0.0, 0.0, 10.0), Vec3::new(0.0, 0.0, 0.0));
+        // Should be looking along -Z, so yaw ≈ 0
+        assert!(cam.yaw.abs() < 1e-4, "yaw should be ~0, got {}", cam.yaw);
+        assert!(
+            cam.pitch.abs() < 1e-4,
+            "pitch should be ~0, got {}",
+            cam.pitch
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `Camera::look_at(eye, target)` constructor that computes yaw/pitch from the eye-to-target direction vector
- Update default camera in both windowed and headless modes: eye=(40,28,40) targeting basin center at (16,6,16)
- Verified scene particle positions are correct: water (x=4..28, z=4..28) is fully inside walls (x=2..4/28..30, z=2..4/28..30)

## Test plan
- [x] `cargo test -p client` passes (12 tests including 2 new `look_at` tests)
- [x] `cargo check -p app` compiles
- [ ] `cargo run -p app` shows basin properly centered in view
- [ ] `cargo run -p app -- --headless --frames 0 --output test.png` produces correct screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)