### PR TITLE
fix(shaders): deterministic material selection at voxel boundaries

### DIFF
--- a/crates/shaders/src/compute/react.rs
+++ b/crates/shaders/src/compute/react.rs
@@ -42,7 +42,7 @@ fn has_neighbor_material(
     }
     let idx = (z as u32 * grid_size * grid_size + y as u32 * grid_size + x as u32) as usize;
     let voxel = voxels[idx];
-    voxel.w > 0 && voxel.x == target_material
+    voxel.w > 0 && ((voxel.x >> 16) & 0xFF) == target_material
 }
 
 /// Check the 6 face-neighbors of a particle's voxel position for a given material.

--- a/crates/shaders/src/compute/render.rs
+++ b/crates/shaders/src/compute/render.rs
@@ -447,7 +447,7 @@ fn compute_lava_light(
                         + ny as u32 * grid_size
                         + nx as u32) as usize;
                     let voxel = voxels[idx];
-                    if voxel.w > 0 && voxel.x == 2 {
+                    if voxel.w > 0 && ((voxel.x >> 16) & 0xFF) == 2 {
                         // Lava found — add warm orange light with distance falloff
                         let dist_sq = (dx * dx + dy * dy + dz * dz) as f32;
                         let attenuation = 1.0 / (1.0 + dist_sq * 0.5);
@@ -606,7 +606,7 @@ pub fn render_pixel(
             let voxel = voxels[idx];
             if voxel.w > 0 {
                 hit = true;
-                hit_material = voxel.x;
+                hit_material = (voxel.x >> 16) & 0xFF;
                 break;
             }
         } else {
@@ -661,9 +661,9 @@ pub fn render_pixel(
         );
         let in_shadow = march_shadow(shadow_origin, sun_direction(), voxels, grid_size);
 
-        // Read phase from voxel data (.y component)
+        // Read phase from packed voxel data (.x component, bits 8-15)
         let hit_idx = (vz as u32 * grid_size * grid_size + vy as u32 * grid_size + vx as u32) as usize;
-        let hit_phase = voxels[hit_idx].y;
+        let hit_phase = (voxels[hit_idx].x >> 8) & 0xFF;
 
         // Override color for gas/steam (phase == 2): white-ish wispy appearance
         let base_color = if hit_phase == 2 {

--- a/crates/shaders/src/compute/voxelize.rs
+++ b/crates/shaders/src/compute/voxelize.rs
@@ -3,10 +3,32 @@
 //! Each thread processes one particle, mapping its position to a voxel cell
 //! and writing material_id + temperature to a 3D output buffer.
 //! Used for BLAS brick occupancy detection and rendering.
+//!
+//! ## Majority-vote material selection
+//!
+//! At material boundaries, multiple particles of different materials contribute
+//! to the same voxel cell. A naive last-write-wins causes the material_id to
+//! oscillate each frame (visible as flickering).
+//!
+//! To fix this, we pack `(weight, material_id, phase)` into a single `u32` and
+//! use `atomicMax` so the particle with the highest trilinear weight wins
+//! deterministically. For equal weights, the higher material_id wins (stable).
+//!
+//! ### Voxel buffer layout (4 u32s per cell, accessed as flat `&mut [u32]`):
+//!
+//! | Offset | Field | Description |
+//! |--------|-------|-------------|
+//! | 0 | packed_material | `(weight_8b << 24) \| (material_id_8b << 16) \| (phase_8b << 8) \| 0xFF` — atomicMax |
+//! | 1 | temperature | f32 reinterpreted as u32 bits — last-write from winner |
+//! | 2 | _reserved | unused (zero) |
+//! | 3 | occupied | non-zero if any particle maps here — atomicMax with 1 |
 
 use crate::types::Particle;
 use spirv_std::glam::{UVec3, UVec4};
 use spirv_std::spirv;
+
+/// Number of u32 values per voxel cell.
+const U32S_PER_VOXEL: u32 = 4;
 
 /// Push constants for the voxelize shader.
 #[derive(Copy, Clone)]
@@ -22,30 +44,77 @@ pub struct VoxelizePushConstants {
     pub _pad1: u32,
 }
 
-/// Voxel cell data packed into a UVec4 for atomic-friendly writes.
+/// Pack material selection data into a single u32 for atomic competition.
 ///
-/// - x: material_id
-/// - y: phase
-/// - z: temperature as u32 bits (f32 reinterpreted)
-/// - w: density counter (number of particles in this voxel)
+/// Layout: `(weight_8b << 24) | (material_id_8b << 16) | (phase_8b << 8) | 0xFF`
 ///
-/// When multiple particles map to the same voxel, the one with the
-/// highest density counter "wins" via atomic max on the w component.
-/// This is a simplification; a proper implementation would use
-/// splatting or averaging.
+/// `atomicMax` on this value means the highest-weight particle wins.
+/// For equal weights, the higher material_id wins (deterministic tie-break).
+pub fn pack_material(weight_f32: f32, material_id: u32, phase: u32) -> u32 {
+    // Quantize weight [0.0, 1.0] to [0, 255]
+    let w_clamped = if weight_f32 < 0.0 {
+        0.0
+    } else if weight_f32 > 1.0 {
+        1.0
+    } else {
+        weight_f32
+    };
+    let w_u8 = (w_clamped * 255.0) as u32;
+    let mat_u8 = material_id & 0xFF;
+    let phase_u8 = phase & 0xFF;
+    (w_u8 << 24) | (mat_u8 << 16) | (phase_u8 << 8) | 0xFF
+}
 
-/// Map a particle to a voxel cell and write its data using trilinear splatting.
+/// Unpack material_id from a packed voxel material u32.
+pub fn unpack_material_id(packed: u32) -> u32 {
+    (packed >> 16) & 0xFF
+}
+
+/// Unpack phase from a packed voxel material u32.
+pub fn unpack_phase(packed: u32) -> u32 {
+    (packed >> 8) & 0xFF
+}
+
+/// Atomically set the voxel's packed material data using max-wins competition.
 ///
-/// Instead of writing to a single cell (which causes flickering when particles
-/// straddle cell boundaries), splats to the 2x2x2 nearest cells weighted by
-/// the trilinear interpolation weights. Only writes cells with weight > 0.1
-/// to avoid polluting distant voxels.
+/// Uses `atomic_u_max` on SPIR-V targets. Falls back to simple comparison
+/// on CPU (for testing).
+///
+/// # Safety
+/// Caller must ensure `voxels[index]` is valid and properly aligned.
+#[inline]
+pub unsafe fn voxel_atomic_max(voxels: &mut [u32], index: usize, value: u32) -> u32 {
+    #[cfg(target_arch = "spirv")]
+    {
+        unsafe {
+            spirv_std::arch::atomic_u_max::<u32, 1u32, 0x0u32>(&mut voxels[index], value)
+        }
+    }
+    #[cfg(not(target_arch = "spirv"))]
+    {
+        let old = voxels[index];
+        if value > old {
+            voxels[index] = value;
+        }
+        old
+    }
+}
+
+/// Map a particle to voxel cells and write material data using atomic competition.
+///
+/// Splats to the 2x2x2 nearest cells weighted by trilinear interpolation.
+/// Uses `atomicMax` on a packed `(weight, material_id, phase)` value so the
+/// particle with the highest contribution weight wins deterministically.
+/// This eliminates boundary flickering caused by non-deterministic write order.
+///
+/// The voxel buffer is accessed as flat `[u32]` with 4 values per cell
+/// to enable per-component atomics (same pattern as P2G uses flat `[f32]`).
 ///
 /// Separated into a helper function for the rust-gpu linker bug workaround
 /// (see CLAUDE.md trap #4a).
 pub fn write_voxel(
     particle: &Particle,
-    voxels: &mut [UVec4],
+    voxels: &mut [u32],
     grid_size: u32,
 ) {
     let pos = particle.pos_mass.truncate();
@@ -81,11 +150,28 @@ pub fn write_voxel(
                     let w = wx * wy * wz;
 
                     // Only write if weight is significant
-                    if w > 0.3 {
-                        let idx =
+                    if w > 0.1 {
+                        let cell_idx =
                             (cz * grid_size * grid_size + cy * grid_size + cx) as usize;
-                        // Simple last-write-wins, but with splatting it's much smoother
-                        voxels[idx] = UVec4::new(material_id, phase, temp_bits, 1);
+                        let base = cell_idx * U32S_PER_VOXEL as usize;
+
+                        let packed = pack_material(w, material_id, phase);
+
+                        // Atomic max-wins competition: highest weight determines material
+                        // Safety: atomic u32 max on the voxel buffer
+                        let old = unsafe { voxel_atomic_max(voxels, base, packed) };
+
+                        // If we won (our value >= old), write temperature
+                        // Temperature is continuous, so slight races here are invisible
+                        if packed >= old {
+                            voxels[base + 1] = temp_bits;
+                        }
+
+                        // Mark cell as occupied (any non-zero value)
+                        // Safety: atomic u32 max on the occupied slot
+                        unsafe {
+                            voxel_atomic_max(voxels, base + 3, 1);
+                        }
                     }
                 }
                 dk += 1;
@@ -96,36 +182,40 @@ pub fn write_voxel(
     }
 }
 
-/// Clear a single voxel cell to empty.
+/// Clear a single voxel cell to empty (all 4 u32 components).
 ///
 /// Helper for the clear pass before voxelization.
-pub fn clear_voxel(voxel: &mut UVec4) {
-    *voxel = UVec4::ZERO;
+pub fn clear_voxel_cell(voxels: &mut [u32], base: usize) {
+    voxels[base] = 0;
+    voxels[base + 1] = 0;
+    voxels[base + 2] = 0;
+    voxels[base + 3] = 0;
 }
 
 /// Compute shader entry point: clear voxel grid.
 ///
 /// Must be dispatched before `voxelize` to reset the voxel buffer.
-/// Descriptor set 0, binding 0: storage buffer of `UVec4` (voxel grid).
+/// Descriptor set 0, binding 0: storage buffer of `u32` (voxel grid, 4 per cell).
 /// Dispatch with `(GRID_SIZE/4, GRID_SIZE/4, GRID_SIZE/4)` workgroups.
 #[spirv(compute(threads(4, 4, 4)))]
 pub fn clear_voxels(
     #[spirv(global_invocation_id)] id: UVec3,
     #[spirv(push_constant)] push: &VoxelizePushConstants,
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] voxels: &mut [UVec4],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] voxels: &mut [u32],
 ) {
     let grid_size = push.grid_size;
     if id.x >= grid_size || id.y >= grid_size || id.z >= grid_size {
         return;
     }
-    let index = (id.z * grid_size * grid_size + id.y * grid_size + id.x) as usize;
-    clear_voxel(&mut voxels[index]);
+    let cell_idx = (id.z * grid_size * grid_size + id.y * grid_size + id.x) as usize;
+    let base = cell_idx * U32S_PER_VOXEL as usize;
+    clear_voxel_cell(voxels, base);
 }
 
 /// Compute shader entry point: voxelize particles.
 ///
 /// Descriptor set 0, binding 0: storage buffer of `Particle` (read).
-/// Descriptor set 0, binding 1: storage buffer of `UVec4` (voxel grid, write).
+/// Descriptor set 0, binding 1: storage buffer of `u32` (voxel grid, 4 per cell, write).
 /// Push constants: `VoxelizePushConstants`.
 /// Dispatch with `(ceil(num_particles / 64), 1, 1)` workgroups.
 #[spirv(compute(threads(64)))]
@@ -133,7 +223,7 @@ pub fn voxelize(
     #[spirv(global_invocation_id)] id: UVec3,
     #[spirv(push_constant)] push: &VoxelizePushConstants,
     #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] particles: &[Particle],
-    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] voxels: &mut [UVec4],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] voxels: &mut [u32],
 ) {
     let idx = id.x as usize;
     if id.x >= push.num_particles {


### PR DESCRIPTION
## Summary

- Replace last-write-wins voxelization with atomic max-wins competition using `atomicMax`
- Pack `(weight_8b, material_id_8b, phase_8b)` into a single `u32` so the particle with the highest trilinear weight wins deterministically
- Update render and react shaders to unpack material_id and phase from the new packed format
- Lower splatting threshold from 0.3 to 0.1 for better coverage at cell edges

## Problem

At material boundaries (water/lava/stone), multiple particles of different materials write to the same voxel cell. The previous last-write-wins approach caused material_id to oscillate each frame depending on GPU thread execution order, producing visible flickering.

## Solution

The voxel buffer's first u32 per cell now holds a packed value: `(weight << 24) | (material_id << 16) | (phase << 8) | 0xFF`. Using `atomicMax` on this packed value, the particle with the highest trilinear interpolation weight always wins, regardless of thread execution order. The buffer layout (4 u32s per cell = 16 bytes = sizeof(UVec4)) is unchanged, so no host-side buffer allocation changes are needed.

## Test plan

- [x] `cargo build -p shader-builder` compiles shaders to SPIR-V successfully
- [x] `cargo build` full workspace builds
- [x] `cargo test -p shared -p sim-cpu -p protocol` all 80 tests pass
- [ ] Visual verification: material boundaries should no longer flicker

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)