### PR TITLE
feat: mouse material spawning

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -36,6 +36,12 @@ use winit::{
 /// Default number of simulation substeps per frame.
 const DEFAULT_SUBSTEPS: u32 = 4;
 
+/// Distance from camera eye at which particles are spawned.
+const SPAWN_DISTANCE: f32 = 8.0;
+
+/// Radius for particle removal (middle click).
+const REMOVE_RADIUS: f32 = 2.0;
+
 /// Command-line arguments for the app.
 struct Args {
     /// Run in headless mode (no window, render to PNG).
@@ -259,6 +265,8 @@ struct App {
     pressed_keys: HashSet<PhysicalKey>,
     /// Whether the mouse cursor is captured for camera look.
     cursor_captured: bool,
+    /// Last known cursor position in pixels (for spawn ray calculation).
+    cursor_position: (f32, f32),
     /// Timestamp of the last frame for delta-time calculation.
     last_frame_time: Instant,
     /// Number of simulation substeps per frame.
@@ -285,6 +293,7 @@ impl App {
             camera,
             pressed_keys: HashSet::new(),
             cursor_captured: false,
+            cursor_position: (0.0, 0.0),
             last_frame_time: Instant::now(),
             substeps,
         }
@@ -305,6 +314,66 @@ impl App {
             window.set_cursor_visible(true);
             let _ = window.set_cursor_grab(CursorGrabMode::None);
             self.cursor_captured = false;
+        }
+    }
+
+    /// Spawn a small cube of particles at the camera's aim point.
+    ///
+    /// Creates a 2x2x2 block of particles at `camera.eye() + forward * SPAWN_DISTANCE`.
+    /// `mat` and `phase` define the material type. `temperature` sets initial temperature.
+    fn spawn_particles(&mut self, mat: u32, phase: u32, temperature: f32) {
+        let (ctx, sim) = match (self.ctx.as_ref(), self.sim.as_mut()) {
+            (Some(c), Some(s)) => (c, s),
+            _ => return,
+        };
+
+        let center = self.camera.eye() + self.camera.forward() * SPAWN_DISTANCE;
+        let mut new_particles = Vec::new();
+        spawn_cell(&mut new_particles, center.x - 0.5, center.y - 0.5, center.z - 0.5, 0.125, mat, phase);
+
+        // Set temperature on all spawned particles
+        if temperature != 0.0 {
+            for p in &mut new_particles {
+                p.vel_temp = glam::Vec4::new(0.0, 0.0, 0.0, temperature);
+            }
+        }
+
+        if let Err(e) = sim.add_particles(ctx, &new_particles) {
+            tracing::warn!("Failed to spawn particles: {}", e);
+        }
+    }
+
+    /// Remove particles near the camera's aim point within [`REMOVE_RADIUS`].
+    ///
+    /// Reads back all particles, filters out those within the radius of the
+    /// aim point, and re-uploads. Expensive but acceptable for MVP.
+    fn remove_particles(&mut self) {
+        let (ctx, sim) = match (self.ctx.as_ref(), self.sim.as_mut()) {
+            (Some(c), Some(s)) => (c, s),
+            _ => return,
+        };
+
+        let center = self.camera.eye() + self.camera.forward() * SPAWN_DISTANCE;
+        let radius_sq = REMOVE_RADIUS * REMOVE_RADIUS;
+
+        match sim.readback_particles(ctx) {
+            Ok(particles) => {
+                let filtered: Vec<Particle> = particles
+                    .into_iter()
+                    .filter(|p| (p.position() - center).length_squared() > radius_sq)
+                    .collect();
+                let removed = sim.num_particles() as usize - filtered.len();
+                if removed > 0 {
+                    if let Err(e) = sim.init_particles(ctx, &filtered) {
+                        tracing::warn!("Failed to re-upload after remove: {}", e);
+                    } else {
+                        tracing::info!("Removed {} particles", removed);
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!("Failed to readback for remove: {}", e);
+            }
         }
     }
 
@@ -444,13 +513,32 @@ impl ApplicationHandler for App {
                 }
             }
 
+            WindowEvent::CursorMoved { position, .. } => {
+                self.cursor_position = (position.x as f32, position.y as f32);
+            }
+
             WindowEvent::MouseInput {
                 state: ElementState::Pressed,
-                button: MouseButton::Left,
+                button,
                 ..
             } => {
                 if !self.cursor_captured {
+                    // First click captures the cursor
                     self.capture_cursor();
+                } else {
+                    // While captured, clicks spawn or remove material
+                    match button {
+                        MouseButton::Left => {
+                            self.spawn_particles(MAT_WATER, PHASE_LIQUID, 0.0);
+                        }
+                        MouseButton::Right => {
+                            self.spawn_particles(MAT_LAVA, PHASE_LIQUID, 2000.0);
+                        }
+                        MouseButton::Middle => {
+                            self.remove_particles();
+                        }
+                        _ => {}
+                    }
                 }
             }
 

--- a/crates/client/src/camera.rs
+++ b/crates/client/src/camera.rs
@@ -122,6 +122,25 @@ impl Camera {
             self.aspect = width as f32 / height as f32;
         }
     }
+
+    /// Convert a screen pixel coordinate to a world-space ray (origin, direction).
+    ///
+    /// `px` and `py` are pixel coordinates (top-left origin).
+    /// `width` and `height` are the viewport dimensions in pixels.
+    /// Returns `(origin, direction)` where `direction` is normalized.
+    pub fn screen_to_ray(&self, px: f32, py: f32, width: f32, height: f32) -> (Vec3, Vec3) {
+        let forward = self.forward();
+        let right = forward.cross(Vec3::Y).normalize();
+        let up = right.cross(forward);
+
+        let fov_tan = (self.fov * 0.5).tan();
+
+        let ndc_x = (2.0 * px / width - 1.0) * self.aspect * fov_tan;
+        let ndc_y = (1.0 - 2.0 * py / height) * fov_tan;
+
+        let dir = (forward + right * ndc_x + up * ndc_y).normalize();
+        (self.eye(), dir)
+    }
 }
 
 #[cfg(test)]
@@ -245,5 +264,34 @@ mod tests {
     fn test_eye() {
         let cam = Camera::new(Vec3::new(5.0, 6.0, 7.0), 0.0, 0.0);
         assert_eq!(cam.eye(), cam.position);
+    }
+
+    #[test]
+    fn test_screen_to_ray_center() {
+        let cam = Camera::new(Vec3::new(0.0, 0.0, 5.0), 0.0, 0.0);
+        let (origin, dir) = cam.screen_to_ray(640.0, 360.0, 1280.0, 720.0);
+        assert_eq!(origin, cam.eye());
+        // Center of screen should point along forward direction (-Z)
+        let fwd = cam.forward();
+        assert!(
+            (dir - fwd).length() < 1e-4,
+            "center ray should match forward: dir={:?}, fwd={:?}",
+            dir,
+            fwd
+        );
+    }
+
+    #[test]
+    fn test_screen_to_ray_corners_diverge() {
+        let cam = Camera::new(Vec3::ZERO, 0.0, 0.0);
+        let (_, dir_tl) = cam.screen_to_ray(0.0, 0.0, 1280.0, 720.0);
+        let (_, dir_br) = cam.screen_to_ray(1280.0, 720.0, 1280.0, 720.0);
+        // Corners should point in different directions
+        let dot = dir_tl.dot(dir_br);
+        assert!(
+            dot < 0.99,
+            "corner rays should diverge, got dot={}",
+            dot
+        );
     }
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -486,6 +486,32 @@ impl GpuSimulation {
         );
     }
 
+    /// Append new particles to the existing simulation.
+    ///
+    /// Reads back current particles from the GPU, appends the new ones,
+    /// and re-uploads the full set. The total count must not exceed
+    /// [`MAX_PARTICLES`]. This is not efficient but works for MVP interactive
+    /// spawning where we add small batches infrequently.
+    pub fn add_particles(&mut self, ctx: &VulkanContext, new_particles: &[Particle]) -> Result<()> {
+        let new_total = self.num_particles as usize + new_particles.len();
+        if new_total > MAX_PARTICLES as usize {
+            return Err(ServerError::TooManyParticles(new_total));
+        }
+
+        // Read back existing particles
+        let mut all_particles = self.readback_particles(ctx)?;
+        all_particles.extend_from_slice(new_particles);
+
+        self.num_particles = all_particles.len() as u32;
+        buffer::upload(ctx, &all_particles, &self.particle_buffer)?;
+        tracing::info!(
+            "Added {} particles, total now {}",
+            new_particles.len(),
+            self.num_particles
+        );
+        Ok(())
+    }
+
     /// Read particle data back from the GPU for debugging.
     ///
     /// This is a synchronous operation that stalls the GPU pipeline.


### PR DESCRIPTION
## Summary
- **Camera** (`client`): Added `screen_to_ray()` method to convert screen pixel coordinates to world-space rays, with 2 unit tests
- **Server**: Added `add_particles()` method that reads back existing particles, appends new ones, and re-uploads (MVP approach, not perf-critical)
- **App**: Left-click spawns 8 water particles (2x2x2 block) at camera aim point, right-click spawns lava at 2000K, middle-click removes particles within radius 2.0. First click captures cursor; Escape releases it.

Closes #39, closes #57

## Test plan
- [x] `cargo build -p app` compiles
- [x] `cargo test -p client` — all 14 tests pass (including 2 new screen_to_ray tests)
- [x] `cargo test -p server -- --test-threads=1` — all 6 tests pass
- [ ] Manual: run app, click to capture cursor, left-click to spawn water, right-click for lava, middle-click to remove

🤖 Generated with [Claude Code](https://claude.com/claude-code)