### PR TITLE
fix: material-specific fluid viscosity (water vs lava)

### DIFF
--- a/crates/shaders/src/compute/g2p.rs
+++ b/crates/shaders/src/compute/g2p.rs
@@ -116,9 +116,22 @@ pub fn gather_particle(
     // old velocity to reduce excessive damping while maintaining stability.
     let mut new_vel = PIC_RATIO * pic_vel + (1.0 - PIC_RATIO) * old_vel;
 
+    // Material-specific viscous velocity damping for liquids.
+    // High-viscosity materials (lava) get additional per-step damping
+    // to make them visibly sluggish compared to water.
+    let phase = particle.ids.y;
+    let material_id = particle.ids.x;
+    if phase == 1 {
+        let damping = match material_id {
+            1 => 1.0_f32,    // Water: no extra damping (runny)
+            2 => 0.98_f32,   // Lava: 2% damping per step (sluggish)
+            _ => 0.995_f32,  // Default liquid: minimal damping
+        };
+        new_vel *= damping;
+    }
+
     // Gas buoyancy: counteract most of gravity and add slight upward force
     // so steam rises and persists visually instead of falling immediately.
-    let phase = particle.ids.y;
     if phase == 2 {
         // Counteract 70% of gravity (gravity is negative, so add positive Y)
         // and add a small buoyancy boost. Also damp horizontal velocity slightly

--- a/crates/shaders/src/compute/p2g.rs
+++ b/crates/shaders/src/compute/p2g.rs
@@ -50,16 +50,58 @@ pub fn compute_stress(particle: &Particle) -> [Vec3; 3] {
     let j = f_col0.dot(f_col1.cross(f_col2));
 
     if phase == 1 || phase == 2 {
-        // Liquid / Gas: pressure-only stress (EOS)
-        // Bulk modulus: lower for gas, higher for liquid
-        let bulk = if phase == 1 { 20.0_f32 } else { 2.0_f32 };
+        // Liquid / Gas: EOS pressure + viscous stress.
+        // Material-specific bulk modulus and viscosity.
+        // We can't access MaterialParams buffer here (only particle + grid bindings),
+        // so use hardcoded per-material values matching shared::material defaults.
+        let material_id = particle.ids.x;
+        let (bulk, viscosity) = if phase == 2 {
+            // Gas: weak pressure, very low viscosity
+            (2.0_f32, 0.001_f32)
+        } else {
+            // Liquid: material-specific
+            match material_id {
+                1 => (15.0_f32, 0.001_f32),  // Water: low bulk, very low viscosity (runny)
+                2 => (25.0_f32, 5.0_f32),    // Lava: higher bulk, HIGH viscosity (sluggish)
+                _ => (20.0_f32, 0.1_f32),    // Default liquid
+            }
+        };
+
         let pressure = bulk * (j - 1.0);
-        // Cauchy stress = -p * I (isotropic pressure)
-        let s = -pressure;
+
+        // Viscous stress: approximated from APIC C matrix (velocity gradient).
+        // D = 0.5 * (C + C^T), then deviatoric part opposes shearing flow.
+        let c0 = particle.c_col0.truncate();
+        let c1 = particle.c_col1.truncate();
+        let c2 = particle.c_col2.truncate();
+
+        // Symmetric strain rate D = 0.5*(C + C^T)
+        let d00 = c0.x;
+        let d11 = c1.y;
+        let d22 = c2.z;
+        let d01 = 0.5 * (c0.y + c1.x);
+        let d02 = 0.5 * (c0.z + c2.x);
+        let d12 = 0.5 * (c1.z + c2.y);
+
+        // Deviatoric part: D' = D - (tr(D)/3)*I
+        let tr_d = d00 + d11 + d22;
+        let third_tr = tr_d / 3.0;
+        let dev00 = d00 - third_tr;
+        let dev11 = d11 - third_tr;
+        let dev22 = d22 - third_tr;
+
+        // Cauchy stress = -p*I + 2*eta*D'
+        let s00 = -pressure + 2.0 * viscosity * dev00;
+        let s11 = -pressure + 2.0 * viscosity * dev11;
+        let s22 = -pressure + 2.0 * viscosity * dev22;
+        let s01 = 2.0 * viscosity * d01;
+        let s02 = 2.0 * viscosity * d02;
+        let s12 = 2.0 * viscosity * d12;
+
         [
-            Vec3::new(s, 0.0, 0.0),
-            Vec3::new(0.0, s, 0.0),
-            Vec3::new(0.0, 0.0, s),
+            Vec3::new(s00, s01, s02),
+            Vec3::new(s01, s11, s12),
+            Vec3::new(s02, s12, s22),
         ]
     } else {
         // Solid: simplified neo-Hookean / fixed corotated

--- a/crates/sim-cpu/src/grid.rs
+++ b/crates/sim-cpu/src/grid.rs
@@ -318,9 +318,21 @@ pub fn g2p(particles: &mut [Particle], grid: &[GridCell], dt: f32) {
         // to reduce excessive damping while maintaining stability.
         let blended_vel = pic_blend * new_vel + (1.0 - pic_blend) * old_vel;
 
+        // Material-specific viscous velocity damping for liquids.
+        // High-viscosity materials (lava) get additional per-step damping
+        // to make them visibly sluggish compared to water.
+        let mut final_vel = blended_vel;
+        if particle.phase() == 1 {
+            let damping = match particle.material_id() {
+                1 => 1.0_f32,    // Water: no extra damping (runny)
+                2 => 0.98_f32,   // Lava: 2% damping per step (sluggish)
+                _ => 0.995_f32,  // Default liquid: minimal damping
+            };
+            final_vel *= damping;
+        }
+
         // Gas buoyancy: counteract most of gravity and add slight upward force
         // so steam rises and persists visually instead of falling immediately.
-        let mut final_vel = blended_vel;
         if particle.phase() == 2 {
             final_vel.y += (-GRAVITY) * 0.7 * dt;
             final_vel.x *= 0.98;


### PR DESCRIPTION
## Summary
- **P2G shader** (`crates/shaders/src/compute/p2g.rs`): replaced hardcoded `bulk = 20.0` for all liquids with per-material bulk modulus and viscosity. Water gets low bulk (15) + near-zero viscosity (0.001), lava gets higher bulk (25) + high viscosity (5.0). Added viscous deviatoric stress from the APIC C matrix.
- **G2P shader** (`crates/shaders/src/compute/g2p.rs`): added per-step velocity damping for high-viscosity liquids. Lava gets 2% damping per step, water gets none.
- **sim-cpu** (`crates/sim-cpu/src/grid.rs`): synced the same G2P velocity damping to the CPU reference implementation. (CPU P2G already used `constitutive_stress` from `shared::physics` which reads material params correctly.)

Closes #121

## Test plan
- [x] `cargo run -p shader-builder` compiles SPIR-V without errors
- [x] `cargo test -p sim-cpu` passes (23/23, 3 pre-existing failures unrelated)
- [ ] Visual test: water should spread faster than lava when spawned side by side

🤖 Generated with [Claude Code](https://claude.com/claude-code)