### PR TITLE
feat(physics): falling solids via voxel support check

### DIFF
--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -324,7 +324,7 @@ impl GpuSimulation {
             ctx,
             shader_module,
             c"compute::g2p::g2p",
-            &[&particle_buffer, &grid_buffer],
+            &[&particle_buffer, &grid_buffer, &voxel_buffer],
             mem::size_of::<G2pPushConstants>() as u32,
             descriptor_pool,
             "g2p",

--- a/crates/shaders/src/compute/g2p.rs
+++ b/crates/shaders/src/compute/g2p.rs
@@ -29,6 +29,45 @@ pub struct G2pPushConstants {
 /// 0.7 PIC balances stability with fluid-like flow (less viscous damping).
 const PIC_RATIO: f32 = 0.7;
 
+/// Number of u32 values per voxel cell (must match voxelize.rs layout).
+const U32S_PER_VOXEL: u32 = 4;
+
+/// Check if a solid particle has support from a solid voxel below it.
+///
+/// Reads the voxel buffer (from the previous frame's voxelize pass) to see
+/// if the cell directly below this particle is occupied by a solid (phase==0).
+/// Particles at the grid floor (vy <= 1) are always considered supported.
+pub fn check_solid_support(pos: spirv_std::glam::Vec3, voxels: &[u32], grid_size: u32) -> bool {
+    let vx = pos.x as u32;
+    let vy = pos.y as u32;
+    let vz = pos.z as u32;
+
+    // At bottom of grid = supported by boundary
+    if vy <= 1 {
+        return true;
+    }
+
+    // Check cell below
+    let below_y = vy - 1;
+    if vx >= grid_size || below_y >= grid_size || vz >= grid_size {
+        return true; // out of bounds = treat as supported (safe default)
+    }
+
+    let below_idx = (vz * grid_size * grid_size + below_y * grid_size + vx) as usize;
+    let base = below_idx * U32S_PER_VOXEL as usize;
+
+    // Check occupied flag (offset +3) and that the occupant is solid (phase==0)
+    let occupied = voxels[base + 3] > 0;
+    if !occupied {
+        return false;
+    }
+
+    // Unpack phase from packed_material at offset +0: (weight<<24 | mat<<16 | phase<<8 | 0xFF)
+    let packed = voxels[base];
+    let phase_below = (packed >> 8) & 0xFF;
+    phase_below == 0 // supported only if the voxel below is also solid
+}
+
 /// Gather velocity from the grid and update one particle.
 ///
 /// Implements the G2P transfer step:
@@ -38,9 +77,13 @@ const PIC_RATIO: f32 = 0.7;
 /// 4. Update deformation gradient F
 /// 5. Advect position
 /// 6. Check phase transitions by temperature
+///
+/// For solid particles (phase==0), checks support from the voxel below.
+/// Supported solids update only F/C (pinned). Unsupported solids fall normally.
 pub fn gather_particle(
     particle: &mut Particle,
     grid: &[GridCell],
+    voxels: &[u32],
     grid_size: u32,
     dt: f32,
 ) {
@@ -177,17 +220,22 @@ pub fn gather_particle(
     new_pos.y = new_pos.y.clamp(margin, upper);
     new_pos.z = new_pos.z.clamp(margin, upper);
 
-    // Solids: update F and C for stress computation but skip position/velocity advection.
-    // This prevents stone floor particles from drifting toward grid cell boundaries (#45).
+    // Solids: check if the particle has support from a solid voxel below.
+    // Supported solids update F and C only (pinned, prevents floor drift #45).
+    // Unsupported solids fall through to full position/velocity update.
     if phase == 0 {
-        particle.f_col0 = new_f0.extend(0.0);
-        particle.f_col1 = new_f1.extend(0.0);
-        particle.f_col2 = new_f2.extend(0.0);
-        particle.c_col0 = c_col0.extend(0.0);
-        particle.c_col1 = c_col1.extend(0.0);
-        particle.c_col2 = c_col2.extend(0.0);
-        apply_phase_transitions(particle);
-        return;
+        let supported = check_solid_support(pos, voxels, grid_size);
+        if supported {
+            particle.f_col0 = new_f0.extend(0.0);
+            particle.f_col1 = new_f1.extend(0.0);
+            particle.f_col2 = new_f2.extend(0.0);
+            particle.c_col0 = c_col0.extend(0.0);
+            particle.c_col1 = c_col1.extend(0.0);
+            particle.c_col2 = c_col2.extend(0.0);
+            apply_phase_transitions(particle);
+            return;
+        }
+        // Unsupported: fall through to position/velocity update below
     }
 
     // Write back to particle (liquids and gases only)
@@ -269,6 +317,7 @@ pub fn apply_phase_transitions(particle: &mut Particle) {
 ///
 /// Descriptor set 0, binding 0: storage buffer of `Particle` (read-write).
 /// Descriptor set 0, binding 1: storage buffer of `GridCell` (read).
+/// Descriptor set 0, binding 2: storage buffer of `u32` (voxel grid, 4 per cell, read).
 /// Push constants: `G2pPushConstants`.
 /// Dispatch with `(ceil(num_particles / 64), 1, 1)` workgroups.
 #[spirv(compute(threads(64)))]
@@ -277,10 +326,11 @@ pub fn g2p(
     #[spirv(push_constant)] push: &G2pPushConstants,
     #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] particles: &mut [Particle],
     #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] grid: &[GridCell],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] voxels: &[u32],
 ) {
     let idx = id.x as usize;
     if id.x >= push.num_particles {
         return;
     }
-    gather_particle(&mut particles[idx], grid, push.grid_size, push.dt);
+    gather_particle(&mut particles[idx], grid, voxels, push.grid_size, push.dt);
 }

--- a/crates/sim-cpu/src/grid.rs
+++ b/crates/sim-cpu/src/grid.rs
@@ -235,6 +235,60 @@ pub fn grid_update(grid: &mut [GridCell], dt: f32) {
     }
 }
 
+/// Build a boolean occupancy grid of solid particles for support checks.
+///
+/// Returns a `Vec<bool>` of size `GRID_SIZE^3` where each entry is `true`
+/// if a solid (phase==0) particle maps to that cell.
+///
+/// # Arguments
+/// - `particles`: slice of all particles
+pub fn build_solid_occupancy(particles: &[Particle]) -> Vec<bool> {
+    let gs = GRID_SIZE as usize;
+    let mut occupancy = vec![false; gs * gs * gs];
+    for p in particles {
+        if p.phase() != 0 {
+            continue;
+        }
+        let pos = p.position();
+        let gp = pos * GRID_SIZE as f32;
+        let ix = gp.x as i32;
+        let iy = gp.y as i32;
+        let iz = gp.z as i32;
+        if let Some(idx) = grid_index(ix, iy, iz) {
+            occupancy[idx] = true;
+        }
+    }
+    occupancy
+}
+
+/// Check if a solid particle has support from a solid voxel below it.
+///
+/// A particle is considered supported if:
+/// - It is at the grid floor (iy <= 1), or
+/// - The cell directly below it in the occupancy grid is occupied by a solid.
+///
+/// # Arguments
+/// - `pos`: particle position in world space [0, 1]
+/// - `solid_occupancy`: boolean grid from [`build_solid_occupancy`]
+pub fn check_solid_support(pos: Vec3, solid_occupancy: &[bool]) -> bool {
+    let gs = GRID_SIZE as f32;
+    let gp = pos * gs;
+    let ix = gp.x as i32;
+    let iy = gp.y as i32;
+    let iz = gp.z as i32;
+
+    // At bottom of grid = supported by boundary
+    if iy <= 1 {
+        return true;
+    }
+
+    // Check cell below
+    match grid_index(ix, iy - 1, iz) {
+        Some(idx) => solid_occupancy[idx],
+        None => true, // out of bounds = treat as supported
+    }
+}
+
 /// Grid-to-Particle transfer (G2P).
 ///
 /// Gathers velocity from 27 neighbor grid cells to update each particle:
@@ -243,11 +297,15 @@ pub fn grid_update(grid: &mut [GridCell], dt: f32) {
 /// 3. Update deformation gradient: `F_new = (I + dt*C) * F`
 /// 4. Advect position: `pos += vel * dt`
 ///
+/// For solid particles (phase==0), checks support from the cell below.
+/// Supported solids update only F/C (pinned). Unsupported solids fall normally.
+///
 /// # Arguments
 /// - `particles`: mutable slice of particles
 /// - `grid`: grid buffer with updated velocities
+/// - `solid_occupancy`: boolean grid from [`build_solid_occupancy`] (pass empty slice to skip support check)
 /// - `dt`: timestep
-pub fn g2p(particles: &mut [Particle], grid: &[GridCell], dt: f32) {
+pub fn g2p(particles: &mut [Particle], grid: &[GridCell], solid_occupancy: &[bool], dt: f32) {
     let gs = GRID_SIZE as f32;
     let pic_blend = 0.7_f32; // PIC/FLIP blend factor
 
@@ -339,15 +397,30 @@ pub fn g2p(particles: &mut [Particle], grid: &[GridCell], dt: f32) {
             final_vel.z *= 0.98;
         }
 
+        // Update deformation gradient: F_new = (I + dt * C) * F
+        let f_old = particle.deformation_gradient();
+        let f_new = (Mat3::IDENTITY + dt * new_c) * f_old;
+
+        // Solids: check if the particle has support from a solid voxel below.
+        // Supported solids update F and C only (pinned, prevents floor drift).
+        // Unsupported solids fall through to full position/velocity update.
+        if particle.phase() == 0 && !solid_occupancy.is_empty() {
+            let supported = check_solid_support(pos, solid_occupancy);
+            if supported {
+                particle.set_affine_momentum(new_c);
+                particle.set_deformation_gradient(f_new);
+                continue;
+            }
+            // Unsupported: fall through to position/velocity update
+        }
+
         // Update velocity
         particle.set_velocity(final_vel);
 
         // Update APIC C matrix
         particle.set_affine_momentum(new_c);
 
-        // Update deformation gradient: F_new = (I + dt * C) * F
-        let f_old = particle.deformation_gradient();
-        let f_new = (Mat3::IDENTITY + dt * new_c) * f_old;
+        // Update deformation gradient
         particle.set_deformation_gradient(f_new);
 
         // Advect position
@@ -491,7 +564,8 @@ mod tests {
             let mut grid = make_grid();
             p2g(&particles, &mut grid, &table, dt);
             grid_update(&mut grid, dt);
-            g2p(&mut particles, &grid, dt);
+            let occupancy = build_solid_occupancy(&particles);
+            g2p(&mut particles, &grid, &occupancy, dt);
         }
 
         let final_y = particles[0].position().y;
@@ -515,7 +589,8 @@ mod tests {
             let mut grid = make_grid();
             p2g(&particles, &mut grid, &table, dt);
             grid_update(&mut grid, dt);
-            g2p(&mut particles, &grid, dt);
+            let occupancy = build_solid_occupancy(&particles);
+            g2p(&mut particles, &grid, &occupancy, dt);
         }
 
         for (i, p) in particles.iter().enumerate() {

--- a/crates/sim-cpu/src/world.rs
+++ b/crates/sim-cpu/src/world.rs
@@ -11,7 +11,7 @@ use shared::{
 };
 use thiserror::Error;
 
-use crate::grid::{clear_grid, g2p, grid_update, p2g};
+use crate::grid::{build_solid_occupancy, clear_grid, g2p, grid_update, p2g};
 
 /// Errors that can occur during simulation.
 #[derive(Debug, Error)]
@@ -122,8 +122,9 @@ impl Simulation {
         // 3. Grid update: momentum → velocity, gravity, boundaries
         grid_update(&mut self.grid, dt);
 
-        // 4. Grid-to-Particle transfer
-        g2p(&mut self.particles, &self.grid, dt);
+        // 4. Grid-to-Particle transfer (with solid support check)
+        let solid_occupancy = build_solid_occupancy(&self.particles);
+        g2p(&mut self.particles, &self.grid, &solid_occupancy, dt);
 
         self.time += dt;
         self.step_count += 1;


### PR DESCRIPTION
## Summary
- Solid particles (phase==0) now check for support below before being pinned in G2P
- Unsupported solids (no solid voxel below) fall under gravity like liquids/gases
- Fixes explosion debris freezing mid-air when cooled to stone, and broken structures never collapsing

## Changes
- **shaders/g2p.rs**: Added `check_solid_support()` that reads the voxel buffer (previous frame) to detect if a solid voxel exists below the particle. Added voxel buffer as binding 2 on the G2P entry point.
- **server/lib.rs**: Bound `voxel_buffer` as third descriptor for the G2P compute pass.
- **sim-cpu/grid.rs**: Added `build_solid_occupancy()` and `check_solid_support()` for CPU reference implementation. Updated `g2p()` signature to accept occupancy grid.
- **sim-cpu/world.rs**: Builds solid occupancy grid before calling G2P.

## Test plan
- [x] `cargo build -p app` (includes SPIR-V shader compilation) -- passes
- [x] `cargo test -p shared` -- 44 passed
- [x] `cargo test -p client` -- 34 passed
- [x] `cargo test -p sim-cpu` -- 24 passed (3 pre-existing failures unrelated to this change)

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)