### PR TITLE
fix(shaders): solid boundary conditions prevent fluid leaking through walls

### DIFF
--- a/crates/shaders/src/compute/grid_update.rs
+++ b/crates/shaders/src/compute/grid_update.rs
@@ -70,6 +70,15 @@ pub fn update_cell(
         vz = 0.0;
     }
 
+    // Solid boundary conditions: zero velocity at cells occupied by solid particles.
+    // The solid flag is written by P2G into force_pad.w (the pad slot).
+    // This prevents fluid from leaking through solid walls/floors.
+    if cell.force_pad.w > 0.5 {
+        vx = 0.0;
+        vy = 0.0;
+        vz = 0.0;
+    }
+
     cell.velocity_mass = Vec4::new(vx, vy, vz, mass);
 }
 

--- a/crates/shaders/src/compute/p2g.rs
+++ b/crates/shaders/src/compute/p2g.rs
@@ -210,6 +210,15 @@ pub fn scatter_particle(
                         grid_atomic_add(grid, base + 5, stress_force.y);
                         grid_atomic_add(grid, base + 6, stress_force.z);
                     }
+
+                    // Mark cells with solid particle contribution (phase == 0)
+                    // so grid_update can enforce solid boundary conditions.
+                    // Uses the pad slot (index 7) as a solid flag.
+                    if particle.ids.y == 0 {
+                        unsafe {
+                            grid_atomic_add(grid, base + 7, 1.0);
+                        }
+                    }
                 }
                 dk += 1;
             }


### PR DESCRIPTION
## Summary
- **P2G shader**: When scattering a solid particle (phase == 0), writes a solid flag to the grid pad slot (`grid[base + 7]`) via atomic add
- **Grid update shader**: After computing velocity and applying gravity/edge boundaries, checks `force_pad.w > 0.5` and zeroes velocity at cells occupied by solid particles
- **clear_grid** already zeros `force_pad` (including `.w`) each frame — no change needed

This prevents water/lava from leaking through cave walls by enforcing zero velocity at grid cells that contain solid material.

Closes #72

## Test plan
- [x] `cargo build -p app` passes (shaders compile to valid SPIR-V)
- [ ] Visual test: water stays inside cave walls instead of leaking through
- [ ] Lava flow respects solid boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)