### PR TITLE
fix(app): scale explosion/spawn params for 256³ grid

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -30,10 +30,10 @@ use winit::{
 };
 
 const DEFAULT_SUBSTEPS: u32 = 4;
-const SPAWN_DISTANCE: f32 = 8.0;
+const SPAWN_DISTANCE: f32 = 30.0;
 const REMOVE_RADIUS: f32 = 2.0;
-const EXPLOSION_RADIUS: f32 = 3.0;
-const EXPLOSION_STRENGTH: f32 = 50.0;
+const EXPLOSION_RADIUS: f32 = 20.0;
+const EXPLOSION_STRENGTH: f32 = 500.0;
 /// Water level scales with grid: ~15% of grid height.
 const WATER_LEVEL_FRAC: f32 = 0.15;
 const MARGIN: u32 = 2;


### PR DESCRIPTION
## Summary
- Increased `EXPLOSION_RADIUS` from 3.0 to 20.0 and `EXPLOSION_STRENGTH` from 50.0 to 500.0 so explosions are visible at 256³ grid scale
- Increased `SPAWN_DISTANCE` from 8.0 to 30.0 so spawned/removed particles appear at a reasonable distance in the larger world

## Test plan
- [x] `cargo build -p app` passes
- [ ] Run `cargo run -p app`, middle-click to trigger explosion — verify visible particle displacement
- [ ] Verify left-click spawn and right-click remove work at comfortable distance

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)