### PR TITLE
feat: explosion force field (radial impulse)

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -32,6 +32,8 @@ use winit::{
 const DEFAULT_SUBSTEPS: u32 = 4;
 const SPAWN_DISTANCE: f32 = 8.0;
 const REMOVE_RADIUS: f32 = 2.0;
+const EXPLOSION_RADIUS: f32 = 3.0;
+const EXPLOSION_STRENGTH: f32 = 50.0;
 /// Water level scales with grid: ~15% of grid height.
 const WATER_LEVEL_FRAC: f32 = 0.15;
 const MARGIN: u32 = 2;
@@ -295,6 +297,7 @@ struct App {
     substeps: u32,
     selected_material: usize,
     palette: Vec<MaterialSlot>,
+    pending_explosion: Option<[f32; 3]>,
 }
 
 impl App {
@@ -322,6 +325,7 @@ impl App {
             substeps,
             selected_material: 0,
             palette: material_palette(),
+            pending_explosion: None,
         }
     }
 
@@ -358,6 +362,12 @@ impl App {
         if let Err(e) = sim.add_particles(ctx, &new_particles) {
             tracing::warn!("Failed to spawn particles: {}", e);
         }
+    }
+
+    fn trigger_explosion(&mut self) {
+        let center = self.player.camera.eye() + self.player.camera.forward() * SPAWN_DISTANCE;
+        self.pending_explosion = Some([center.x, center.y, center.z]);
+        tracing::info!("Explosion at [{:.1}, {:.1}, {:.1}]", center.x, center.y, center.z);
     }
 
     fn remove_particles(&mut self) {
@@ -492,6 +502,7 @@ impl ApplicationHandler for App {
                     match button {
                         MouseButton::Left => self.spawn_particles(),
                         MouseButton::Right => self.remove_particles(),
+                        MouseButton::Middle => self.trigger_explosion(),
                         _ => {}
                     }
                 }
@@ -518,9 +529,13 @@ impl ApplicationHandler for App {
                 let eye = self.player.camera.eye();
                 let target = self.player.camera.target();
                 let toolbar_pc = self.toolbar_push_constants();
+                let explosion = self.pending_explosion.take();
                 if let (Some(renderer), Some(ctx), Some(sim)) = (self.renderer.as_mut(), self.ctx.as_ref(), self.sim.as_ref()) {
                     if let Err(e) = ctx.execute_one_shot(|cmd| {
                         for _ in 0..substeps { sim.step(cmd); }
+                        if let Some(center) = explosion {
+                            sim.apply_explosion(cmd, center, EXPLOSION_RADIUS, EXPLOSION_STRENGTH);
+                        }
                         sim.render(cmd, RENDER_WIDTH, RENDER_HEIGHT, [eye.x, eye.y, eye.z], [target.x, target.y, target.z]);
                         sim.render_toolbar(cmd, &toolbar_pc);
                         sim.finalize_render(cmd);

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -117,6 +117,20 @@ pub struct ReactPushConstants {
     pub _pad1: u32,
 }
 
+/// Push constants for the explosion shader.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Pod, bytemuck::Zeroable)]
+pub struct ExplosionPushConstants {
+    /// Explosion center (xyz), w unused.
+    pub center: glam::Vec4,
+    /// x = radius, y = strength, z = dt, w = num_particles as f32.
+    pub params: glam::Vec4,
+    /// Total number of active particles.
+    pub num_particles: u32,
+    /// Padding to 16-byte alignment.
+    pub _pad: [u32; 3],
+}
+
 /// Maximum number of material slots in the toolbar.
 pub const TOOLBAR_MAX_MATERIALS: usize = 8;
 
@@ -195,6 +209,7 @@ pub struct GpuSimulation {
     render_pass: ComputePass,
     toolbar_overlay_pass: ComputePass,
     react_pass: ComputePass,
+    explosion_pass: ComputePass,
 
     // Shader module (kept alive for pipeline lifetime)
     shader_module: vk::ShaderModule,
@@ -265,13 +280,13 @@ impl GpuSimulation {
         )?;
 
         // -- Descriptor pool --
-        // 9 passes, max 2 bindings each = up to 18 storage buffer descriptors
+        // 10 passes, max 2 bindings each = up to 20 storage buffer descriptors
         let pool_sizes = [vk::DescriptorPoolSize {
             ty: vk::DescriptorType::STORAGE_BUFFER,
-            descriptor_count: 18,
+            descriptor_count: 20,
         }];
         let descriptor_pool =
-            pipeline::create_descriptor_pool(ctx, &pool_sizes, 9, "sim-descriptor-pool")?;
+            pipeline::create_descriptor_pool(ctx, &pool_sizes, 10, "sim-descriptor-pool")?;
 
         // -- Create each compute pass --
         // Entry point names are fully qualified module paths in rust-gpu SPIR-V.
@@ -365,6 +380,16 @@ impl GpuSimulation {
             "react",
         )?;
 
+        let explosion_pass = Self::create_pass(
+            ctx,
+            shader_module,
+            c"compute::explosion::explosion",
+            &[&particle_buffer],
+            mem::size_of::<ExplosionPushConstants>() as u32,
+            descriptor_pool,
+            "explosion",
+        )?;
+
         tracing::info!("GpuSimulation created successfully");
 
         Ok(Self {
@@ -381,6 +406,7 @@ impl GpuSimulation {
             render_pass,
             toolbar_overlay_pass,
             react_pass,
+            explosion_pass,
             shader_module,
             descriptor_pool,
             num_particles: 0,
@@ -649,6 +675,38 @@ impl GpuSimulation {
         );
     }
 
+    /// Record an explosion dispatch into the given command buffer.
+    ///
+    /// Applies a radial impulse to all particles within `radius` of `center`.
+    /// Should be called between `step()` and `render()`. The command buffer
+    /// must be in recording state.
+    pub fn apply_explosion(
+        &self,
+        cmd: vk::CommandBuffer,
+        center: [f32; 3],
+        radius: f32,
+        strength: f32,
+    ) {
+        Self::barrier(cmd, &self.device);
+
+        let push = ExplosionPushConstants {
+            center: glam::Vec4::new(center[0], center[1], center[2], 0.0),
+            params: glam::Vec4::new(radius, strength, shared::DT, self.num_particles as f32),
+            num_particles: self.num_particles,
+            _pad: [0; 3],
+        };
+
+        let particle_wg = (self.num_particles + 63) / 64;
+        self.dispatch(
+            cmd,
+            &self.explosion_pass,
+            particle_wg,
+            1,
+            1,
+            bytemuck::bytes_of(&push),
+        );
+    }
+
     /// Insert a final barrier to ensure all render output writes are complete
     /// before the buffer is copied to the swapchain.
     ///
@@ -813,6 +871,7 @@ impl GpuSimulation {
             &self.render_pass,
             &self.toolbar_overlay_pass,
             &self.react_pass,
+            &self.explosion_pass,
         ];
         for pass in passes {
             pipeline::destroy_pipeline(ctx, pass.pipeline);
@@ -884,6 +943,8 @@ mod tests {
         assert_eq!(mem::size_of::<G2pPushConstants>(), 16);
         assert_eq!(mem::size_of::<VoxelizePushConstants>(), 16);
         assert_eq!(mem::size_of::<ReactPushConstants>(), 16);
+        // ExplosionPushConstants: 2 Vec4s (32 bytes) + 1 u32 + 3 u32 pad (16 bytes) = 48 bytes
+        assert_eq!(mem::size_of::<ExplosionPushConstants>(), 48);
         // RenderPushConstants: 4 u32s (16 bytes) + 2 Vec4s (32 bytes) = 48 bytes
         assert_eq!(mem::size_of::<RenderPushConstants>(), 48);
         // ToolbarPushConstants: 4 u32s (16 bytes) + 8 Vec4s (128 bytes) = 144 bytes

--- a/crates/shaders/src/compute/explosion.rs
+++ b/crates/shaders/src/compute/explosion.rs
@@ -1,0 +1,80 @@
+//! Explosion force field compute shader.
+//!
+//! Applies a radial impulse to all particles within a given radius of an
+//! explosion center. Uses softened inverse-square falloff so particles near
+//! the center receive a large but finite push, while distant ones get a
+//! gentle nudge.
+//!
+//! Optionally accumulates damage on solid-phase particles (ids.z).
+
+use crate::types::Particle;
+use spirv_std::glam::{UVec3, Vec4};
+use spirv_std::spirv;
+
+/// Push constants for the explosion shader.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct ExplosionPushConstants {
+    /// Explosion center (xyz), w unused.
+    pub center: Vec4,
+    /// x = radius, y = strength, z = dt, w = num_particles as f32.
+    pub params: Vec4,
+    /// Total number of active particles.
+    pub num_particles: u32,
+    /// Padding to 16-byte alignment.
+    pub _pad: [u32; 3],
+}
+
+/// Apply radial impulse to a single particle from an explosion.
+///
+/// The force uses a softened inverse-square law: `strength / (dist^2 + 1.0)`.
+/// Solid-phase particles also accumulate damage in `ids.z` (clamped to 255).
+pub fn apply_explosion(particle: &mut Particle, center: Vec4, radius: f32, strength: f32, dt: f32) {
+    let pos = particle.pos_mass.truncate();
+    let center_pos = center.truncate();
+    let dir = pos - center_pos;
+    let dist = dir.length();
+
+    if dist >= radius || dist < 0.01 {
+        return;
+    }
+
+    let force = strength / (dist * dist + 1.0);
+    let impulse = dir * (force / dist) * dt; // normalize(dir) * force * dt
+
+    particle.vel_temp = Vec4::new(
+        particle.vel_temp.x + impulse.x,
+        particle.vel_temp.y + impulse.y,
+        particle.vel_temp.z + impulse.z,
+        particle.vel_temp.w,
+    );
+
+    // Accumulate damage on solid-phase particles
+    if particle.ids.y == 0 {
+        let damage_add = (force * 0.001) as u32;
+        let new_damage = particle.ids.z + damage_add;
+        particle.ids.z = if new_damage > 255 { 255 } else { new_damage };
+    }
+}
+
+/// Compute shader entry point: explosion force field.
+///
+/// Applies a radial impulse to particles within range of the explosion center.
+/// Descriptor set 0, binding 0: storage buffer of `Particle` (read-write).
+/// Push constants: `ExplosionPushConstants`.
+/// Dispatch with `(ceil(num_particles / 64), 1, 1)` workgroups.
+#[spirv(compute(threads(64)))]
+pub fn explosion(
+    #[spirv(global_invocation_id)] id: UVec3,
+    #[spirv(push_constant)] push: &ExplosionPushConstants,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] particles: &mut [Particle],
+) {
+    let idx = id.x as usize;
+    if id.x >= push.num_particles {
+        return;
+    }
+    let radius = push.params.x;
+    let strength = push.params.y;
+    let dt = push.params.z;
+    apply_explosion(&mut particles[idx], push.center, radius, strength, dt);
+}

--- a/crates/shaders/src/compute/mod.rs
+++ b/crates/shaders/src/compute/mod.rs
@@ -10,6 +10,7 @@
 //! Both views alias the same GPU buffer. Each `GridCell` = 8 contiguous f32s.
 
 pub mod clear_grid;
+pub mod explosion;
 pub mod g2p;
 pub mod grid_update;
 pub mod p2g;


### PR DESCRIPTION
## Summary
- Add `explosion` compute shader (`crates/shaders/src/compute/explosion.rs`) with softened inverse-square radial impulse and damage accumulation on solid particles
- Add `explosion_pass` and `apply_explosion()` method to `GpuSimulation` in server
- Middle mouse button triggers explosion at aim point in the app (radius=3.0, strength=50.0)

Closes #103

## Test plan
- [x] `cargo build -p app` compiles successfully (shaders + server + app)
- [x] `cargo test -p server -- --test-threads=1` — all 6 tests pass (including push constant size check for `ExplosionPushConstants`)
- [ ] Manual: run app, middle-click near particles to verify radial impulse effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)