### PR TITLE
fix(server): shader cache invalidation on source changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,13 @@ Scene must produce particles under MAX_PARTICLES. Never hand off broken builds.
 G2P skips velocity/position update for phase=0 (solid). Falling solids check voxel below for support.
 Explosion debris must be converted to liquid (phase=1) + heated above melting point to fly properly.
 
+### 20. Shader build.rs must track shader source files
+spirv-builder compiles shaders in a **separate** cargo invocation inside `crates/server/build.rs`.
+Cargo's build-script caching only watches files the build script itself reads, so it has no idea
+when shader sources change. You **must** add explicit `cargo:rerun-if-changed` directives for
+`../shaders/src/` and `../shaders/Cargo.toml`. Without these, editing a shader file may not
+trigger recompilation and you'll keep running stale SPIR-V.
+
 ---
 
 ## Code Patterns

--- a/crates/server/build.rs
+++ b/crates/server/build.rs
@@ -7,6 +7,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .join("..")
         .join("shaders");
 
+    // spirv-builder runs a separate cargo build, so the outer build.rs
+    // doesn't know about shader source changes unless we tell it explicitly.
+    println!("cargo:rerun-if-changed=../shaders/src/");
+    println!("cargo:rerun-if-changed=../shaders/Cargo.toml");
+
     let result = SpirvBuilder::new(shader_crate, "spirv-unknown-vulkan1.3")
         .capability(Capability::AtomicFloat32AddEXT)
         .capability(Capability::VulkanMemoryModelDeviceScope)


### PR DESCRIPTION
## Summary
- Added `cargo:rerun-if-changed` directives to `crates/server/build.rs` for `../shaders/src/` and `../shaders/Cargo.toml` so that shader source edits trigger spirv-builder recompilation
- Documented as trap #20 in CLAUDE.md

Closes #172

## Test plan
- [x] `cargo build` succeeds
- [ ] Modify a shader source file, rebuild, verify shaders are recompiled

🤖 Generated with [Claude Code](https://claude.com/claude-code)