### PR TITLE
feat(materials): add gunpowder material (slot 6)

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -18,8 +18,8 @@ use glam::Vec3;
 use gpu_core::VulkanContext;
 use server::{GpuSimulation, ToolbarPushConstants, TOOLBAR_MAX_MATERIALS};
 use shared::{
-    GRID_SIZE, MAT_ASH, MAT_ICE, MAT_LAVA, MAT_STONE, MAT_WATER, MAT_WOOD, PHASE_LIQUID,
-    PHASE_SOLID, Particle, RENDER_HEIGHT, RENDER_WIDTH,
+    GRID_SIZE, MAT_ASH, MAT_GUNPOWDER, MAT_ICE, MAT_LAVA, MAT_STONE, MAT_WATER, MAT_WOOD,
+    PHASE_LIQUID, PHASE_SOLID, Particle, RENDER_HEIGHT, RENDER_WIDTH,
 };
 use winit::{
     application::ApplicationHandler,
@@ -91,6 +91,13 @@ fn material_palette() -> Vec<MaterialSlot> {
             phase: PHASE_SOLID,
             temperature: -50.0,
             color: glam::Vec4::new(0.7, 0.85, 0.95, 1.0),
+        },
+        MaterialSlot {
+            name: "Gunpowder",
+            mat_id: MAT_GUNPOWDER,
+            phase: PHASE_SOLID,
+            temperature: 0.0,
+            color: glam::Vec4::new(0.25, 0.2, 0.15, 1.0),
         },
     ]
 }
@@ -567,6 +574,10 @@ impl ApplicationHandler for App {
                             winit::keyboard::KeyCode::Digit6 if self.palette.len() > 5 => {
                                 self.selected_material = 5;
                                 tracing::info!("Selected: {}", self.palette[5].name);
+                            }
+                            winit::keyboard::KeyCode::Digit7 if self.palette.len() > 6 => {
+                                self.selected_material = 6;
+                                tracing::info!("Selected: {}", self.palette[6].name);
                             }
                             _ => {}
                         }

--- a/crates/shaders/src/compute/g2p.rs
+++ b/crates/shaders/src/compute/g2p.rs
@@ -252,6 +252,20 @@ pub fn apply_phase_transitions(particle: &mut Particle) {
                 new_material = 1; // MAT_WATER
             }
         }
+        // Gunpowder
+        6 => {
+            if phase == 0 && temp > 200.0 {
+                new_phase = 2; // solid -> gas (explosion)
+                // Boost temp for massive EOS pressure
+                particle.vel_temp = Vec4::new(
+                    particle.vel_temp.x, particle.vel_temp.y, particle.vel_temp.z, 3000.0
+                );
+                // Reset F (trap #8)
+                particle.f_col0 = Vec4::new(1.0, 0.0, 0.0, 0.0);
+                particle.f_col1 = Vec4::new(0.0, 1.0, 0.0, 0.0);
+                particle.f_col2 = Vec4::new(0.0, 0.0, 1.0, 0.0);
+            }
+        }
         _ => {}
     }
 

--- a/crates/shaders/src/compute/render.rs
+++ b/crates/shaders/src/compute/render.rs
@@ -237,6 +237,18 @@ fn textured_material_color(material_id: u32, vx: i32, vy: i32, vz: i32, grid_siz
             pale.y + (white.y - pale.y) * t,
             pale.z + (white.z - pale.z) * t,
         )
+    } else if material_id == 6 {
+        // Gunpowder: dark brown with granular noise
+        let h = hash3(vx, vy, vz);
+        let noise = value_noise(vx as f32 * 3.0, vy as f32 * 3.0, vz as f32 * 3.0);
+        let base = Vec3::new(0.25, 0.2, 0.15);
+        let dark = Vec3::new(0.15, 0.12, 0.08);
+        let t = h * 0.5 + noise * 0.5;
+        Vec3::new(
+            dark.x + (base.x - dark.x) * t,
+            dark.y + (base.y - dark.y) * t,
+            dark.z + (base.z - dark.z) * t,
+        )
     } else {
         // Unknown: magenta
         Vec3::new(1.0, 0.0, 1.0)
@@ -743,6 +755,14 @@ pub fn render_pixel(
             // Temperature is encoded in the voxel; approximate by using
             // a moderate glow since we know wood on fire has T > 300
             let emissive = Vec3::new(1.0, 0.4, 0.05) * 0.5;
+            Vec3::new(
+                lit_color.x + emissive.x,
+                lit_color.y + emissive.y,
+                lit_color.z + emissive.z,
+            )
+        } else if hit_material == 6 && hit_phase == 2 {
+            // Burning gunpowder (phase=gas): bright white-orange flash
+            let emissive = Vec3::new(1.0, 0.9, 0.5) * 1.2;
             Vec3::new(
                 lit_color.x + emissive.x,
                 lit_color.y + emissive.y,

--- a/crates/shaders/src/types.rs
+++ b/crates/shaders/src/types.rs
@@ -70,6 +70,7 @@ pub const MAT_WATER: u32 = 1;
 pub const MAT_WOOD: u32 = 3;
 pub const MAT_ASH: u32 = 4;
 pub const MAT_ICE: u32 = 5;
+pub const MAT_GUNPOWDER: u32 = 6;
 
 /// Number of materials in the table (synced with shared::material).
-pub const MATERIAL_COUNT: usize = 6;
+pub const MATERIAL_COUNT: usize = 7;

--- a/crates/shared/src/material.rs
+++ b/crates/shared/src/material.rs
@@ -28,6 +28,7 @@ pub const MAT_LAVA: u32 = 2;
 pub const MAT_WOOD: u32 = 3;
 pub const MAT_ASH: u32 = 4;
 pub const MAT_ICE: u32 = 5;
+pub const MAT_GUNPOWDER: u32 = 6;
 
 /// Phase constants.
 pub const PHASE_SOLID: u32 = 0;
@@ -35,7 +36,7 @@ pub const PHASE_LIQUID: u32 = 1;
 pub const PHASE_GAS: u32 = 2;
 
 /// Number of materials in the table.
-pub const MATERIAL_COUNT: usize = 6;
+pub const MATERIAL_COUNT: usize = 7;
 
 /// Build the default material parameter table.
 ///
@@ -175,6 +176,28 @@ pub fn default_material_table() -> [MaterialParams; MATERIAL_COUNT] {
             ),
             color: Vec4::new(0.7, 0.85, 0.95, 0.0), // light blue-white
         },
+        // Gunpowder (solid, crumbly, explosive)
+        MaterialParams {
+            elastic: Vec4::new(
+                0.0,   // youngs_modulus (crumbly granular)
+                0.0,   // poissons_ratio
+                500.0, // yield_stress (weak)
+                0.0,   // viscosity (solid — not used)
+            ),
+            thermal: Vec4::new(
+                f32::MAX, // melting_point (doesn't melt, explodes)
+                f32::MAX, // boiling_point
+                0.5,      // heat_conductivity
+                800.0,    // specific_heat
+            ),
+            visual: Vec4::new(
+                1800.0, // density (kg/m³)
+                200.0,  // emissive_temp (glows when igniting at 200°C)
+                1.0,    // opacity
+                0.0,    // pad
+            ),
+            color: Vec4::new(0.25, 0.2, 0.15, 0.0), // dark brown
+        },
     ]
 }
 
@@ -199,15 +222,15 @@ mod tests {
     fn material_table_uniform_buffer_size() {
         let table = default_material_table();
         let total_bytes = size_of::<MaterialParams>() * table.len();
-        // 6 materials × 64 bytes = 384 bytes (fits in uniform buffer)
-        assert_eq!(total_bytes, 384);
+        // 7 materials × 64 bytes = 448 bytes (fits in uniform buffer)
+        assert_eq!(total_bytes, 448);
     }
 
     #[test]
     fn material_table_bytemuck_cast() {
         let table = default_material_table();
         let bytes: &[u8] = bytemuck::cast_slice(&table);
-        assert_eq!(bytes.len(), 384);
+        assert_eq!(bytes.len(), 448);
     }
 
     #[test]
@@ -252,5 +275,13 @@ mod tests {
         assert_eq!(table[MAT_ICE as usize].elastic.z, 3000.0); // brittle
         assert_eq!(table[MAT_ICE as usize].visual.x, 917.0); // ice density
         assert!((table[MAT_ICE as usize].color.x - 0.7).abs() < 0.01); // light blue-white
+    }
+
+    #[test]
+    fn gunpowder_is_material_six() {
+        let table = default_material_table();
+        assert_eq!(table[MAT_GUNPOWDER as usize].elastic.z, 500.0); // crumbly
+        assert_eq!(table[MAT_GUNPOWDER as usize].visual.x, 1800.0); // density
+        assert!((table[MAT_GUNPOWDER as usize].color.x - 0.25).abs() < 0.01); // dark brown
     }
 }

--- a/crates/shared/src/phase.rs
+++ b/crates/shared/src/phase.rs
@@ -5,11 +5,12 @@
 //! - Water T > 100 -> Steam (gas)
 //! - Water T < 0 -> Ice (solid)
 //! - Lava T < 1500 -> Stone (solid)
+//! - Gunpowder T > 200 -> Gas (explosion)
 //!
 //! On transition: reset F = Identity, damage = 0, update phase.
 
 use crate::{
-    material::{MAT_ICE, MAT_LAVA, MAT_STONE, MAT_WATER, PHASE_GAS, PHASE_LIQUID, PHASE_SOLID},
+    material::{MAT_GUNPOWDER, MAT_ICE, MAT_LAVA, MAT_STONE, MAT_WATER, PHASE_GAS, PHASE_LIQUID, PHASE_SOLID},
     particle::Particle,
 };
 
@@ -37,6 +38,7 @@ pub enum PhaseTransition {
 /// - Water (material=1, phase=liquid) + T < 0 -> Ice (material=5, phase=solid)
 /// - Lava (material=2, phase=liquid) + T < 1500 -> Stone (material=0, phase=solid)
 /// - Ice (material=5, phase=solid) + T > 0 -> Water (material=1, phase=liquid)
+/// - Gunpowder (material=6, phase=solid) + T > 200 -> Gas (material=6, phase=gas) [explosion]
 pub fn check_phase_transition(particle: &Particle) -> PhaseTransition {
     let mat_id = particle.material_id();
     let phase = particle.phase();
@@ -67,6 +69,11 @@ pub fn check_phase_transition(particle: &Particle) -> PhaseTransition {
         (MAT_LAVA, PHASE_LIQUID) if temp < 1500.0 => PhaseTransition::Transition {
             new_material_id: MAT_STONE,
             new_phase: PHASE_SOLID,
+        },
+        // Gunpowder solid -> Gas when T > 200 (explosion)
+        (MAT_GUNPOWDER, PHASE_SOLID) if temp > 200.0 => PhaseTransition::Transition {
+            new_material_id: MAT_GUNPOWDER,
+            new_phase: PHASE_GAS,
         },
         _ => PhaseTransition::None,
     }
@@ -170,6 +177,27 @@ mod tests {
                 new_phase: PHASE_SOLID,
             }
         );
+    }
+
+    #[test]
+    fn gunpowder_explodes_to_gas() {
+        let mut p = Particle::new(Vec3::ZERO, 1.0, MAT_GUNPOWDER, PHASE_SOLID);
+        p.set_temperature(250.0);
+        let tr = check_phase_transition(&p);
+        assert_eq!(
+            tr,
+            PhaseTransition::Transition {
+                new_material_id: MAT_GUNPOWDER,
+                new_phase: PHASE_GAS,
+            }
+        );
+    }
+
+    #[test]
+    fn gunpowder_stays_solid_below_ignition() {
+        let mut p = Particle::new(Vec3::ZERO, 1.0, MAT_GUNPOWDER, PHASE_SOLID);
+        p.set_temperature(100.0);
+        assert_eq!(check_phase_transition(&p), PhaseTransition::None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `MAT_GUNPOWDER = 6` to shared and shader type constants, bump `MATERIAL_COUNT` to 7
- Define gunpowder MaterialParams: crumbly solid (yield=500), ignition at T>200C, dark brown color
- Phase transition: solid gunpowder -> gas at T>200 with temp boost to 3000 for explosive EOS pressure (GPU g2p.rs + CPU phase.rs)
- Render: dark brown granular procedural texture + bright white-orange emissive flash when burning
- App: palette slot 7 (key 7) for gunpowder spawning

## Test plan
- [x] `cargo test -p shared` -- all 47 tests pass (including new gunpowder_is_material_six, gunpowder_explodes_to_gas, gunpowder_stays_solid_below_ignition)
- [x] `cargo build -p app` -- full build succeeds
- [ ] Manual: spawn gunpowder (key 7), place near lava, verify explosion to gas

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)