### PR TITLE
fix(gunpowder): faster ignition from nearby lava at 256³ grid

### DIFF
--- a/crates/shaders/src/compute/g2p.rs
+++ b/crates/shaders/src/compute/g2p.rs
@@ -291,7 +291,7 @@ pub fn apply_phase_transitions(particle: &mut Particle) {
         }
         // Gunpowder
         6 => {
-            if phase == 0 && temp > 200.0 {
+            if phase == 0 && temp > 150.0 {
                 new_phase = 2; // solid -> gas (explosion)
                 // Boost temp for massive EOS pressure
                 particle.vel_temp = Vec4::new(

--- a/crates/shared/src/material.rs
+++ b/crates/shared/src/material.rs
@@ -187,12 +187,12 @@ pub fn default_material_table() -> [MaterialParams; MATERIAL_COUNT] {
             thermal: Vec4::new(
                 f32::MAX, // melting_point (doesn't melt, explodes)
                 f32::MAX, // boiling_point
-                0.5,      // heat_conductivity
+                5.0,      // heat_conductivity (10x: fast absorption from nearby lava)
                 800.0,    // specific_heat
             ),
             visual: Vec4::new(
                 1800.0, // density (kg/m³)
-                200.0,  // emissive_temp (glows when igniting at 200°C)
+                150.0,  // emissive_temp (glows when igniting at 150°C)
                 1.0,    // opacity
                 0.0,    // pad
             ),


### PR DESCRIPTION
## Summary
- Increased gunpowder `heat_conductivity` from 0.5 to 5.0 (10x) so thermal diffusion from nearby lava reaches ignition temp on larger grids
- Lowered ignition threshold in G2P shader from 200°C to 150°C for easier ignition
- Aligned `emissive_temp` visual param (200 -> 150) so glow matches the new ignition point

Closes #148

## Test plan
- [ ] Place gunpowder adjacent to lava at 256³ grid — should ignite within ~1s
- [ ] Verify `cargo build -p app` passes (confirmed)
- [ ] Visual check: gunpowder glows before exploding at the correct temp

🤖 Generated with [Claude Code](https://claude.com/claude-code)