### PR TITLE
feat: add WorldConfig for runtime world parameters

### DIFF
--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -20,6 +20,7 @@ use gpu_core::{
 };
 use shared::{
     GRID_CELL_COUNT, GRID_SIZE, GridCell, MAX_PARTICLES, Particle, RENDER_HEIGHT, RENDER_WIDTH,
+    WorldConfig,
 };
 
 /// Compiled SPIR-V shader module bytes, included at compile time.
@@ -198,6 +199,10 @@ pub struct GpuSimulation {
     grid_buffer: GpuBuffer,
     voxel_buffer: GpuBuffer,
     render_output_buffer: GpuBuffer,
+    world_config_buffer: GpuBuffer,
+
+    // Cached world configuration
+    world_config: WorldConfig,
 
     // Compute passes
     clear_grid_pass: ComputePass,
@@ -278,6 +283,22 @@ impl GpuSimulation {
             vk::BufferUsageFlags::STORAGE_BUFFER | vk::BufferUsageFlags::TRANSFER_SRC,
             "render-output-buffer",
         )?;
+
+        // -- World config uniform buffer --
+        let world_config = WorldConfig::default();
+        let world_config_buf_size = mem::size_of::<WorldConfig>() as vk::DeviceSize;
+        let world_config_buffer = buffer::create_device_local_buffer(
+            ctx,
+            world_config_buf_size,
+            vk::BufferUsageFlags::UNIFORM_BUFFER,
+            "world-config-buffer",
+        )?;
+        buffer::upload(
+            ctx,
+            core::slice::from_ref(&world_config),
+            &world_config_buffer,
+        )?;
+        tracing::info!("Uploaded default WorldConfig to GPU");
 
         // -- Descriptor pool --
         // 10 passes, max 2 bindings each = up to 20 storage buffer descriptors
@@ -410,6 +431,8 @@ impl GpuSimulation {
             shader_module,
             descriptor_pool,
             num_particles: 0,
+            world_config_buffer,
+            world_config,
             device: ctx.device.clone(),
         })
     }
@@ -598,6 +621,27 @@ impl GpuSimulation {
     /// Returns the current number of active particles.
     pub fn num_particles(&self) -> u32 {
         self.num_particles
+    }
+
+    /// Returns the current [`WorldConfig`].
+    pub fn world_config(&self) -> &WorldConfig {
+        &self.world_config
+    }
+
+    /// Update the world configuration on the GPU.
+    ///
+    /// Uploads the new config to the uniform buffer via a staging buffer.
+    /// This is a synchronous operation that stalls the GPU pipeline.
+    pub fn update_world_config(&mut self, ctx: &VulkanContext, config: &WorldConfig) -> Result<()> {
+        self.world_config = *config;
+        buffer::upload(ctx, core::slice::from_ref(config), &self.world_config_buffer)?;
+        tracing::info!("Updated WorldConfig on GPU");
+        Ok(())
+    }
+
+    /// Returns a reference to the world config [`GpuBuffer`].
+    pub fn world_config_buffer(&self) -> &GpuBuffer {
+        &self.world_config_buffer
     }
 
     /// Returns a reference to the particle buffer.
@@ -933,10 +977,19 @@ impl GpuSimulation {
                 size: 0,
             },
         );
+        let world_config_buf = std::mem::replace(
+            &mut self.world_config_buffer,
+            GpuBuffer {
+                buffer: vk::Buffer::null(),
+                allocation: None,
+                size: 0,
+            },
+        );
         buffer::destroy_buffer(ctx, particle_buf);
         buffer::destroy_buffer(ctx, grid_buf);
         buffer::destroy_buffer(ctx, voxel_buf);
         buffer::destroy_buffer(ctx, render_output_buf);
+        buffer::destroy_buffer(ctx, world_config_buf);
     }
 }
 

--- a/crates/shared/src/config.rs
+++ b/crates/shared/src/config.rs
@@ -1,0 +1,132 @@
+//! World configuration parameters.
+//!
+//! [`WorldConfig`] is a GPU-uploadable uniform buffer containing all
+//! physics constants that can vary per-world (gravity, wind, timestep, etc.).
+
+use bytemuck::{Pod, Zeroable};
+use glam::Vec4;
+
+/// World configuration parameters. Uploaded to GPU as uniform buffer.
+///
+/// All physics constants that could vary per-world go here.
+/// Uses [`Vec4`] everywhere to satisfy GPU alignment requirements (trap #1).
+///
+/// # Layout
+/// - `gravity`: Gravity vector (xyz) + padding (w). Default: `(0, -196, 0, 0)`.
+/// - `wind`: Wind force vector (xyz) + padding (w). Default: `(0, 0, 0, 0)`.
+/// - `params`: Packed parameters:
+///   - `x` = ambient temperature (Celsius). Default: `20.0`.
+///   - `y` = air density (kg/m^3). Default: `1.225`.
+///   - `z` = simulation timestep (seconds). Default: `0.001`.
+///   - `w` = grid size as f32. Default: `256.0`.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Pod, Zeroable)]
+pub struct WorldConfig {
+    /// Gravity vector (xyz) + padding (w). Default: `(0, -196, 0, 0)` for 5cm voxels.
+    pub gravity: Vec4,
+    /// Wind force vector (xyz) + padding (w). Default: `(0, 0, 0, 0)`.
+    pub wind: Vec4,
+    /// Packed parameters: x=ambient_temperature, y=air_density, z=dt, w=grid_size as f32.
+    pub params: Vec4,
+}
+
+impl Default for WorldConfig {
+    fn default() -> Self {
+        Self {
+            gravity: Vec4::new(0.0, -196.0, 0.0, 0.0),
+            wind: Vec4::ZERO,
+            params: Vec4::new(20.0, 1.225, 0.001, 256.0),
+        }
+    }
+}
+
+impl WorldConfig {
+    /// Returns the gravity vector as (x, y, z).
+    pub fn gravity_xyz(&self) -> (f32, f32, f32) {
+        (self.gravity.x, self.gravity.y, self.gravity.z)
+    }
+
+    /// Returns the wind vector as (x, y, z).
+    pub fn wind_xyz(&self) -> (f32, f32, f32) {
+        (self.wind.x, self.wind.y, self.wind.z)
+    }
+
+    /// Returns the ambient temperature in Celsius.
+    pub fn ambient_temperature(&self) -> f32 {
+        self.params.x
+    }
+
+    /// Returns the air density in kg/m^3.
+    pub fn air_density(&self) -> f32 {
+        self.params.y
+    }
+
+    /// Returns the simulation timestep in seconds.
+    pub fn dt(&self) -> f32 {
+        self.params.z
+    }
+
+    /// Returns the grid size (cells per axis) as f32.
+    pub fn grid_size(&self) -> f32 {
+        self.params.w
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem;
+
+    #[test]
+    fn world_config_size_and_alignment() {
+        // 3 Vec4s = 3 * 16 = 48 bytes
+        assert_eq!(mem::size_of::<WorldConfig>(), 48);
+        assert_eq!(mem::align_of::<WorldConfig>(), 16);
+    }
+
+    #[test]
+    fn world_config_default_values() {
+        let cfg = WorldConfig::default();
+
+        // Gravity: -196 on Y axis
+        assert_eq!(cfg.gravity.x, 0.0);
+        assert_eq!(cfg.gravity.y, -196.0);
+        assert_eq!(cfg.gravity.z, 0.0);
+        assert_eq!(cfg.gravity.w, 0.0);
+
+        // Wind: zero
+        assert_eq!(cfg.wind, Vec4::ZERO);
+
+        // Params
+        assert_eq!(cfg.ambient_temperature(), 20.0);
+        assert!((cfg.air_density() - 1.225).abs() < 1e-6);
+        assert_eq!(cfg.dt(), 0.001);
+        assert_eq!(cfg.grid_size(), 256.0);
+    }
+
+    #[test]
+    fn world_config_accessors() {
+        let cfg = WorldConfig {
+            gravity: Vec4::new(1.0, -9.81, 0.5, 0.0),
+            wind: Vec4::new(5.0, 0.0, -2.0, 0.0),
+            params: Vec4::new(25.0, 1.0, 0.002, 128.0),
+        };
+
+        assert_eq!(cfg.gravity_xyz(), (1.0, -9.81, 0.5));
+        assert_eq!(cfg.wind_xyz(), (5.0, 0.0, -2.0));
+        assert_eq!(cfg.ambient_temperature(), 25.0);
+        assert_eq!(cfg.air_density(), 1.0);
+        assert_eq!(cfg.dt(), 0.002);
+        assert_eq!(cfg.grid_size(), 128.0);
+    }
+
+    #[test]
+    fn world_config_is_pod() {
+        // This compiles only if WorldConfig: Pod + Zeroable
+        let zeroed: WorldConfig = bytemuck::Zeroable::zeroed();
+        assert_eq!(zeroed.gravity, Vec4::ZERO);
+        let cfg = WorldConfig::default();
+        let bytes: &[u8] = bytemuck::bytes_of(&cfg);
+        assert_eq!(bytes.len(), 48);
+    }
+}

--- a/crates/shared/src/constants.rs
+++ b/crates/shared/src/constants.rs
@@ -7,10 +7,16 @@ pub const GRID_SIZE: u32 = 256;
 pub const GRID_CELL_COUNT: u32 = GRID_SIZE * GRID_SIZE * GRID_SIZE;
 
 /// Fixed simulation timestep (seconds).
+///
+/// This is the default value. At runtime, prefer [`WorldConfig::dt()`](crate::WorldConfig::dt)
+/// for per-world configuration.
 pub const DT: f32 = 0.001;
 
 /// Gravity acceleration (grid-units/s², negative Y).
 /// Scaled 20x from 9.81 for 256³ grid with 5cm voxels.
+///
+/// This is the default value. At runtime, prefer [`WorldConfig::gravity`](crate::WorldConfig)
+/// for per-world configuration.
 pub const GRAVITY: f32 = -196.0;
 
 /// Brick size for BLAS acceleration structure (voxels per axis).

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -8,6 +8,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+pub mod config;
 pub mod constants;
 pub mod material;
 pub mod particle;
@@ -16,6 +17,7 @@ pub mod physics;
 pub mod reaction;
 pub mod svd;
 
+pub use config::*;
 pub use constants::*;
 pub use material::*;
 pub use particle::*;


### PR DESCRIPTION
## Summary
- Add `WorldConfig` struct to `shared` crate: `#[repr(C)]` + `Pod` + `Zeroable`, 48 bytes (3x Vec4), contains gravity, wind, ambient_temperature, air_density, dt, grid_size
- Export from `shared::config` with accessor methods and `Default` impl
- Create GPU uniform buffer in `GpuSimulation::new()` with default config upload
- Add `update_world_config()`, `world_config()`, and `world_config_buffer()` methods to server
- Add doc comments to `DT` and `GRAVITY` constants noting WorldConfig as runtime alternative
- 4 unit tests for size/alignment, defaults, accessors, and Pod trait

Closes #152

## Test plan
- [x] `cargo test -p shared -- config` — 4 tests pass (size, defaults, accessors, Pod)
- [x] `cargo test -p server -- --test-threads=1` — all 6 tests pass (including GPU integration)
- [x] `cargo build -p server` — clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)