### PR TITLE
feat(shaders): read MaterialParams from GPU buffer

### DIFF
--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -20,6 +20,7 @@ use gpu_core::{
 };
 use shared::{
     GRID_CELL_COUNT, GRID_SIZE, GridCell, MAX_PARTICLES, Particle, RENDER_HEIGHT, RENDER_WIDTH,
+    material::{self, MATERIAL_COUNT, MaterialParams},
 };
 
 /// Compiled SPIR-V shader module bytes, included at compile time.
@@ -198,6 +199,7 @@ pub struct GpuSimulation {
     grid_buffer: GpuBuffer,
     voxel_buffer: GpuBuffer,
     render_output_buffer: GpuBuffer,
+    material_buffer: GpuBuffer,
 
     // Compute passes
     clear_grid_pass: ComputePass,
@@ -279,11 +281,30 @@ impl GpuSimulation {
             "render-output-buffer",
         )?;
 
+        // Material params buffer: MATERIAL_COUNT * 64 bytes
+        let material_buf_size =
+            (MATERIAL_COUNT * mem::size_of::<MaterialParams>()) as vk::DeviceSize;
+        let material_buffer = buffer::create_device_local_buffer(
+            ctx,
+            material_buf_size,
+            vk::BufferUsageFlags::STORAGE_BUFFER,
+            "material-buffer",
+        )?;
+
+        // Upload default material table
+        let material_table = material::default_material_table();
+        buffer::upload(ctx, &material_table, &material_buffer)?;
+        tracing::info!(
+            "Uploaded {} materials ({} bytes) to GPU",
+            MATERIAL_COUNT,
+            material_buf_size
+        );
+
         // -- Descriptor pool --
-        // 10 passes, max 2 bindings each = up to 20 storage buffer descriptors
+        // 10 passes, max 3 bindings each = up to 30 storage buffer descriptors
         let pool_sizes = [vk::DescriptorPoolSize {
             ty: vk::DescriptorType::STORAGE_BUFFER,
-            descriptor_count: 20,
+            descriptor_count: 30,
         }];
         let descriptor_pool =
             pipeline::create_descriptor_pool(ctx, &pool_sizes, 10, "sim-descriptor-pool")?;
@@ -304,7 +325,7 @@ impl GpuSimulation {
             ctx,
             shader_module,
             c"compute::p2g::p2g",
-            &[&particle_buffer, &grid_buffer],
+            &[&particle_buffer, &grid_buffer, &material_buffer],
             mem::size_of::<P2gPushConstants>() as u32,
             descriptor_pool,
             "p2g",
@@ -354,7 +375,7 @@ impl GpuSimulation {
             ctx,
             shader_module,
             c"compute::render::render_voxels",
-            &[&voxel_buffer, &render_output_buffer],
+            &[&voxel_buffer, &render_output_buffer, &material_buffer],
             mem::size_of::<RenderPushConstants>() as u32,
             descriptor_pool,
             "render",
@@ -397,6 +418,7 @@ impl GpuSimulation {
             grid_buffer,
             voxel_buffer,
             render_output_buffer,
+            material_buffer,
             clear_grid_pass,
             p2g_pass,
             grid_update_pass,
@@ -933,10 +955,19 @@ impl GpuSimulation {
                 size: 0,
             },
         );
+        let material_buf = std::mem::replace(
+            &mut self.material_buffer,
+            GpuBuffer {
+                buffer: vk::Buffer::null(),
+                allocation: None,
+                size: 0,
+            },
+        );
         buffer::destroy_buffer(ctx, particle_buf);
         buffer::destroy_buffer(ctx, grid_buf);
         buffer::destroy_buffer(ctx, voxel_buf);
         buffer::destroy_buffer(ctx, render_output_buf);
+        buffer::destroy_buffer(ctx, material_buf);
     }
 }
 

--- a/crates/shaders/src/compute/p2g.rs
+++ b/crates/shaders/src/compute/p2g.rs
@@ -8,7 +8,7 @@
 //! float atomics. Each `GridCell` occupies 8 consecutive f32 values:
 //! `[vel_x, vel_y, vel_z, mass, force_x, force_y, force_z, pad]`.
 
-use crate::types::Particle;
+use crate::types::{MaterialParams, Particle};
 use spirv_std::glam::{UVec3, Vec3};
 use spirv_std::spirv;
 
@@ -39,8 +39,10 @@ pub struct P2gPushConstants {
 /// For liquid (phase=1): equation of state pressure.
 /// For gas (phase=2): weak EOS pressure.
 ///
+/// Reads viscosity from the MaterialParams buffer instead of hardcoded values.
+///
 /// Returns the Cauchy stress tensor columns packed into Vec3s.
-pub fn compute_stress(particle: &Particle) -> [Vec3; 3] {
+pub fn compute_stress(particle: &Particle, materials: &[MaterialParams]) -> [Vec3; 3] {
     let phase = particle.ids.y;
     let f_col0 = particle.f_col0.truncate();
     let f_col1 = particle.f_col1.truncate();
@@ -51,20 +53,22 @@ pub fn compute_stress(particle: &Particle) -> [Vec3; 3] {
 
     if phase == 1 || phase == 2 {
         // Liquid / Gas: EOS pressure + viscous stress.
-        // Material-specific bulk modulus and viscosity.
-        // We can't access MaterialParams buffer here (only particle + grid bindings),
-        // so use hardcoded per-material values matching shared::material defaults.
+        // Read viscosity from material buffer.
         let material_id = particle.ids.x;
+        let mat_count = materials.len() as u32;
+        let safe_id = if material_id < mat_count {
+            material_id
+        } else {
+            0
+        };
+        let mat = &materials[safe_id as usize];
+
         let (bulk, viscosity) = if phase == 2 {
             // Gas: weak pressure, very low viscosity
             (2.0_f32, 0.001_f32)
         } else {
-            // Liquid: material-specific
-            match material_id {
-                1 => (20.0_f32, 0.001_f32),  // Water: low viscosity (runny)
-                2 => (20.0_f32, 8.0_f32),    // Lava: HIGH viscosity (thick spread), SAME bulk
-                _ => (20.0_f32, 0.1_f32),    // Default liquid
-            }
+            // Liquid: read viscosity from material elastic.w
+            (20.0_f32, mat.elastic.w)
         };
 
         let pressure = bulk * (j - 1.0);
@@ -172,6 +176,7 @@ pub fn scatter_particle(
     grid: &mut [f32],
     grid_size: u32,
     dt: f32,
+    materials: &[MaterialParams],
 ) {
     let pos = particle.pos_mass.truncate();
     let vel = particle.vel_temp.truncate();
@@ -196,8 +201,8 @@ pub fn scatter_particle(
     let c_col1 = particle.c_col1.truncate();
     let c_col2 = particle.c_col2.truncate();
 
-    // Compute stress contribution
-    let stress = compute_stress(particle);
+    // Compute stress contribution (reads viscosity from material buffer)
+    let stress = compute_stress(particle, materials);
 
     // Scatter to 3x3x3 neighborhood
     let mut di = 0u32;
@@ -275,6 +280,7 @@ pub fn scatter_particle(
 /// Descriptor set 0, binding 0: storage buffer of `Particle` (read).
 /// Descriptor set 0, binding 1: storage buffer of `f32` (grid, read-write with atomics).
 ///   Layout: 8 floats per cell `[vel_x, vel_y, vel_z, mass, force_x, force_y, force_z, pad]`.
+/// Descriptor set 0, binding 2: storage buffer of `MaterialParams` (material table, read).
 /// Push constants: `P2gPushConstants`.
 /// Dispatch with `(ceil(num_particles / 64), 1, 1)` workgroups.
 #[spirv(compute(threads(64)))]
@@ -283,10 +289,11 @@ pub fn p2g(
     #[spirv(push_constant)] push: &P2gPushConstants,
     #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] particles: &[Particle],
     #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] grid: &mut [f32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] materials: &[MaterialParams],
 ) {
     let idx = id.x as usize;
     if id.x >= push.num_particles {
         return;
     }
-    scatter_particle(&particles[idx], grid, push.grid_size, push.dt);
+    scatter_particle(&particles[idx], grid, push.grid_size, push.dt, materials);
 }

--- a/crates/shaders/src/compute/render.rs
+++ b/crates/shaders/src/compute/render.rs
@@ -3,6 +3,7 @@
 //! Dispatched with (ceil(width/8), ceil(height/8), 1) workgroups.
 //! Each thread computes one pixel via DDA ray marching through the 3D voxel grid.
 
+use crate::types::MaterialParams;
 use spirv_std::glam::{UVec3, UVec4, Vec3, Vec4};
 #[cfg(target_arch = "spirv")]
 use spirv_std::num_traits::Float;
@@ -160,99 +161,29 @@ fn value_noise(x: f32, y: f32, z: f32) -> f32 {
 
 /// Get procedurally textured color for a material at a given voxel position.
 ///
-/// Each material uses noise/hash functions seeded by voxel coordinates to produce
-/// visual variation instead of flat color. Returns (r, g, b) as floats in [0, 1].
-fn textured_material_color(material_id: u32, vx: i32, vy: i32, vz: i32, grid_size: u32) -> Vec3 {
-    if material_id == 0 {
-        // Stone: dark veins through lighter base with per-voxel grain
-        let noise = value_noise(vx as f32 * 0.7, vy as f32 * 0.7, vz as f32 * 0.7);
-        let noise2 = value_noise(vx as f32 * 2.3, vy as f32 * 2.3, vz as f32 * 2.3);
-        let base = Vec3::new(0.5, 0.48, 0.45);
-        let vein = Vec3::new(0.35, 0.33, 0.30);
-        let t = noise * 0.7 + noise2 * 0.3;
-        let inv_t = 1.0 - t;
-        let inv_t = if inv_t < 0.0 { 0.0 } else { inv_t };
-        let color = Vec3::new(
-            base.x + (vein.x - base.x) * inv_t,
-            base.y + (vein.y - base.y) * inv_t,
-            base.z + (vein.z - base.z) * inv_t,
-        );
-        // Subtle per-voxel variation
-        let h = hash3(vx, vy, vz);
-        let offset = (h - 0.5) * 0.06;
-        Vec3::new(color.x + offset, color.y + offset, color.z + offset)
-    } else if material_id == 1 {
-        // Water: depth-based blue variation
-        let gs = grid_size as f32;
-        let depth_factor = 1.0 - (vy as f32 / gs);
-        let depth_factor = if depth_factor < 0.0 { 0.0 } else { depth_factor };
-        let base = Vec3::new(0.1, 0.35, 0.85);
-        let deep = Vec3::new(0.05, 0.15, 0.5);
-        let t = depth_factor * 0.5;
-        Vec3::new(
-            base.x + (deep.x - base.x) * t,
-            base.y + (deep.y - base.y) * t,
-            base.z + (deep.z - base.z) * t,
-        )
-    } else if material_id == 2 {
-        // Lava: turbulent bright/dark patches
-        let noise = value_noise(vx as f32 * 1.5, vy as f32 * 1.5, vz as f32 * 1.5);
-        let bright = Vec3::new(1.0, 0.7, 0.1);
-        let dark = Vec3::new(0.8, 0.2, 0.0);
-        Vec3::new(
-            dark.x + (bright.x - dark.x) * noise,
-            dark.y + (bright.y - dark.y) * noise,
-            dark.z + (bright.z - dark.z) * noise,
-        )
-    } else if material_id == 3 {
-        // Wood: grain pattern with brown variation
-        let noise = value_noise(vx as f32 * 0.5, vy as f32 * 2.0, vz as f32 * 0.5);
-        let noise2 = value_noise(vx as f32 * 3.0, vy as f32 * 0.3, vz as f32 * 3.0);
-        let light = Vec3::new(0.6, 0.4, 0.2);
-        let dark = Vec3::new(0.4, 0.25, 0.1);
-        let t = noise * 0.6 + noise2 * 0.4;
-        let color = Vec3::new(
-            dark.x + (light.x - dark.x) * t,
-            dark.y + (light.y - dark.y) * t,
-            dark.z + (light.z - dark.z) * t,
-        );
-        let h = hash3(vx, vy, vz);
-        let offset = (h - 0.5) * 0.04;
-        Vec3::new(color.x + offset, color.y + offset, color.z + offset)
-    } else if material_id == 4 {
-        // Ash: gray with subtle variation
-        let h = hash3(vx, vy, vz);
-        let base = 0.4 + (h - 0.5) * 0.08;
-        Vec3::new(base, base, base)
-    } else if material_id == 5 {
-        // Ice: light blue-white with crystalline shimmer
-        let noise = value_noise(vx as f32 * 1.2, vy as f32 * 1.2, vz as f32 * 1.2);
-        let h = hash3(vx, vy, vz);
-        // Vary between pale blue and almost white
-        let pale = Vec3::new(0.7, 0.85, 0.95);
-        let white = Vec3::new(0.85, 0.92, 0.98);
-        let t = noise * 0.6 + h * 0.4;
-        Vec3::new(
-            pale.x + (white.x - pale.x) * t,
-            pale.y + (white.y - pale.y) * t,
-            pale.z + (white.z - pale.z) * t,
-        )
-    } else if material_id == 6 {
-        // Gunpowder: dark brown with granular noise
-        let h = hash3(vx, vy, vz);
-        let noise = value_noise(vx as f32 * 3.0, vy as f32 * 3.0, vz as f32 * 3.0);
-        let base = Vec3::new(0.25, 0.2, 0.15);
-        let dark = Vec3::new(0.15, 0.12, 0.08);
-        let t = h * 0.5 + noise * 0.5;
-        Vec3::new(
-            dark.x + (base.x - dark.x) * t,
-            dark.y + (base.y - dark.y) * t,
-            dark.z + (base.z - dark.z) * t,
-        )
+/// Reads the base color from the MaterialParams buffer, then applies procedural
+/// noise on top for per-voxel visual variation. Returns (r, g, b) as floats in [0, 1].
+fn textured_material_color(
+    material_id: u32,
+    vx: i32,
+    vy: i32,
+    vz: i32,
+    materials: &[MaterialParams],
+) -> Vec3 {
+    // Read base color from MaterialParams buffer (safe index with fallback)
+    let mat_count = materials.len() as u32;
+    let safe_id = if material_id < mat_count {
+        material_id
     } else {
-        // Unknown: magenta
-        Vec3::new(1.0, 0.0, 1.0)
-    }
+        0
+    };
+    let base = materials[safe_id as usize].color.truncate();
+
+    // Apply procedural noise for per-voxel variation: base_color * (0.85 + noise * 0.15)
+    let noise = value_noise(vx as f32 * 1.0, vy as f32 * 1.0, vz as f32 * 1.0);
+    let factor = 0.85 + noise * 0.15;
+
+    Vec3::new(base.x * factor, base.y * factor, base.z * factor)
 }
 
 /// Sun direction constant used for both diffuse lighting and shadow rays.
@@ -522,6 +453,7 @@ pub fn render_pixel(
     push: &RenderPushConstants,
     voxels: &[UVec4],
     output: &mut [u32],
+    materials: &[MaterialParams],
 ) {
     let width = push.width;
     let height = push.height;
@@ -714,7 +646,7 @@ pub fn render_pixel(
         let base_color = if hit_phase == 2 {
             Vec3::new(0.9, 0.9, 0.95)
         } else {
-            textured_material_color(hit_material, vx, vy, vz, grid_size)
+            textured_material_color(hit_material, vx, vy, vz, materials)
         };
 
         // Lighting: if in shadow, only ambient contributes; otherwise full lighting
@@ -799,6 +731,7 @@ pub fn render_pixel(
 /// Dispatched with `(ceil(width/8), ceil(height/8), 1)` workgroups.
 /// Descriptor set 0, binding 0: storage buffer of `UVec4` (voxel grid, read).
 /// Descriptor set 0, binding 1: storage buffer of `u32` (pixel output, write).
+/// Descriptor set 0, binding 2: storage buffer of `MaterialParams` (material table, read).
 /// Push constants: `RenderPushConstants`.
 #[spirv(compute(threads(8, 8, 1)))]
 pub fn render_voxels(
@@ -806,6 +739,7 @@ pub fn render_voxels(
     #[spirv(push_constant)] push: &RenderPushConstants,
     #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] voxels: &[UVec4],
     #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] output: &mut [u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] materials: &[MaterialParams],
 ) {
-    render_pixel(id.x, id.y, push, voxels, output);
+    render_pixel(id.x, id.y, push, voxels, output, materials);
 }

--- a/crates/shaders/src/types.rs
+++ b/crates/shaders/src/types.rs
@@ -66,6 +66,26 @@ pub const DT: f32 = 0.001;
 /// Scaled 20x from 9.81 for 256^3 grid with 5cm voxels.
 pub const GRAVITY: f32 = -196.0;
 
+/// Material parameters for GPU storage buffer. 64 bytes per material.
+///
+/// Mirrors `shared::material::MaterialParams` layout exactly.
+/// - `elastic`: x=youngs_modulus, y=poissons_ratio, z=yield_stress, w=viscosity
+/// - `thermal`: x=melting_point, y=boiling_point, z=heat_conductivity, w=specific_heat
+/// - `visual`: x=density, y=emissive_temp, z=opacity, w=pad
+/// - `color`: xyz=rgb (0..1), w=pad
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct MaterialParams {
+    /// Elastic properties: x=youngs_modulus, y=poissons_ratio, z=yield_stress, w=viscosity.
+    pub elastic: Vec4,
+    /// Thermal properties: x=melting_point, y=boiling_point, z=heat_conductivity, w=specific_heat.
+    pub thermal: Vec4,
+    /// Visual properties: x=density, y=emissive_temp, z=opacity, w=pad.
+    pub visual: Vec4,
+    /// Color: xyz=rgb (0..1), w=pad.
+    pub color: Vec4,
+}
+
 /// Material ID constants (synced with shared::material).
 pub const MAT_WATER: u32 = 1;
 pub const MAT_WOOD: u32 = 3;


### PR DESCRIPTION
## Summary
- Add `MaterialParams` struct to shader types mirroring `shared::material::MaterialParams` layout (64 bytes, `#[repr(C)]`)
- Server creates a GPU storage buffer with `default_material_table()` and binds it to render and P2G shader passes
- Render shader reads base color from `materials[material_id].color` and applies procedural noise (`base * (0.85 + noise * 0.15)`) instead of per-material hardcoded color functions
- P2G shader reads viscosity from `materials[material_id].elastic.w` for liquid stress computation, replacing hardcoded match blocks

## Test plan
- [x] `cargo build` passes (including SPIR-V shader compilation)
- [x] `cargo test -p server -- --test-threads=1` passes (all 5 unit tests + GPU integration test)
- [x] Material buffer upload confirmed in logs: "Uploaded 7 materials (448 bytes) to GPU"
- [ ] Visual regression: verify colors still look correct in running app

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)