### PR TITLE
fix(shaders): split material color functions to fix wood purple

### DIFF
--- a/crates/shaders/src/compute/render.rs
+++ b/crates/shaders/src/compute/render.rs
@@ -158,74 +158,110 @@ fn value_noise(x: f32, y: f32, z: f32) -> f32 {
     c0 + (c1 - c0) * fz
 }
 
+/// Stone color: dark veins through lighter base with per-voxel grain.
+fn color_stone(vx: i32, vy: i32, vz: i32) -> Vec3 {
+    let noise = value_noise(vx as f32 * 0.7, vy as f32 * 0.7, vz as f32 * 0.7);
+    let noise2 = value_noise(vx as f32 * 2.3, vy as f32 * 2.3, vz as f32 * 2.3);
+    let base = Vec3::new(0.5, 0.48, 0.45);
+    let vein = Vec3::new(0.35, 0.33, 0.30);
+    let t = noise * 0.7 + noise2 * 0.3;
+    let inv_t = 1.0 - t;
+    let inv_t = if inv_t < 0.0 { 0.0 } else { inv_t };
+    let color = Vec3::new(
+        base.x + (vein.x - base.x) * inv_t,
+        base.y + (vein.y - base.y) * inv_t,
+        base.z + (vein.z - base.z) * inv_t,
+    );
+    let h = hash3(vx, vy, vz);
+    let offset = (h - 0.5) * 0.06;
+    Vec3::new(color.x + offset, color.y + offset, color.z + offset)
+}
+
+/// Water color: depth-based blue variation.
+fn color_water(vx: i32, vy: i32, _vz: i32, grid_size: u32) -> Vec3 {
+    let gs = grid_size as f32;
+    let depth_factor = 1.0 - (vy as f32 / gs);
+    let depth_factor = if depth_factor < 0.0 { 0.0 } else { depth_factor };
+    let base = Vec3::new(0.1, 0.35, 0.85);
+    let deep = Vec3::new(0.05, 0.15, 0.5);
+    let t = depth_factor * 0.5;
+    Vec3::new(
+        base.x + (deep.x - base.x) * t,
+        base.y + (deep.y - base.y) * t,
+        base.z + (deep.z - base.z) * t,
+    )
+}
+
+/// Lava color: turbulent bright/dark patches.
+fn color_lava(vx: i32, vy: i32, vz: i32) -> Vec3 {
+    let noise = value_noise(vx as f32 * 1.5, vy as f32 * 1.5, vz as f32 * 1.5);
+    let bright = Vec3::new(1.0, 0.7, 0.1);
+    let dark = Vec3::new(0.8, 0.2, 0.0);
+    Vec3::new(
+        dark.x + (bright.x - dark.x) * noise,
+        dark.y + (bright.y - dark.y) * noise,
+        dark.z + (bright.z - dark.z) * noise,
+    )
+}
+
+/// Wood color: grain pattern with brown variation (base ~0.55, 0.35, 0.15).
+fn color_wood(vx: i32, vy: i32, vz: i32) -> Vec3 {
+    let noise = value_noise(vx as f32 * 0.5, vy as f32 * 2.0, vz as f32 * 0.5);
+    let noise2 = value_noise(vx as f32 * 3.0, vy as f32 * 0.3, vz as f32 * 3.0);
+    let light = Vec3::new(0.65, 0.42, 0.2);
+    let dark = Vec3::new(0.45, 0.28, 0.1);
+    let t = noise * 0.6 + noise2 * 0.4;
+    let color = Vec3::new(
+        dark.x + (light.x - dark.x) * t,
+        dark.y + (light.y - dark.y) * t,
+        dark.z + (light.z - dark.z) * t,
+    );
+    let h = hash3(vx, vy, vz);
+    let offset = (h - 0.5) * 0.04;
+    Vec3::new(color.x + offset, color.y + offset, color.z + offset)
+}
+
+/// Ash color: gray with subtle variation.
+fn color_ash(vx: i32, vy: i32, vz: i32) -> Vec3 {
+    let h = hash3(vx, vy, vz);
+    let base = 0.4 + (h - 0.5) * 0.08;
+    Vec3::new(base, base, base)
+}
+
+/// Ice color: light blue-white with crystalline shimmer.
+fn color_ice(vx: i32, vy: i32, vz: i32) -> Vec3 {
+    let noise = value_noise(vx as f32 * 1.2, vy as f32 * 1.2, vz as f32 * 1.2);
+    let h = hash3(vx, vy, vz);
+    let pale = Vec3::new(0.7, 0.85, 0.95);
+    let white = Vec3::new(0.85, 0.92, 0.98);
+    let t = noise * 0.6 + h * 0.4;
+    Vec3::new(
+        pale.x + (white.x - pale.x) * t,
+        pale.y + (white.y - pale.y) * t,
+        pale.z + (white.z - pale.z) * t,
+    )
+}
+
 /// Get procedurally textured color for a material at a given voxel position.
 ///
-/// Each material uses noise/hash functions seeded by voxel coordinates to produce
-/// visual variation instead of flat color. Returns (r, g, b) as floats in [0, 1].
+/// Each material is dispatched to a separate helper function to avoid
+/// rust-gpu dropping later branches in long if/else chains (see issue #125).
+/// Returns (r, g, b) as floats in [0, 1].
 fn textured_material_color(material_id: u32, vx: i32, vy: i32, vz: i32, grid_size: u32) -> Vec3 {
     if material_id == 0 {
-        // Stone: dark veins through lighter base with per-voxel grain
-        let noise = value_noise(vx as f32 * 0.7, vy as f32 * 0.7, vz as f32 * 0.7);
-        let noise2 = value_noise(vx as f32 * 2.3, vy as f32 * 2.3, vz as f32 * 2.3);
-        let base = Vec3::new(0.5, 0.48, 0.45);
-        let vein = Vec3::new(0.35, 0.33, 0.30);
-        let t = noise * 0.7 + noise2 * 0.3;
-        let inv_t = 1.0 - t;
-        let inv_t = if inv_t < 0.0 { 0.0 } else { inv_t };
-        let color = Vec3::new(
-            base.x + (vein.x - base.x) * inv_t,
-            base.y + (vein.y - base.y) * inv_t,
-            base.z + (vein.z - base.z) * inv_t,
-        );
-        // Subtle per-voxel variation
-        let h = hash3(vx, vy, vz);
-        let offset = (h - 0.5) * 0.06;
-        Vec3::new(color.x + offset, color.y + offset, color.z + offset)
+        color_stone(vx, vy, vz)
     } else if material_id == 1 {
-        // Water: depth-based blue variation
-        let gs = grid_size as f32;
-        let depth_factor = 1.0 - (vy as f32 / gs);
-        let depth_factor = if depth_factor < 0.0 { 0.0 } else { depth_factor };
-        let base = Vec3::new(0.1, 0.35, 0.85);
-        let deep = Vec3::new(0.05, 0.15, 0.5);
-        let t = depth_factor * 0.5;
-        Vec3::new(
-            base.x + (deep.x - base.x) * t,
-            base.y + (deep.y - base.y) * t,
-            base.z + (deep.z - base.z) * t,
-        )
+        color_water(vx, vy, vz, grid_size)
     } else if material_id == 2 {
-        // Lava: turbulent bright/dark patches
-        let noise = value_noise(vx as f32 * 1.5, vy as f32 * 1.5, vz as f32 * 1.5);
-        let bright = Vec3::new(1.0, 0.7, 0.1);
-        let dark = Vec3::new(0.8, 0.2, 0.0);
-        Vec3::new(
-            dark.x + (bright.x - dark.x) * noise,
-            dark.y + (bright.y - dark.y) * noise,
-            dark.z + (bright.z - dark.z) * noise,
-        )
+        color_lava(vx, vy, vz)
     } else if material_id == 3 {
-        // Wood: grain pattern with brown variation
-        let noise = value_noise(vx as f32 * 0.5, vy as f32 * 2.0, vz as f32 * 0.5);
-        let noise2 = value_noise(vx as f32 * 3.0, vy as f32 * 0.3, vz as f32 * 3.0);
-        let light = Vec3::new(0.6, 0.4, 0.2);
-        let dark = Vec3::new(0.4, 0.25, 0.1);
-        let t = noise * 0.6 + noise2 * 0.4;
-        let color = Vec3::new(
-            dark.x + (light.x - dark.x) * t,
-            dark.y + (light.y - dark.y) * t,
-            dark.z + (light.z - dark.z) * t,
-        );
-        let h = hash3(vx, vy, vz);
-        let offset = (h - 0.5) * 0.04;
-        Vec3::new(color.x + offset, color.y + offset, color.z + offset)
+        color_wood(vx, vy, vz)
     } else if material_id == 4 {
-        // Ash: gray with subtle variation
-        let h = hash3(vx, vy, vz);
-        let base = 0.4 + (h - 0.5) * 0.08;
-        Vec3::new(base, base, base)
+        color_ash(vx, vy, vz)
+    } else if material_id == 5 {
+        color_ice(vx, vy, vz)
     } else {
-        // Unknown: magenta
+        // Unknown: magenta debug color
         Vec3::new(1.0, 0.0, 1.0)
     }
 }


### PR DESCRIPTION
## Summary
- Split the monolithic `textured_material_color` if/else chain into 6 separate helper functions (`color_stone`, `color_water`, `color_lava`, `color_wood`, `color_ash`, `color_ice`)
- This prevents rust-gpu from dropping later branches during SPIR-V compilation, which was causing wood (material_id=3) and higher to fall through to the magenta default
- Restored the missing ice (material_id=5) case that had been lost
- Slightly adjusted wood brown tones (light: 0.65/0.42/0.2, dark: 0.45/0.28/0.1) for better appearance

Closes #125

## Test plan
- [x] `cargo run -p shader-builder` compiles SPIR-V without errors
- [x] `cargo build` succeeds for full workspace
- [ ] Visual check: wood renders brown, not purple/magenta
- [ ] Visual check: ash renders gray
- [ ] Visual check: ice renders light blue-white

🤖 Generated with [Claude Code](https://claude.com/claude-code)