### PR TITLE
fix(physics): equalize liquid falling speed

### DIFF
--- a/crates/shaders/src/compute/g2p.rs
+++ b/crates/shaders/src/compute/g2p.rs
@@ -116,19 +116,8 @@ pub fn gather_particle(
     // old velocity to reduce excessive damping while maintaining stability.
     let mut new_vel = PIC_RATIO * pic_vel + (1.0 - PIC_RATIO) * old_vel;
 
-    // Material-specific viscous velocity damping for liquids.
-    // High-viscosity materials (lava) get additional per-step damping
-    // to make them visibly sluggish compared to water.
+    // Phase extraction for gas buoyancy below
     let phase = particle.ids.y;
-    let material_id = particle.ids.x;
-    if phase == 1 {
-        let damping = match material_id {
-            1 => 1.0_f32,    // Water: no extra damping (runny)
-            2 => 0.999_f32,  // Lava: very light damping (viscosity handled in P2G stress)
-            _ => 0.995_f32,  // Default liquid: minimal damping
-        };
-        new_vel *= damping;
-    }
 
     // Gas buoyancy: counteract most of gravity and add slight upward force
     // so steam rises and persists visually instead of falling immediately.

--- a/crates/shaders/src/compute/p2g.rs
+++ b/crates/shaders/src/compute/p2g.rs
@@ -61,8 +61,8 @@ pub fn compute_stress(particle: &Particle) -> [Vec3; 3] {
         } else {
             // Liquid: material-specific
             match material_id {
-                1 => (15.0_f32, 0.001_f32),  // Water: low bulk, very low viscosity (runny)
-                2 => (25.0_f32, 5.0_f32),    // Lava: higher bulk, HIGH viscosity (sluggish)
+                1 => (20.0_f32, 0.001_f32),  // Water: low viscosity (runny)
+                2 => (20.0_f32, 8.0_f32),    // Lava: HIGH viscosity (thick spread), SAME bulk
                 _ => (20.0_f32, 0.1_f32),    // Default liquid
             }
         };

--- a/crates/sim-cpu/src/grid.rs
+++ b/crates/sim-cpu/src/grid.rs
@@ -318,18 +318,7 @@ pub fn g2p(particles: &mut [Particle], grid: &[GridCell], dt: f32) {
         // to reduce excessive damping while maintaining stability.
         let blended_vel = pic_blend * new_vel + (1.0 - pic_blend) * old_vel;
 
-        // Material-specific viscous velocity damping for liquids.
-        // High-viscosity materials (lava) get additional per-step damping
-        // to make them visibly sluggish compared to water.
         let mut final_vel = blended_vel;
-        if particle.phase() == 1 {
-            let damping = match particle.material_id() {
-                1 => 1.0_f32,    // Water: no extra damping (runny)
-                2 => 0.98_f32,   // Lava: 2% damping per step (sluggish)
-                _ => 0.995_f32,  // Default liquid: minimal damping
-            };
-            final_vel *= damping;
-        }
 
         // Gas buoyancy: counteract most of gravity and add slight upward force
         // so steam rises and persists visually instead of falling immediately.


### PR DESCRIPTION
## Summary
- Remove per-material velocity damping in G2P shader (`g2p.rs`) and CPU sim (`grid.rs`) that caused lava to fall slower than water
- Equalize bulk modulus to 20.0 for all liquids in P2G stress (`p2g.rs`) — different viscosity values still control spreading behavior
- Same bulk = same falling speed; different viscosity = different flow characteristics

Closes #145

## Test plan
- [x] `cargo build -p app` compiles successfully
- [x] `cargo test -p sim-cpu -- grid::tests` passes (7/7 physics tests, 1 pre-existing `grid_index_bounds` failure unrelated)
- [ ] Visual verification: water and lava cubes dropped from same height reach floor at same time
- [ ] Lava still spreads slower than water due to higher viscosity

🤖 Generated with [Claude Code](https://claude.com/claude-code)