### PR TITLE
fix(shaders): increase cave ambient + reduce boundary flicker

### DIFF
--- a/crates/shaders/src/compute/render.rs
+++ b/crates/shaders/src/compute/render.rs
@@ -322,7 +322,7 @@ fn apply_lighting(color: Vec3, normal: Vec3) -> Vec3 {
     let ndotl = dot(normal, light_dir);
     let diffuse = if ndotl > 0.0 { ndotl } else { 0.0 };
 
-    let ambient = 0.35;
+    let ambient = 0.5;
     let intensity = ambient + (1.0 - ambient) * diffuse;
 
     Vec3::new(
@@ -589,7 +589,7 @@ pub fn render_pixel(
 
         // Lighting: if in shadow, only ambient contributes; otherwise full lighting
         let lit_color = if in_shadow {
-            let ambient = 0.35;
+            let ambient = 0.4;
             Vec3::new(
                 base_color.x * ambient * ao_factor,
                 base_color.y * ambient * ao_factor,

--- a/crates/shaders/src/compute/voxelize.rs
+++ b/crates/shaders/src/compute/voxelize.rs
@@ -81,7 +81,7 @@ pub fn write_voxel(
                     let w = wx * wy * wz;
 
                     // Only write if weight is significant
-                    if w > 0.1 {
+                    if w > 0.3 {
                         let idx =
                             (cz * grid_size * grid_size + cy * grid_size + cx) as usize;
                         // Simple last-write-wins, but with splatting it's much smoother


### PR DESCRIPTION
## Summary
- Increase ambient light from 0.35 to 0.5 and shadow ambient from 0.35 to 0.4 in `render.rs` so cave/indoor scenes are visible
- Raise voxelize splatting weight threshold from 0.1 to 0.3 in `voxelize.rs` to reduce material boundary flickering at water/lava edges

## Test plan
- [ ] Run `cargo build -p app` (verified locally)
- [ ] Visual check: caves should no longer be nearly black
- [ ] Visual check: water/lava boundaries should flicker less

🤖 Generated with [Claude Code](https://claude.com/claude-code)