### PR TITLE
feat: GPU chemical reactions water+lava→stone+steam

### DIFF
--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! Owns [`GpuSimulation`], which manages GPU buffers, compute pipelines,
 //! and the dispatch chain for the MPM simulation:
-//! `clear_grid -> P2G -> grid_update -> G2P -> (clear_voxels -> voxelize)`.
+//! `clear_grid -> P2G -> grid_update -> G2P -> clear_voxels -> voxelize -> react`.
 //!
 //! All shaders are compiled to a single SPIR-V module at build time via
 //! `spirv-builder` in `build.rs`.
@@ -75,6 +75,20 @@ pub struct G2pPushConstants {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Pod, bytemuck::Zeroable)]
 pub struct VoxelizePushConstants {
+    /// Grid dimension (cells per axis).
+    pub grid_size: u32,
+    /// Total number of active particles.
+    pub num_particles: u32,
+    /// Padding.
+    pub _pad0: u32,
+    /// Padding.
+    pub _pad1: u32,
+}
+
+/// Push constants for the react shader.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Pod, bytemuck::Zeroable)]
+pub struct ReactPushConstants {
     /// Grid dimension (cells per axis).
     pub grid_size: u32,
     /// Total number of active particles.
@@ -156,6 +170,7 @@ pub struct GpuSimulation {
     g2p_pass: ComputePass,
     clear_voxels_pass: ComputePass,
     voxelize_pass: ComputePass,
+    react_pass: ComputePass,
     render_pass: ComputePass,
 
     // Shader module (kept alive for pipeline lifetime)
@@ -227,13 +242,13 @@ impl GpuSimulation {
         )?;
 
         // -- Descriptor pool --
-        // 7 passes, max 2 bindings each = up to 14 storage buffer descriptors
+        // 8 passes, max 2 bindings each = up to 16 storage buffer descriptors
         let pool_sizes = [vk::DescriptorPoolSize {
             ty: vk::DescriptorType::STORAGE_BUFFER,
-            descriptor_count: 14,
+            descriptor_count: 16,
         }];
         let descriptor_pool =
-            pipeline::create_descriptor_pool(ctx, &pool_sizes, 7, "sim-descriptor-pool")?;
+            pipeline::create_descriptor_pool(ctx, &pool_sizes, 8, "sim-descriptor-pool")?;
 
         // -- Create each compute pass --
         // Entry point names are fully qualified module paths in rust-gpu SPIR-V.
@@ -297,6 +312,16 @@ impl GpuSimulation {
             "voxelize",
         )?;
 
+        let react_pass = Self::create_pass(
+            ctx,
+            shader_module,
+            c"compute::react::react",
+            &[&particle_buffer, &voxel_buffer],
+            mem::size_of::<ReactPushConstants>() as u32,
+            descriptor_pool,
+            "react",
+        )?;
+
         let render_pass = Self::create_pass(
             ctx,
             shader_module,
@@ -320,6 +345,7 @@ impl GpuSimulation {
             g2p_pass,
             clear_voxels_pass,
             voxelize_pass,
+            react_pass,
             render_pass,
             shader_module,
             descriptor_pool,
@@ -345,7 +371,7 @@ impl GpuSimulation {
     ///
     /// The command buffer must already be in the recording state.
     /// The dispatch chain is:
-    /// `clear_grid -> P2G -> grid_update -> G2P -> clear_voxels -> voxelize`.
+    /// `clear_grid -> P2G -> grid_update -> G2P -> clear_voxels -> voxelize -> react`.
     ///
     /// Memory barriers are inserted between each dispatch to ensure
     /// correct ordering of shader reads and writes.
@@ -440,6 +466,23 @@ impl GpuSimulation {
             1,
             1,
             bytemuck::bytes_of(&vox_pc),
+        );
+        Self::barrier(cmd, &self.device);
+
+        // 7. React (chemical reactions via voxel neighbor lookup)
+        let react_pc = ReactPushConstants {
+            grid_size,
+            num_particles,
+            _pad0: 0,
+            _pad1: 0,
+        };
+        self.dispatch(
+            cmd,
+            &self.react_pass,
+            particle_wg,
+            1,
+            1,
+            bytemuck::bytes_of(&react_pc),
         );
     }
 
@@ -682,6 +725,7 @@ impl GpuSimulation {
             &self.g2p_pass,
             &self.clear_voxels_pass,
             &self.voxelize_pass,
+            &self.react_pass,
             &self.render_pass,
         ];
         for pass in passes {
@@ -753,6 +797,7 @@ mod tests {
         assert_eq!(mem::size_of::<GridUpdatePushConstants>(), 16);
         assert_eq!(mem::size_of::<G2pPushConstants>(), 16);
         assert_eq!(mem::size_of::<VoxelizePushConstants>(), 16);
+        assert_eq!(mem::size_of::<ReactPushConstants>(), 16);
         // RenderPushConstants: 4 u32s (16 bytes) + 2 Vec4s (32 bytes) = 48 bytes
         assert_eq!(mem::size_of::<RenderPushConstants>(), 48);
     }

--- a/crates/shaders/src/compute/mod.rs
+++ b/crates/shaders/src/compute/mod.rs
@@ -12,6 +12,7 @@ pub mod clear_grid;
 pub mod g2p;
 pub mod grid_update;
 pub mod p2g;
+pub mod react;
 pub mod render;
 pub mod voxelize;
 

--- a/crates/shaders/src/compute/react.rs
+++ b/crates/shaders/src/compute/react.rs
@@ -1,0 +1,150 @@
+//! Chemical reaction compute shader.
+//!
+//! Runs AFTER voxelize, BEFORE render. Each thread processes one particle,
+//! checking 6 face-neighbors in the voxel grid for reaction partners.
+//!
+//! Reactions:
+//! - Water (material_id=1, phase=1) + adjacent Lava (material_id=2) -> Stone (material_id=0, phase=0)
+//! - Lava (material_id=2, phase=1) + adjacent Water (material_id=1) -> Steam (material_id=1, phase=2, temp=100)
+
+use crate::types::Particle;
+use spirv_std::glam::{UVec3, UVec4, Vec4};
+use spirv_std::spirv;
+
+/// Push constants for the react shader.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct ReactPushConstants {
+    /// Grid dimension (cells per axis).
+    pub grid_size: u32,
+    /// Total number of active particles.
+    pub num_particles: u32,
+    /// Padding for alignment.
+    pub _pad0: u32,
+    /// Padding for alignment.
+    pub _pad1: u32,
+}
+
+/// Check whether a voxel at given coordinates contains the specified material.
+///
+/// Returns true if the voxel is occupied (w > 0) and its material_id matches.
+fn has_neighbor_material(
+    voxels: &[UVec4],
+    grid_size: u32,
+    x: i32,
+    y: i32,
+    z: i32,
+    target_material: u32,
+) -> bool {
+    let gs = grid_size as i32;
+    if x < 0 || x >= gs || y < 0 || y >= gs || z < 0 || z >= gs {
+        return false;
+    }
+    let idx = (z as u32 * grid_size * grid_size + y as u32 * grid_size + x as u32) as usize;
+    let voxel = voxels[idx];
+    voxel.w > 0 && voxel.x == target_material
+}
+
+/// Check the 6 face-neighbors of a particle's voxel position for a given material.
+///
+/// Returns true if any of the +/-x, +/-y, +/-z neighbors contains the target material.
+fn any_face_neighbor_has_material(
+    voxels: &[UVec4],
+    grid_size: u32,
+    vx: i32,
+    vy: i32,
+    vz: i32,
+    target_material: u32,
+) -> bool {
+    has_neighbor_material(voxels, grid_size, vx - 1, vy, vz, target_material)
+        || has_neighbor_material(voxels, grid_size, vx + 1, vy, vz, target_material)
+        || has_neighbor_material(voxels, grid_size, vx, vy - 1, vz, target_material)
+        || has_neighbor_material(voxels, grid_size, vx, vy + 1, vz, target_material)
+        || has_neighbor_material(voxels, grid_size, vx, vy, vz - 1, target_material)
+        || has_neighbor_material(voxels, grid_size, vx, vy, vz + 1, target_material)
+}
+
+/// Process a single particle for chemical reactions.
+///
+/// Checks 6 face-neighbors in the voxel buffer and applies:
+/// - Water + adjacent Lava -> Stone (reset F = Identity)
+/// - Lava + adjacent Water -> Steam (reset F = Identity, temp = 100)
+pub fn react_particle(
+    particle: &mut Particle,
+    voxels: &[UVec4],
+    grid_size: u32,
+) {
+    let material_id = particle.ids.x;
+    let phase = particle.ids.y;
+
+    // Only react liquids (phase == 1)
+    if phase != 1 {
+        return;
+    }
+
+    let pos = particle.pos_mass.truncate();
+    let vx = pos.x as i32;
+    let vy = pos.y as i32;
+    let vz = pos.z as i32;
+
+    // Bounds check
+    let gs = grid_size as i32;
+    if vx < 0 || vx >= gs || vy < 0 || vy >= gs || vz < 0 || vz >= gs {
+        return;
+    }
+
+    // Water (material_id=1) + adjacent Lava (material_id=2) -> Stone
+    if material_id == 1
+        && any_face_neighbor_has_material(voxels, grid_size, vx, vy, vz, 2)
+    {
+        // Become stone: material_id=0, phase=0 (solid)
+        particle.ids.x = 0;
+        particle.ids.y = 0;
+        // Reset deformation gradient (trap #8)
+        particle.f_col0 = Vec4::new(1.0, 0.0, 0.0, 0.0);
+        particle.f_col1 = Vec4::new(0.0, 1.0, 0.0, 0.0);
+        particle.f_col2 = Vec4::new(0.0, 0.0, 1.0, 0.0);
+        return;
+    }
+
+    // Lava (material_id=2) + adjacent Water (material_id=1) -> Steam
+    if material_id == 2
+        && any_face_neighbor_has_material(voxels, grid_size, vx, vy, vz, 1)
+    {
+        // Become steam: material_id=1 (water material), phase=2 (gas)
+        particle.ids.x = 1;
+        particle.ids.y = 2;
+        // Set temperature to 100 (boiling point)
+        particle.vel_temp = Vec4::new(
+            particle.vel_temp.x,
+            particle.vel_temp.y,
+            particle.vel_temp.z,
+            100.0,
+        );
+        // Reset deformation gradient (trap #8)
+        particle.f_col0 = Vec4::new(1.0, 0.0, 0.0, 0.0);
+        particle.f_col1 = Vec4::new(0.0, 1.0, 0.0, 0.0);
+        particle.f_col2 = Vec4::new(0.0, 0.0, 1.0, 0.0);
+    }
+}
+
+/// Compute shader entry point: chemical reactions.
+///
+/// Runs after voxelize to check particle neighbors via the voxel grid.
+/// Descriptor set 0, binding 0: storage buffer of `Particle` (read-write).
+/// Descriptor set 0, binding 1: storage buffer of `UVec4` (voxel grid, read).
+/// Push constants: `ReactPushConstants`.
+/// Dispatch with `(ceil(num_particles / 64), 1, 1)` workgroups.
+#[spirv(compute(threads(64)))]
+pub fn react(
+    #[spirv(global_invocation_id)] id: UVec3,
+    #[spirv(push_constant)] push: &ReactPushConstants,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] particles: &mut [Particle],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] voxels: &[UVec4],
+) {
+    let idx = id.x as usize;
+    if id.x >= push.num_particles {
+        return;
+    }
+    react_particle(&mut particles[idx], voxels, push.grid_size);
+}

--- a/crates/shaders/src/compute/render.rs
+++ b/crates/shaders/src/compute/render.rs
@@ -326,7 +326,16 @@ pub fn render_pixel(
             Vec3::new(0.0, 0.0, -(step_z as f32))
         };
 
-        let base_color = material_color(hit_material);
+        // Read phase from voxel data (.y component)
+        let hit_idx = (vz as u32 * grid_size * grid_size + vy as u32 * grid_size + vx as u32) as usize;
+        let hit_phase = voxels[hit_idx].y;
+
+        // Override color for gas/steam (phase == 2): white-ish wispy appearance
+        let base_color = if hit_phase == 2 {
+            Vec3::new(0.9, 0.9, 0.95)
+        } else {
+            material_color(hit_material)
+        };
         let lit_color = apply_lighting(base_color, normal);
 
         // Add emissive glow for lava (material_id == 2)


### PR DESCRIPTION
## Summary
- Add new `react` compute shader (`crates/shaders/src/compute/react.rs`) that checks 6 face-neighbors in the voxel grid for chemical reactions
- Water (material_id=1, liquid) + adjacent Lava (material_id=2) → Stone (material_id=0, solid, F=Identity)
- Lava (material_id=2, liquid) + adjacent Water (material_id=1) → Steam (material_id=1, gas phase, temp=100, F=Identity)
- Server dispatch chain extended: `clear_grid → P2G → grid_update → G2P → clear_voxels → voxelize → react`
- Render shader updated to show steam/gas (phase=2) as white-ish color

## Test plan
- [x] `cargo build -p server` compiles (shader recompilation succeeds)
- [x] `cargo test -p server -- --test-threads=1` — all 6 tests pass
- [ ] Manual test: place water and lava particles adjacent, verify reaction occurs
- [ ] Visual check: steam appears white, stone appears gray after reaction

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)