### PR TITLE
feat(physics): add thermal diffusion through MPM grid

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,7 +224,7 @@ Graphics: [Primary Rays + Shading] → [Shadow Rays] → [Tonemap → Swapchain]
 
 ### Struct sizes (verified by tests)
 - `Particle`: 144 bytes, align 16
-- `GridCell`: 32 bytes, align 16
+- `GridCell`: 48 bytes, align 16
 - `MaterialParams`: 64 bytes, align 16
 
 ---

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -250,8 +250,8 @@ impl GpuSimulation {
         )?;
 
         // Grid buffer: must fit both GridCell view and flat f32 view.
-        // GridCell = 32 bytes = 8 * f32, so GRID_CELL_COUNT * sizeof(GridCell)
-        // equals GRID_CELL_COUNT * 8 * sizeof(f32). Same size, no issue.
+        // GridCell = 48 bytes = 12 * f32, so GRID_CELL_COUNT * sizeof(GridCell)
+        // equals GRID_CELL_COUNT * 12 * sizeof(f32). Same size, no issue.
         let grid_buf_size =
             (GRID_CELL_COUNT as usize * mem::size_of::<GridCell>()) as vk::DeviceSize;
         let grid_buffer = buffer::create_device_local_buffer(

--- a/crates/shaders/src/compute/clear_grid.rs
+++ b/crates/shaders/src/compute/clear_grid.rs
@@ -15,6 +15,7 @@ use spirv_std::spirv;
 pub fn zero_cell(cell: &mut GridCell) {
     cell.velocity_mass = Vec4::ZERO;
     cell.force_pad = Vec4::ZERO;
+    cell.temp_pad = Vec4::ZERO;
 }
 
 /// Compute shader entry point: clears all grid cells to zero.

--- a/crates/shaders/src/compute/g2p.rs
+++ b/crates/shaders/src/compute/g2p.rs
@@ -1,8 +1,8 @@
 //! Grid-to-Particle (G2P) compute shader.
 //!
-//! Each thread processes one particle, gathering velocity from the 27
-//! neighboring grid cells using quadratic B-spline weights.
-//! Updates particle velocity (PIC/FLIP blend), APIC C matrix,
+//! Each thread processes one particle, gathering velocity and temperature
+//! from the 27 neighboring grid cells using quadratic B-spline weights.
+//! Updates particle velocity (PIC/FLIP blend), temperature, APIC C matrix,
 //! deformation gradient F, position, and phase transitions.
 
 use crate::types::{GridCell, Particle};
@@ -103,11 +103,12 @@ pub fn gather_particle(
     let wy = quadratic_bspline_weights(fy);
     let wz = quadratic_bspline_weights(fz);
 
-    // Accumulate PIC velocity and APIC C matrix
+    // Accumulate PIC velocity, APIC C matrix, and temperature
     let mut pic_vel = Vec3::ZERO;
     let mut c_col0 = Vec3::ZERO;
     let mut c_col1 = Vec3::ZERO;
     let mut c_col2 = Vec3::ZERO;
+    let mut new_temp = 0.0_f32;
 
     let mut di = 0u32;
     while di < 3 {
@@ -139,6 +140,11 @@ pub fn gather_particle(
                     c_col0 += cell_vel * (w * dx.x);
                     c_col1 += cell_vel * (w * dx.y);
                     c_col2 += cell_vel * (w * dx.z);
+
+                    // Gather temperature from grid (normalized by mass in grid_update).
+                    // This enables natural thermal diffusion through the MPM transfer.
+                    let grid_temp = grid[idx].temp_pad.x;
+                    new_temp += grid_temp * w;
                 }
                 dk += 1;
             }
@@ -221,6 +227,10 @@ pub fn gather_particle(
             particle.c_col0 = c_col0.extend(0.0);
             particle.c_col1 = c_col1.extend(0.0);
             particle.c_col2 = c_col2.extend(0.0);
+            // Update temperature even for pinned solids (heat conducts through stone)
+            particle.vel_temp = Vec4::new(
+                particle.vel_temp.x, particle.vel_temp.y, particle.vel_temp.z, new_temp,
+            );
             apply_phase_transitions(particle);
             return;
         }
@@ -229,7 +239,7 @@ pub fn gather_particle(
 
     // Write back to particle (liquids and gases only)
     particle.pos_mass = Vec4::new(new_pos.x, new_pos.y, new_pos.z, particle.pos_mass.w);
-    particle.vel_temp = Vec4::new(new_vel.x, new_vel.y, new_vel.z, particle.vel_temp.w);
+    particle.vel_temp = Vec4::new(new_vel.x, new_vel.y, new_vel.z, new_temp);
     particle.f_col0 = new_f0.extend(0.0);
     particle.f_col1 = new_f1.extend(0.0);
     particle.f_col2 = new_f2.extend(0.0);

--- a/crates/shaders/src/compute/grid_update.rs
+++ b/crates/shaders/src/compute/grid_update.rs
@@ -40,6 +40,7 @@ pub fn update_cell(
     // Skip empty cells (mass below threshold)
     if mass < 1.0e-6 {
         cell.velocity_mass = Vec4::ZERO;
+        cell.temp_pad = Vec4::ZERO;
         return;
     }
 
@@ -90,6 +91,12 @@ pub fn update_cell(
     }
 
     cell.velocity_mass = Vec4::new(vx, vy, vz, mass);
+
+    // Normalize accumulated temperature by mass (P2G scattered temp * mass * weight).
+    // This gives the mass-weighted average temperature at this grid cell,
+    // enabling natural thermal diffusion through the MPM transfer cycle.
+    let cell_temp = cell.temp_pad.x / mass;
+    cell.temp_pad = Vec4::new(cell_temp, 0.0, 0.0, 0.0);
 }
 
 /// Compute shader entry point: grid velocity update.

--- a/crates/shaders/src/compute/mod.rs
+++ b/crates/shaders/src/compute/mod.rs
@@ -7,7 +7,7 @@
 //! - `&mut [GridCell]` for clear_grid, grid_update, G2P (one thread per cell, no contention)
 //! - `&mut [f32]` for P2G (float atomics for concurrent particle scatter)
 //!
-//! Both views alias the same GPU buffer. Each `GridCell` = 8 contiguous f32s.
+//! Both views alias the same GPU buffer. Each `GridCell` = 12 contiguous f32s.
 
 pub mod clear_grid;
 pub mod explosion;

--- a/crates/shaders/src/compute/p2g.rs
+++ b/crates/shaders/src/compute/p2g.rs
@@ -1,12 +1,12 @@
 //! Particle-to-Grid (P2G) compute shader.
 //!
-//! Each thread processes one particle, scattering mass, momentum, and stress
-//! to the 27 neighboring grid cells using quadratic B-spline weights.
+//! Each thread processes one particle, scattering mass, momentum, stress,
+//! and temperature to the 27 neighboring grid cells using quadratic B-spline weights.
 //! Uses `spirv_std::arch::atomic_f_add()` for concurrent accumulation.
 //!
 //! The grid buffer is accessed as flat `&mut [f32]` to enable per-component
-//! float atomics. Each `GridCell` occupies 8 consecutive f32 values:
-//! `[vel_x, vel_y, vel_z, mass, force_x, force_y, force_z, pad]`.
+//! float atomics. Each `GridCell` occupies 12 consecutive f32 values:
+//! `[vel_x, vel_y, vel_z, mass, force_x, force_y, force_z, solid_flag, temp, pad, pad, pad]`.
 
 use crate::types::{MaterialParams, Particle};
 use spirv_std::glam::{UVec3, Vec3};
@@ -14,8 +14,8 @@ use spirv_std::spirv;
 
 use super::quadratic_bspline_weights;
 
-/// Number of f32 values per grid cell (velocity_mass: 4 + force_pad: 4 = 8).
-const FLOATS_PER_CELL: u32 = 8;
+/// Number of f32 values per grid cell (velocity_mass: 4 + force_pad: 4 + temp_pad: 4 = 12).
+const FLOATS_PER_CELL: u32 = 12;
 
 /// Push constants for the P2G shader.
 ///
@@ -169,8 +169,8 @@ pub unsafe fn grid_atomic_add(grid: &mut [f32], index: usize, value: f32) {
 /// momentum, and stress to its 27 neighboring grid cells weighted
 /// by quadratic B-spline interpolation.
 ///
-/// The grid buffer is flat f32 with 8 floats per cell:
-/// `[vel_x, vel_y, vel_z, mass, force_x, force_y, force_z, pad]`.
+/// The grid buffer is flat f32 with 12 floats per cell:
+/// `[vel_x, vel_y, vel_z, mass, force_x, force_y, force_z, solid_flag, temp, pad, pad, pad]`.
 pub fn scatter_particle(
     particle: &Particle,
     grid: &mut [f32],
@@ -181,6 +181,7 @@ pub fn scatter_particle(
     let pos = particle.pos_mass.truncate();
     let vel = particle.vel_temp.truncate();
     let mass = particle.pos_mass.w;
+    let temp = particle.vel_temp.w;
 
     // Base cell index (integer part of position - 0.5, since B-spline support is [-1.5, 1.5])
     let base_x = (pos.x - 0.5).max(0.0) as u32;
@@ -266,6 +267,14 @@ pub fn scatter_particle(
                             grid_atomic_add(grid, base + 7, 1.0);
                         }
                     }
+
+                    // Scatter weighted temperature to temp_pad.x (index 8).
+                    // Accumulated as temp * mass * weight, normalized by mass
+                    // in grid_update to get average temperature per cell.
+                    let weighted_temp = temp * weighted_mass;
+                    unsafe {
+                        grid_atomic_add(grid, base + 8, weighted_temp);
+                    }
                 }
                 dk += 1;
             }
@@ -279,7 +288,7 @@ pub fn scatter_particle(
 ///
 /// Descriptor set 0, binding 0: storage buffer of `Particle` (read).
 /// Descriptor set 0, binding 1: storage buffer of `f32` (grid, read-write with atomics).
-///   Layout: 8 floats per cell `[vel_x, vel_y, vel_z, mass, force_x, force_y, force_z, pad]`.
+///   Layout: 12 floats per cell `[vel_x, vel_y, vel_z, mass, force_x, force_y, force_z, solid_flag, temp, pad, pad, pad]`.
 /// Descriptor set 0, binding 2: storage buffer of `MaterialParams` (material table, read).
 /// Push constants: `P2gPushConstants`.
 /// Dispatch with `(ceil(num_particles / 64), 1, 1)` workgroups.

--- a/crates/shaders/src/types.rs
+++ b/crates/shaders/src/types.rs
@@ -43,17 +43,21 @@ pub struct Particle {
     pub ids: UVec4,
 }
 
-/// A single grid cell for MPM transfer. 32 bytes, 16-byte aligned.
+/// A single grid cell for MPM transfer. 48 bytes, 16-byte aligned.
 ///
 /// - `velocity_mass`: xyz = velocity (or momentum during P2G), w = mass
-/// - `force_pad`: xyz = force, w = padding
+/// - `force_pad`: xyz = force, w = solid flag
+/// - `temp_pad`: x = accumulated temperature (weighted by mass during P2G,
+///   normalized after grid_update), yzw = padding (reserved for future use)
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct GridCell {
     /// Velocity or momentum (xyz) and mass (w).
     pub velocity_mass: Vec4,
-    /// Force (xyz) and padding (w).
+    /// Force (xyz) and solid flag (w).
     pub force_pad: Vec4,
+    /// Temperature (x) and padding (yzw).
+    pub temp_pad: Vec4,
 }
 
 /// Grid dimension (cells per axis). 256³ with 5cm voxels = 12.8m world.

--- a/crates/shared/src/particle.rs
+++ b/crates/shared/src/particle.rs
@@ -168,15 +168,18 @@ impl Particle {
     }
 }
 
-/// A single grid cell for MPM transfer. 32 bytes, 16-byte aligned.
+/// A single grid cell for MPM transfer. 48 bytes, 16-byte aligned.
 ///
-/// - `velocity_mass`: xyz = velocity, w = mass
-/// - `force_pad`: xyz = force, w = padding
+/// - `velocity_mass`: xyz = velocity (or momentum during P2G), w = mass
+/// - `force_pad`: xyz = force, w = solid flag
+/// - `temp_pad`: x = accumulated temperature (weighted by mass during P2G,
+///   normalized after grid_update), yzw = padding (reserved for future use)
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Pod, Zeroable)]
 pub struct GridCell {
     pub velocity_mass: Vec4,
     pub force_pad: Vec4,
+    pub temp_pad: Vec4,
 }
 
 #[cfg(test)]
@@ -203,11 +206,12 @@ mod tests {
 
     #[test]
     fn grid_cell_struct_layout() {
-        assert_eq!(size_of::<GridCell>(), 32);
+        assert_eq!(size_of::<GridCell>(), 48);
         assert_eq!(align_of::<GridCell>(), 16);
 
         assert_eq!(offset_of!(GridCell, velocity_mass), 0);
         assert_eq!(offset_of!(GridCell, force_pad), 16);
+        assert_eq!(offset_of!(GridCell, temp_pad), 32);
     }
 
     #[test]

--- a/crates/sim-cpu/src/grid.rs
+++ b/crates/sim-cpu/src/grid.rs
@@ -69,6 +69,7 @@ pub fn clear_grid(grid: &mut [GridCell]) {
         *cell = GridCell {
             velocity_mass: glam::Vec4::ZERO,
             force_pad: glam::Vec4::ZERO,
+            temp_pad: glam::Vec4::ZERO,
         };
     }
 }
@@ -95,6 +96,7 @@ pub fn p2g(particles: &[Particle], grid: &mut [GridCell], materials: &[MaterialP
         let pos = particle.position();
         let vel = particle.velocity();
         let mass = particle.mass();
+        let temp = particle.temperature();
         let c = particle.affine_momentum();
 
         // Get material and compute stress
@@ -169,6 +171,10 @@ pub fn p2g(particles: &[Particle], grid: &mut [GridCell], materials: &[MaterialP
                     cell.velocity_mass.y += w * momentum.y + force_contrib.y;
                     cell.velocity_mass.z += w * momentum.z + force_contrib.z;
                     cell.velocity_mass.w += w * mass;
+
+                    // Scatter weighted temperature (temp * mass * weight).
+                    // Normalized by mass in grid_update to get average temperature.
+                    cell.temp_pad.x += temp * w * mass;
                 }
             }
         }
@@ -198,6 +204,7 @@ pub fn grid_update(grid: &mut [GridCell], dt: f32) {
 
                 if mass < MASS_THRESHOLD {
                     cell.velocity_mass = glam::Vec4::ZERO;
+                    cell.temp_pad = glam::Vec4::ZERO;
                     continue;
                 }
 
@@ -230,6 +237,12 @@ pub fn grid_update(grid: &mut [GridCell], dt: f32) {
                 if iz < boundary || iz >= gs - boundary {
                     cell.velocity_mass.z = 0.0;
                 }
+
+                // Normalize accumulated temperature by mass.
+                // P2G scattered temp * mass * weight; dividing by mass gives
+                // the mass-weighted average temperature at this grid cell.
+                let cell_temp = cell.temp_pad.x / mass;
+                cell.temp_pad = glam::Vec4::new(cell_temp, 0.0, 0.0, 0.0);
             }
         }
     }
@@ -320,6 +333,7 @@ pub fn g2p(particles: &mut [Particle], grid: &[GridCell], solid_occupancy: &[boo
 
         let mut new_vel = Vec3::ZERO;
         let mut new_c = Mat3::ZERO;
+        let mut new_temp = 0.0_f32;
 
         // Gather from 3x3x3 neighbors
         for dz in 0..3_i32 {
@@ -366,6 +380,10 @@ pub fn g2p(particles: &mut [Particle], grid: &[GridCell], solid_occupancy: &[boo
                         w * grid_vel * dpos.y * inv_d,
                         w * grid_vel * dpos.z * inv_d,
                     );
+
+                    // Gather temperature from grid (normalized in grid_update).
+                    let grid_temp = cell.temp_pad.x;
+                    new_temp += grid_temp * w;
                 }
             }
         }
@@ -398,13 +416,16 @@ pub fn g2p(particles: &mut [Particle], grid: &[GridCell], solid_occupancy: &[boo
             if supported {
                 particle.set_affine_momentum(new_c);
                 particle.set_deformation_gradient(f_new);
+                // Update temperature even for pinned solids (heat conducts through stone)
+                particle.set_temperature(new_temp);
                 continue;
             }
             // Unsupported: fall through to position/velocity update
         }
 
-        // Update velocity
+        // Update velocity and temperature
         particle.set_velocity(final_vel);
+        particle.set_temperature(new_temp);
 
         // Update APIC C matrix
         particle.set_affine_momentum(new_c);
@@ -441,6 +462,7 @@ mod tests {
             GridCell {
                 velocity_mass: glam::Vec4::ZERO,
                 force_pad: glam::Vec4::ZERO,
+                temp_pad: glam::Vec4::ZERO,
             };
             GRID_CELL_COUNT as usize
         ]
@@ -598,10 +620,66 @@ mod tests {
 
     #[test]
     fn grid_index_bounds() {
+        let gs = shared::constants::GRID_SIZE as i32;
         assert!(grid_index(0, 0, 0).is_some());
-        assert!(grid_index(31, 31, 31).is_some());
+        assert!(grid_index(gs - 1, gs - 1, gs - 1).is_some());
         assert!(grid_index(-1, 0, 0).is_none());
-        assert!(grid_index(0, 32, 0).is_none());
+        assert!(grid_index(0, gs, 0).is_none());
         assert_eq!(grid_index(0, 0, 0).unwrap(), 0);
+    }
+
+    #[test]
+    fn thermal_diffusion_through_grid() {
+        // Verify that temperature transfers between nearby particles
+        // through the P2G -> grid_update -> G2P cycle.
+        let table = default_material_table();
+        let dx = 1.0 / shared::constants::GRID_SIZE as f32;
+        let center = 0.5_f32;
+
+        let mut particles = vec![
+            // Hot water particle
+            {
+                let mut p = shared::particle::Particle::new(
+                    glam::Vec3::new(center, center, center),
+                    1.0,
+                    shared::material::MAT_WATER,
+                    1,
+                );
+                p.set_temperature(500.0);
+                p
+            },
+            // Cold water particle 1 grid cell away
+            {
+                let mut p = shared::particle::Particle::new(
+                    glam::Vec3::new(center + dx, center, center),
+                    1.0,
+                    shared::material::MAT_WATER,
+                    1,
+                );
+                p.set_temperature(0.0);
+                p
+            },
+        ];
+
+        let initial_diff = (particles[0].temperature() - particles[1].temperature()).abs();
+        let dt = 0.001;
+
+        for _ in 0..20 {
+            let mut grid = make_grid();
+            p2g(&particles, &mut grid, &table, dt);
+            grid_update(&mut grid, dt);
+            let occupancy = build_solid_occupancy(&particles);
+            g2p(&mut particles, &grid, &occupancy, dt);
+        }
+
+        let final_diff = (particles[0].temperature() - particles[1].temperature()).abs();
+
+        assert!(
+            final_diff < initial_diff,
+            "Temperature should diffuse through grid: initial_diff={initial_diff}, final_diff={final_diff}"
+        );
+        // Both temperatures should be finite
+        assert!(particles[0].temperature().is_finite());
+        assert!(particles[1].temperature().is_finite());
     }
 }

--- a/crates/sim-cpu/src/thermal.rs
+++ b/crates/sim-cpu/src/thermal.rs
@@ -146,6 +146,11 @@ mod tests {
     #[test]
     fn temperature_diffusion_equalizes() {
         let table = default_material_table();
+        // Place particles close enough to share grid cells.
+        // GRID_SIZE=256, so 1 grid cell = 1/256 ~ 0.0039.
+        // B-spline stencil covers +-1.5 cells, so particles within ~3 cells
+        // (~0.012 world units) will overlap and exchange heat.
+        let dx = 1.0 / shared::constants::GRID_SIZE as f32; // one grid cell
         let mut particles = vec![
             // Hot particle
             {
@@ -153,9 +158,10 @@ mod tests {
                 p.set_temperature(1000.0);
                 p
             },
-            // Cold particle nearby
+            // Cold particle 1 grid cell away (within B-spline overlap)
             {
-                let mut p = Particle::new(Vec3::new(0.52, 0.5, 0.5), 1.0, MAT_STONE, PHASE_SOLID);
+                let mut p =
+                    Particle::new(Vec3::new(0.5 + dx, 0.5, 0.5), 1.0, MAT_STONE, PHASE_SOLID);
                 p.set_temperature(100.0);
                 p
             },
@@ -206,6 +212,7 @@ mod tests {
     #[test]
     fn lava_cools_to_stone() {
         let table = default_material_table();
+        let dx = 1.0 / shared::constants::GRID_SIZE as f32;
         let mut particles = vec![
             // Hot lava
             {
@@ -213,9 +220,14 @@ mod tests {
                 p.set_temperature(1600.0);
                 p
             },
-            // Cold stone nearby (acts as heat sink)
+            // Cold stone 1 grid cell away (acts as heat sink)
             {
-                let mut p = Particle::new(Vec3::new(0.52, 0.5, 0.5), 10.0, MAT_STONE, PHASE_SOLID);
+                let mut p = Particle::new(
+                    Vec3::new(0.5 + dx, 0.5, 0.5),
+                    10.0,
+                    MAT_STONE,
+                    PHASE_SOLID,
+                );
                 p.set_temperature(20.0);
                 p
             },

--- a/crates/sim-cpu/src/world.rs
+++ b/crates/sim-cpu/src/world.rs
@@ -63,6 +63,7 @@ impl Simulation {
                 GridCell {
                     velocity_mass: glam::Vec4::ZERO,
                     force_pad: glam::Vec4::ZERO,
+                    temp_pad: glam::Vec4::ZERO,
                 };
                 GRID_CELL_COUNT as usize
             ],
@@ -87,6 +88,7 @@ impl Simulation {
                 GridCell {
                     velocity_mass: glam::Vec4::ZERO,
                     force_pad: glam::Vec4::ZERO,
+                    temp_pad: glam::Vec4::ZERO,
                 };
                 GRID_CELL_COUNT as usize
             ],


### PR DESCRIPTION
## Summary
- Expand `GridCell` from 32 to 48 bytes with new `temp_pad: Vec4` field for temperature accumulation
- **P2G**: scatter weighted temperature (`temp * mass * weight`) to grid cells alongside momentum
- **grid_update**: normalize accumulated temperature by mass after velocity update
- **G2P**: gather temperature from grid back to particles (including pinned solids)
- Sync CPU reference implementation in `sim-cpu/grid.rs` with the same changes
- Fix pre-existing thermal test failures where particles were placed too far apart to share grid cells

Temperature now naturally diffuses through the MPM transfer cycle: hot particles scatter high temperature to shared grid cells, cold particles gather some of that heat. No separate diffusion pass needed.

## Test plan
- [x] `cargo test -p shared` -- GridCell layout test updated (48 bytes)
- [x] `cargo test -p sim-cpu grid::tests` -- all 9 tests pass including new `thermal_diffusion_through_grid`
- [x] `cargo test -p sim-cpu thermal` -- all 5 thermal tests pass (previously 2 were failing)
- [x] `cargo build -p server` -- shader compilation succeeds with expanded GridCell
- [ ] Visual test: place lava next to gunpowder, verify temperature rises and ignition occurs

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)