### PR TITLE
fix(shaders): make explosions apply visible velocity impulse

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -33,7 +33,7 @@ const DEFAULT_SUBSTEPS: u32 = 4;
 const SPAWN_DISTANCE: f32 = 30.0;
 const REMOVE_RADIUS: f32 = 2.0;
 const EXPLOSION_RADIUS: f32 = 20.0;
-const EXPLOSION_STRENGTH: f32 = 500.0;
+const EXPLOSION_STRENGTH: f32 = 50.0;
 /// Water level scales with grid: ~15% of grid height.
 const WATER_LEVEL_FRAC: f32 = 0.15;
 const MARGIN: u32 = 2;

--- a/crates/shaders/src/compute/explosion.rs
+++ b/crates/shaders/src/compute/explosion.rs
@@ -27,9 +27,11 @@ pub struct ExplosionPushConstants {
 
 /// Apply radial impulse to a single particle from an explosion.
 ///
-/// The force uses a softened inverse-square law: `strength / (dist^2 + 1.0)`.
+/// The velocity impulse uses a linear falloff: `strength * (1 - dist/radius)`.
+/// This gives a direct velocity change (not force * dt), ensuring the effect
+/// is visible regardless of the simulation timestep.
 /// Solid-phase particles also accumulate damage in `ids.z` (clamped to 255).
-pub fn apply_explosion(particle: &mut Particle, center: Vec4, radius: f32, strength: f32, dt: f32) {
+pub fn apply_explosion(particle: &mut Particle, center: Vec4, radius: f32, strength: f32, _dt: f32) {
     let pos = particle.pos_mass.truncate();
     let center_pos = center.truncate();
     let dir = pos - center_pos;
@@ -39,8 +41,10 @@ pub fn apply_explosion(particle: &mut Particle, center: Vec4, radius: f32, stren
         return;
     }
 
-    let force = strength / (dist * dist + 1.0);
-    let impulse = dir * (force / dist) * dt; // normalize(dir) * force * dt
+    // Linear falloff: full strength at center, zero at radius edge.
+    // This is a direct velocity impulse, NOT force * dt.
+    let falloff = 1.0 - dist / radius;
+    let impulse = dir * (strength * falloff / dist);
 
     particle.vel_temp = Vec4::new(
         particle.vel_temp.x + impulse.x,
@@ -51,7 +55,7 @@ pub fn apply_explosion(particle: &mut Particle, center: Vec4, radius: f32, stren
 
     // Accumulate damage on solid-phase particles
     if particle.ids.y == 0 {
-        let damage_add = (force * 0.001) as u32;
+        let damage_add = (strength * falloff * 0.01) as u32;
         let new_damage = particle.ids.z + damage_add;
         particle.ids.z = if new_damage > 255 { 255 } else { new_damage };
     }


### PR DESCRIPTION
## Summary
- **Root cause:** The explosion shader multiplied the impulse by `dt` (0.001), making velocity changes ~1000x too small to be visible in the simulation.
- **Fix:** Changed from `force * dt` integration to a direct velocity impulse with linear falloff (`strength * (1 - dist/radius)`). This ensures the explosion effect is visible regardless of timestep.
- **Tuning:** Reduced `EXPLOSION_STRENGTH` from 500 to 50 in `app/main.rs` to compensate for removing the dt scaling factor.

Closes #120

## Test plan
- [ ] Middle-click to trigger explosion near water particles — particles should visibly scatter
- [ ] Middle-click near stone — particles should show displacement
- [ ] Verify explosion damage accumulates on solid particles
- [ ] `cargo build -p app` passes (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)