### PR TITLE
fix: scale gravity 20x for 256³ grid with 5cm voxels

### DIFF
--- a/crates/client/src/player.rs
+++ b/crates/client/src/player.rs
@@ -14,10 +14,10 @@ use crate::camera::Camera;
 const DEFAULT_PLAYER_HEIGHT: f32 = 1.8;
 
 /// Default jump speed (initial upward velocity) in units per second.
-const DEFAULT_JUMP_SPEED: f32 = 6.0;
+const DEFAULT_JUMP_SPEED: f32 = 120.0;
 
 /// Gravitational acceleration in units per second squared.
-const GRAVITY: f32 = 9.81;
+const GRAVITY: f32 = 196.0;
 
 /// Player controller that wraps a [`Camera`] with optional gravity and ground collision.
 ///

--- a/crates/shaders/src/compute/g2p.rs
+++ b/crates/shaders/src/compute/g2p.rs
@@ -136,7 +136,7 @@ pub fn gather_particle(
         // Counteract 70% of gravity (gravity is negative, so add positive Y)
         // and add a small buoyancy boost. Also damp horizontal velocity slightly
         // to keep steam from flying out of bounds too fast.
-        new_vel.y += 9.81 * 0.7 * dt;
+        new_vel.y += 196.0 * 0.7 * dt;
         new_vel.x *= 0.98;
         new_vel.z *= 0.98;
     }

--- a/crates/shaders/src/types.rs
+++ b/crates/shaders/src/types.rs
@@ -62,8 +62,9 @@ pub const GRID_SIZE: u32 = 256;
 /// Fixed simulation timestep (seconds).
 pub const DT: f32 = 0.001;
 
-/// Gravity acceleration (m/s^2, negative Y).
-pub const GRAVITY: f32 = -9.81;
+/// Gravity acceleration (grid-units/s^2, negative Y).
+/// Scaled 20x from 9.81 for 256^3 grid with 5cm voxels.
+pub const GRAVITY: f32 = -196.0;
 
 /// Material ID constants (synced with shared::material).
 pub const MAT_WATER: u32 = 1;

--- a/crates/shared/src/constants.rs
+++ b/crates/shared/src/constants.rs
@@ -9,8 +9,9 @@ pub const GRID_CELL_COUNT: u32 = GRID_SIZE * GRID_SIZE * GRID_SIZE;
 /// Fixed simulation timestep (seconds).
 pub const DT: f32 = 0.001;
 
-/// Gravity acceleration (m/s², negative Y).
-pub const GRAVITY: f32 = -9.81;
+/// Gravity acceleration (grid-units/s², negative Y).
+/// Scaled 20x from 9.81 for 256³ grid with 5cm voxels.
+pub const GRAVITY: f32 = -196.0;
 
 /// Brick size for BLAS acceleration structure (voxels per axis).
 pub const BRICK_SIZE: u32 = 8;


### PR DESCRIPTION
## Summary
- Scaled gravity from -9.81 to -196.0 (20x) across `shared::constants`, `shaders::types`, `client::player`, and shader `g2p` gas buoyancy
- Scaled player jump speed from 6.0 to 120.0 to match the new gravity
- `sim-cpu::grid` auto-updates via the shared constant import

Closes #139

## Test plan
- [x] `cargo test -p client` -- all 34 tests pass
- [x] `cargo test -p shared` -- all 44 tests pass
- [ ] `cargo build -p app` -- verify full build
- [ ] Visual check: water/lava should fall at realistic speed in the cave scene

🤖 Generated with [Claude Code](https://claude.com/claude-code)