### PR TITLE
fix: trilinear voxel splatting + 8 PPC for fluids

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -76,12 +76,35 @@ fn parse_args() -> Args {
     }
 }
 
+/// Spawn 8 particles (2x2x2 sub-grid) within a single cell.
+///
+/// Distributes particles at quarter-cell offsets for smoother fluid behavior.
+/// This eliminates grid-seam artifacts caused by particles clustering at
+/// grid nodes when using only 1 particle per cell.
+fn spawn_cell(particles: &mut Vec<Particle>, x: f32, y: f32, z: f32, mass_per_particle: f32, mat: u32, phase: u32) {
+    for dx in 0..2u32 {
+        for dy in 0..2u32 {
+            for dz in 0..2u32 {
+                let pos = Vec3::new(
+                    x + 0.25 + dx as f32 * 0.5,
+                    y + 0.25 + dy as f32 * 0.5,
+                    z + 0.25 + dz as f32 * 0.5,
+                );
+                particles.push(Particle::new(pos, mass_per_particle, mat, phase));
+            }
+        }
+    }
+}
+
 /// Create the initial set of particles for the MVP demo.
 ///
 /// Scene: hollow ellipsoidal cave carved from a stone block,
 /// with a water lake at the bottom and a lava stream dripping
 /// from a ceiling crack. Demonstrates water-lava reaction
 /// (stone + steam), temperature, and phase transitions.
+///
+/// Stone uses 1 particle per cell (solid, pinned). Water and lava use
+/// 8 particles per cell (2x2x2 sub-grid) for smoother fluid behavior.
 fn create_initial_particles() -> Vec<Particle> {
     let mut particles = Vec::new();
     let center = Vec3::new(16.0, 12.0, 16.0);
@@ -103,7 +126,7 @@ fn create_initial_particles() -> Vec<Particle> {
         }
     }
 
-    // 2. Water lake at bottom of cave
+    // 2. Water lake at bottom of cave (8 PPC for smooth fluid)
     for x in 7..25 {
         for z in 7..25 {
             for y in 4..7 {
@@ -112,14 +135,14 @@ fn create_initial_particles() -> Vec<Particle> {
                 let dist_sq = d.x * d.x + d.y * d.y + d.z * d.z;
 
                 if dist_sq < 1.0 {
-                    // Inside cave = water
-                    particles.push(Particle::new(pos, 1.0, MAT_WATER, PHASE_LIQUID));
+                    // Inside cave = water, 8 particles per cell
+                    spawn_cell(&mut particles, x as f32, y as f32, z as f32, 0.125, MAT_WATER, PHASE_LIQUID);
                 }
             }
         }
     }
 
-    // 3. Lava stream from ceiling crack
+    // 3. Lava stream from ceiling crack (8 PPC for smooth fluid)
     for x in 14..18 {
         for z in 14..18 {
             for y in 18..26 {
@@ -129,10 +152,12 @@ fn create_initial_particles() -> Vec<Particle> {
 
                 // Only place lava where there's no stone (inside cave or near surface)
                 if dist_sq < 1.2 {
-                    let mut p = Particle::new(pos, 1.0, MAT_LAVA, PHASE_LIQUID);
+                    let start = particles.len();
+                    spawn_cell(&mut particles, x as f32, y as f32, z as f32, 0.125, MAT_LAVA, PHASE_LIQUID);
                     // Set lava temperature to 2000K (above melting point, stays liquid and glows)
-                    p.vel_temp = glam::Vec4::new(0.0, 0.0, 0.0, 2000.0);
-                    particles.push(p);
+                    for p in &mut particles[start..] {
+                        p.vel_temp = glam::Vec4::new(0.0, 0.0, 0.0, 2000.0);
+                    }
                 }
             }
         }

--- a/crates/shaders/src/compute/voxelize.rs
+++ b/crates/shaders/src/compute/voxelize.rs
@@ -34,7 +34,12 @@ pub struct VoxelizePushConstants {
 /// This is a simplification; a proper implementation would use
 /// splatting or averaging.
 
-/// Map a particle to a voxel cell and write its data.
+/// Map a particle to a voxel cell and write its data using trilinear splatting.
+///
+/// Instead of writing to a single cell (which causes flickering when particles
+/// straddle cell boundaries), splats to the 2x2x2 nearest cells weighted by
+/// the trilinear interpolation weights. Only writes cells with weight > 0.1
+/// to avoid polluting distant voxels.
 ///
 /// Separated into a helper function for the rust-gpu linker bug workaround
 /// (see CLAUDE.md trap #4a).
@@ -44,28 +49,51 @@ pub fn write_voxel(
     grid_size: u32,
 ) {
     let pos = particle.pos_mass.truncate();
-
-    // Convert continuous position to discrete voxel index
-    let vx = pos.x as u32;
-    let vy = pos.y as u32;
-    let vz = pos.z as u32;
-
-    // Bounds check
-    if vx >= grid_size || vy >= grid_size || vz >= grid_size {
-        return;
-    }
-
-    let index = (vz * grid_size * grid_size + vy * grid_size + vx) as usize;
-
     let material_id = particle.ids.x;
     let phase = particle.ids.y;
     let temp_bits = particle.vel_temp.w.to_bits();
 
-    // Simple write — last particle wins for now.
-    // A more sophisticated approach would use atomicMax on a packed value
-    // (e.g., pack material_id + density into a single u32 for atomic comparison).
-    // For MVP with low particle counts this is acceptable.
-    voxels[index] = UVec4::new(material_id, phase, temp_bits, 1);
+    // Base cell (floor of position)
+    let bx = pos.x as u32;
+    let by = pos.y as u32;
+    let bz = pos.z as u32;
+
+    // Fractional part for trilinear weights
+    let fx = pos.x - bx as f32;
+    let fy = pos.y - by as f32;
+    let fz = pos.z - bz as f32;
+
+    // Write to 2x2x2 neighbors with trilinear weights
+    let mut di = 0u32;
+    while di < 2 {
+        let mut dj = 0u32;
+        while dj < 2 {
+            let mut dk = 0u32;
+            while dk < 2 {
+                let cx = bx + di;
+                let cy = by + dj;
+                let cz = bz + dk;
+
+                if cx < grid_size && cy < grid_size && cz < grid_size {
+                    let wx = if di == 0 { 1.0 - fx } else { fx };
+                    let wy = if dj == 0 { 1.0 - fy } else { fy };
+                    let wz = if dk == 0 { 1.0 - fz } else { fz };
+                    let w = wx * wy * wz;
+
+                    // Only write if weight is significant
+                    if w > 0.1 {
+                        let idx =
+                            (cz * grid_size * grid_size + cy * grid_size + cx) as usize;
+                        // Simple last-write-wins, but with splatting it's much smoother
+                        voxels[idx] = UVec4::new(material_id, phase, temp_bits, 1);
+                    }
+                }
+                dk += 1;
+            }
+            dj += 1;
+        }
+        di += 1;
+    }
 }
 
 /// Clear a single voxel cell to empty.


### PR DESCRIPTION
## Summary
- **Trilinear splatting** (#59): `write_voxel()` in `crates/shaders/src/compute/voxelize.rs` now splats each particle to 2x2x2 nearest cells using trilinear interpolation weights (threshold > 0.1), eliminating boundary flickering when particles straddle cell edges.
- **8 particles per cell for fluids** (#64): Water and lava in `crates/app/src/main.rs` now spawn with a 2x2x2 sub-grid pattern (8 particles, mass/8 each), producing smoother fluid behavior. Stone remains at 1 PPC (solid, pinned). Total count: ~17.5K particles (well under 50K limit).

Closes #59
Closes #64

## Test plan
- [x] `cargo build -p app` compiles successfully
- [ ] `cargo run -p app -- --headless --frames 10 --output test.png` renders without flickering artifacts
- [ ] Visual comparison: water surface should be smoother, no cell-boundary popping
- [ ] Particle count logged at startup should be ~17,504

🤖 Generated with [Claude Code](https://claude.com/claude-code)