### PR TITLE
fix(tests): update client tests for walk-mode default + add regression tests

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -602,6 +602,32 @@ impl ApplicationHandler for App {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn island_particles_under_limit() {
+        let particles = create_island_particles();
+        assert!(
+            particles.len() < shared::MAX_PARTICLES as usize,
+            "Scene has {} particles, max is {}",
+            particles.len(),
+            shared::MAX_PARTICLES
+        );
+    }
+
+    #[test]
+    fn heightmap_values_valid() {
+        let hm = generate_heightmap();
+        assert_eq!(hm.len(), (GRID_SIZE * GRID_SIZE) as usize);
+        for h in &hm {
+            assert!(h.is_finite(), "NaN in heightmap");
+            assert!(*h >= 0.0 && *h < GRID_SIZE as f32, "Height {} out of bounds", h);
+        }
+    }
+}
+
 fn main() -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::try_from_default_env()

--- a/crates/client/src/player.rs
+++ b/crates/client/src/player.rs
@@ -224,7 +224,7 @@ mod tests {
     #[test]
     fn test_new_defaults() {
         let pc = make_controller();
-        assert!(pc.fly_mode);
+        assert!(!pc.fly_mode);
         assert!(!pc.on_ground);
         assert_eq!(pc.velocity_y, 0.0);
         assert_eq!(pc.player_height, DEFAULT_PLAYER_HEIGHT);
@@ -235,11 +235,11 @@ mod tests {
     #[test]
     fn test_toggle_fly_mode() {
         let mut pc = make_controller();
-        assert!(pc.fly_mode);
-        pc.toggle_fly_mode();
         assert!(!pc.fly_mode);
         pc.toggle_fly_mode();
         assert!(pc.fly_mode);
+        pc.toggle_fly_mode();
+        assert!(!pc.fly_mode);
     }
 
     #[test]
@@ -325,6 +325,7 @@ mod tests {
     #[test]
     fn test_fly_mode_delegates_keyboard() {
         let mut pc = make_controller();
+        pc.fly_mode = true;
         assert!(pc.fly_mode);
         let pos_before = pc.camera.position;
         pc.process_keyboard(KeyCode::KeyW, 1.0);
@@ -367,6 +368,7 @@ mod tests {
     #[test]
     fn test_update_fly_mode_noop() {
         let mut pc = make_controller();
+        pc.fly_mode = true;
         assert!(pc.fly_mode);
         let pos_before = pc.camera.position;
         pc.update(1.0);

--- a/crates/sim-cpu/src/world.rs
+++ b/crates/sim-cpu/src/world.rs
@@ -241,7 +241,7 @@ pub fn create_particle_block(
 
 #[cfg(test)]
 mod tests {
-    use shared::material::{MAT_WATER, PHASE_LIQUID};
+    use shared::material::{MAT_STONE, MAT_WATER, PHASE_LIQUID, PHASE_SOLID};
 
     use super::*;
 
@@ -362,6 +362,43 @@ mod tests {
         assert!(
             ke_final > ke_initial,
             "Kinetic energy should increase under gravity: initial={ke_initial}, final={ke_final}"
+        );
+    }
+
+    #[test]
+    fn water_above_stone_floor_falls() {
+        // Regression: a single water particle above a stone floor must move downward
+        let mut particles = Vec::new();
+
+        // Stone floor: a layer of stone particles at y ≈ 0.3
+        for x in 0..5 {
+            for z in 0..5 {
+                particles.push(Particle::new(
+                    Vec3::new(0.3 + x as f32 * 0.05, 0.3, 0.3 + z as f32 * 0.05),
+                    1.0,
+                    MAT_STONE,
+                    PHASE_SOLID,
+                ));
+            }
+        }
+
+        // One water particle above the floor
+        let water_start_y = 0.7;
+        particles.push(Particle::new(
+            Vec3::new(0.5, water_start_y, 0.5),
+            1.0,
+            MAT_WATER,
+            PHASE_LIQUID,
+        ));
+
+        let water_idx = particles.len() - 1;
+        let mut sim = Simulation::new(particles);
+        sim.run(50).unwrap();
+
+        let final_y = sim.particles[water_idx].position().y;
+        assert!(
+            final_y < water_start_y,
+            "Water particle should fall under gravity: start_y={water_start_y}, final_y={final_y}"
         );
     }
 


### PR DESCRIPTION
## Summary
- Fix 4 broken client tests in `PlayerController` that still asserted `fly_mode==true` after the default changed to `false` (walk mode)
- Add 2 scene validation tests in `app`: particle count under `MAX_PARTICLES` and heightmap values valid
- Add physics regression test in `sim-cpu`: water particle above stone floor falls under gravity

## Test plan
- [x] `cargo test -p client` — all 34 tests pass (4 were previously failing)
- [x] `cargo test -p app` — 2 new tests pass
- [x] `cargo test -p shared` — 43 tests pass (unchanged)
- [x] `cargo test -p sim-cpu` — new `water_above_stone_floor_falls` passes (3 pre-existing failures in thermal/grid unrelated to this PR)

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)