### PR TITLE
fix(physics): tune thermal diffusion, gunpowder explosion, radiative cooling

### DIFF
--- a/crates/server/build.rs
+++ b/crates/server/build.rs
@@ -16,5 +16,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let spv_path = result.module.unwrap_single();
     println!("cargo:rustc-env=SHADERS_SPV_PATH={}", spv_path.display());
 
+    // Ensure build.rs reruns when shader source files change
+    println!("cargo:rerun-if-changed=../shaders/src/");
+
     Ok(())
 }

--- a/crates/shaders/src/compute/g2p.rs
+++ b/crates/shaders/src/compute/g2p.rs
@@ -159,6 +159,23 @@ pub fn gather_particle(
     c_col1 *= apic_scale;
     c_col2 *= apic_scale;
 
+    // Thermal diffusion: blend grid temp with particle temp for gradual transfer.
+    // Full grid temp (blend=1.0) = instant equalization (too fast, lava cools in <1s).
+    // Blend=0.005 means 0.5% of grid temp difference per step.
+    // At 120 steps/sec: after 1s temp moves ~45% toward grid average.
+    // Lava at 2000C surrounded by stone at 20C cools to solidification (~1500C) in ~3-5s.
+    let thermal_blend = 0.005_f32;
+    let old_temp = particle.vel_temp.w;
+    new_temp = old_temp + thermal_blend * (new_temp - old_temp);
+
+    // Radiative cooling: particles lose heat to environment over time (Newton's cooling law).
+    // Without this, total thermal energy only accumulates (each explosion adds 3000C)
+    // and chain explosions escalate infinitely. This ensures heat dissipates even
+    // without cold neighbors nearby.
+    // At 0.002 per step (120 steps/sec): hot particle loses ~21% of excess heat per second.
+    // 3000C -> ~2370C after 1s, ~1870C after 2s, reaches ambient in ~15-20s.
+    new_temp = apply_radiative_cooling(new_temp);
+
     // PIC/FLIP blend
     // True FLIP requires old grid velocities which we don't store.
     // Instead, use a weighted blend of PIC (grid velocity) and the particle's
@@ -251,6 +268,69 @@ pub fn gather_particle(
     apply_phase_transitions(particle);
 }
 
+/// Apply radiative cooling (Newton's cooling law) to a temperature value.
+///
+/// Particles lose heat to the environment at a rate proportional to the
+/// temperature difference from ambient (20C). This prevents thermal runaway
+/// where explosions accumulate heat indefinitely.
+///
+/// `cooling_rate = 0.002` per step. At 120 steps/sec, a 3000C particle
+/// loses ~21% of excess heat per second.
+fn apply_radiative_cooling(temp: f32) -> f32 {
+    let ambient_temp = 20.0_f32;
+    let cooling_rate = 0.002_f32;
+    temp + cooling_rate * (ambient_temp - temp)
+}
+
+/// GPU-friendly pseudo-random hash for a single float.
+///
+/// Uses integer bit reinterpretation and xorshift-style mixing to produce
+/// a value in [-1.0, 1.0] with reasonable distribution, even for
+/// nearby integer-ish inputs (e.g., grid-aligned particle positions).
+fn hash_f32(x: f32) -> f32 {
+    // Reinterpret float bits as integer for mixing
+    let mut bits = x.to_bits();
+    bits ^= bits >> 16;
+    bits = bits.wrapping_mul(0x45d9f3b);
+    bits ^= bits >> 16;
+    // Convert to [-1, 1] range
+    let normalized = (bits & 0xFFFF) as f32 / 32768.0 - 1.0;
+    normalized
+}
+
+/// Apply gunpowder explosion: set velocity to pseudo-random outward direction.
+///
+/// Uses particle position as a seed for the hash to give each particle
+/// a unique explosion direction. Speed is calibrated against gravity (-196)
+/// so particles travel ~30-60 grid units before falling back.
+///
+/// Also boosts temperature to 3000C for thermal pressure effects.
+fn apply_gunpowder_explosion(particle: &mut Particle) {
+    let px = particle.pos_mass.x;
+    let py = particle.pos_mass.y;
+    let pz = particle.pos_mass.z;
+
+    // Hash each axis with different seeds for decorrelation
+    let hx = hash_f32(px * 73.17 + pz * 37.91);
+    let hy = hash_f32(py * 127.31 + px * 53.47);
+    let hz = hash_f32(pz * 91.53 + py * 67.13);
+
+    // Explosion speed: 150 grid-units/s.
+    // Against gravity=-196, max vertical rise = v^2/(2*g) ≈ 57 grid units.
+    // Horizontal spread is unimpeded. Good visual for 256-grid.
+    let explosion_speed = 150.0_f32;
+    particle.vel_temp = Vec4::new(
+        hx * explosion_speed,
+        hy.abs() * explosion_speed + 80.0, // always some upward bias
+        hz * explosion_speed,
+        3000.0, // boost temperature for gas thermal pressure
+    );
+    // Reset F (trap #8)
+    particle.f_col0 = Vec4::new(1.0, 0.0, 0.0, 0.0);
+    particle.f_col1 = Vec4::new(0.0, 1.0, 0.0, 0.0);
+    particle.f_col2 = Vec4::new(0.0, 0.0, 1.0, 0.0);
+}
+
 /// Check and apply phase transitions based on temperature thresholds.
 ///
 /// - Stone (mat=0) T > 1500 -> Liquid (lava, mat=2)
@@ -303,14 +383,8 @@ pub fn apply_phase_transitions(particle: &mut Particle) {
         6 => {
             if phase == 0 && temp > 150.0 {
                 new_phase = 2; // solid -> gas (explosion)
-                // Boost temp for massive EOS pressure
-                particle.vel_temp = Vec4::new(
-                    particle.vel_temp.x, particle.vel_temp.y, particle.vel_temp.z, 3000.0
-                );
-                // Reset F (trap #8)
-                particle.f_col0 = Vec4::new(1.0, 0.0, 0.0, 0.0);
-                particle.f_col1 = Vec4::new(0.0, 1.0, 0.0, 0.0);
-                particle.f_col2 = Vec4::new(0.0, 0.0, 1.0, 0.0);
+                // Explosion: outward velocity with pseudo-random direction per particle.
+                apply_gunpowder_explosion(particle);
             }
         }
         _ => {}

--- a/crates/shaders/src/compute/p2g.rs
+++ b/crates/shaders/src/compute/p2g.rs
@@ -71,7 +71,11 @@ pub fn compute_stress(particle: &Particle, materials: &[MaterialParams]) -> [Vec
             (20.0_f32, mat.elastic.w)
         };
 
-        let pressure = bulk * (j - 1.0);
+        // Gas thermal pressure: hot gas expands outward (ideal gas law approx).
+        // Scale factor 0.05 keeps pressure reasonable: at 3000C -> 150 extra pressure.
+        // Capped at 200 to prevent numerical blowup from extreme temperatures.
+        let thermal_pressure = compute_gas_thermal_pressure(particle, phase);
+        let pressure = bulk * (j - 1.0) + thermal_pressure;
 
         // Viscous stress: approximated from APIC C matrix (velocity gradient).
         // D = 0.5 * (C + C^T), then deviatoric part opposes shearing flow.
@@ -121,6 +125,27 @@ pub fn compute_stress(particle: &Particle, materials: &[MaterialParams]) -> [Vec
         let s2 = mu * (f_col2 - Vec3::Z) * stress_scale + Vec3::Z * lambda * log_j;
         [s0, s1, s2]
     }
+}
+
+/// Compute gas thermal pressure contribution.
+///
+/// Hot gas (phase==2, T>100) generates outward expansion pressure proportional
+/// to temperature, simulating the ideal gas law. Scaled by 0.05 and capped at
+/// 200 to prevent numerical instability at extreme temperatures.
+///
+/// Returns 0.0 for non-gas particles or cool gas.
+fn compute_gas_thermal_pressure(particle: &Particle, phase: u32) -> f32 {
+    if phase != 2 {
+        return 0.0;
+    }
+    let temp = particle.vel_temp.w;
+    if temp <= 100.0 {
+        return 0.0;
+    }
+    // Scale: 3000C * 0.05 = 150 pressure units (comparable to bulk=2.0 * J deviation)
+    let raw = temp * 0.05;
+    // Cap to prevent extreme pressure from runaway temperatures
+    if raw > 200.0 { 200.0 } else { raw }
 }
 
 /// Approximate natural logarithm for GPU (no std::ln available in no_std).

--- a/crates/shared/src/phase.rs
+++ b/crates/shared/src/phase.rs
@@ -5,7 +5,7 @@
 //! - Water T > 100 -> Steam (gas)
 //! - Water T < 0 -> Ice (solid)
 //! - Lava T < 1500 -> Stone (solid)
-//! - Gunpowder T > 200 -> Gas (explosion)
+//! - Gunpowder T > 150 -> Gas (explosion)
 //!
 //! On transition: reset F = Identity, damage = 0, update phase.
 
@@ -71,7 +71,7 @@ pub fn check_phase_transition(particle: &Particle) -> PhaseTransition {
             new_phase: PHASE_SOLID,
         },
         // Gunpowder solid -> Gas when T > 200 (explosion)
-        (MAT_GUNPOWDER, PHASE_SOLID) if temp > 200.0 => PhaseTransition::Transition {
+        (MAT_GUNPOWDER, PHASE_SOLID) if temp > 150.0 => PhaseTransition::Transition {
             new_material_id: MAT_GUNPOWDER,
             new_phase: PHASE_GAS,
         },

--- a/crates/shared/src/physics.rs
+++ b/crates/shared/src/physics.rs
@@ -107,14 +107,41 @@ fn liquid_stress(particle: &Particle, material: &MaterialParams) -> Mat3 {
     -pressure * j * Mat3::IDENTITY + 2.0 * viscosity * j * deviatoric_d
 }
 
-/// Gas constitutive model: weak EOS with minimal viscosity.
+/// Gas constitutive model: weak EOS with thermal expansion pressure.
 ///
-/// Same structure as liquid but with much weaker pressure response
-/// and near-zero viscosity.
+/// Same structure as liquid but with much weaker bulk modulus and
+/// near-zero viscosity. Hot gas (T>100) gets additional thermal pressure
+/// to simulate ideal gas expansion (e.g., gunpowder explosion debris).
+///
+/// Thermal pressure is scaled by 0.05 and capped at 200 to prevent
+/// numerical instability, matching the shader implementation in p2g.rs.
 fn gas_stress(particle: &Particle, material: &MaterialParams) -> Mat3 {
-    // Gas uses the same model as liquid but with much smaller coefficients
-    // which are already encoded in the material parameters
-    liquid_stress(particle, material)
+    let f = particle.deformation_gradient();
+    let j = f.determinant().max(STRESS_EPSILON);
+
+    let bulk_modulus = material.elastic.x;
+    let viscosity = material.elastic.w;
+
+    // EOS pressure
+    let eos_pressure = bulk_modulus * (1.0 / j - 1.0);
+
+    // Gas thermal pressure: hot gas expands outward.
+    // Must match shader p2g.rs compute_gas_thermal_pressure().
+    let temp = particle.temperature();
+    let thermal_pressure = if temp > 100.0 {
+        (temp * 0.05).min(200.0)
+    } else {
+        0.0
+    };
+
+    let total_pressure = eos_pressure + thermal_pressure;
+
+    // Viscous stress from APIC C matrix
+    let c = particle.affine_momentum();
+    let d = 0.5 * (c + c.transpose());
+    let deviatoric_d = d - (d.col(0).x + d.col(1).y + d.col(2).z) / 3.0 * Mat3::IDENTITY;
+
+    -total_pressure * j * Mat3::IDENTITY + 2.0 * viscosity * j * deviatoric_d
 }
 
 #[cfg(test)]

--- a/crates/sim-cpu/src/grid.rs
+++ b/crates/sim-cpu/src/grid.rs
@@ -388,6 +388,20 @@ pub fn g2p(particles: &mut [Particle], grid: &[GridCell], solid_occupancy: &[boo
             }
         }
 
+        // Thermal diffusion: blend grid temp with particle temp for gradual transfer.
+        // Must match shader g2p.rs thermal_blend value (0.005 = 0.5% per step).
+        // At 120 steps/sec: lava cools from 2000C to solidification in ~3-5 seconds.
+        let thermal_blend = 0.005_f32;
+        let old_temp = particle.temperature();
+        new_temp = old_temp + thermal_blend * (new_temp - old_temp);
+
+        // Radiative cooling: particles lose heat to environment (Newton's cooling law).
+        // Must match shader g2p.rs apply_radiative_cooling().
+        // Prevents thermal runaway from repeated explosions.
+        let ambient_temp = 20.0_f32;
+        let cooling_rate = 0.002_f32;
+        new_temp = new_temp + cooling_rate * (ambient_temp - new_temp);
+
         // PIC/FLIP blend
         // True FLIP requires old grid velocities which we don't store.
         // Instead, blend PIC (grid velocity) with old particle velocity

--- a/crates/sim-cpu/src/thermal.rs
+++ b/crates/sim-cpu/src/thermal.rs
@@ -126,13 +126,63 @@ pub fn diffuse_temperature(particles: &mut [Particle], materials: &[MaterialPara
 /// After temperature update, each particle is checked against phase
 /// transition rules. On transition: F = Identity, damage = 0.
 ///
+/// Gunpowder explosion additionally sets outward velocity and boosts
+/// temperature to 3000C, matching the shader implementation in g2p.rs.
+///
 /// # Arguments
 /// - `particles`: mutable particle slice
 pub fn apply_phase_transitions(particles: &mut [Particle]) {
     for particle in particles.iter_mut() {
+        let was_gunpowder_solid = particle.material_id() == shared::material::MAT_GUNPOWDER
+            && particle.phase() == shared::material::PHASE_SOLID;
         let transition = check_phase_transition(particle);
         apply_phase_transition(particle, transition);
+
+        // Gunpowder explosion: apply outward velocity and boost temperature.
+        // Must match shader g2p.rs apply_gunpowder_explosion().
+        if was_gunpowder_solid && particle.phase() == shared::material::PHASE_GAS {
+            apply_gunpowder_explosion_cpu(particle);
+        }
     }
+}
+
+/// Apply gunpowder explosion velocity and temperature boost (CPU side).
+///
+/// Uses particle position as a seed for pseudo-random direction.
+/// Matches the shader implementation in g2p.rs `apply_gunpowder_explosion()`.
+fn apply_gunpowder_explosion_cpu(particle: &mut Particle) {
+    let pos = particle.position();
+    let px = pos.x;
+    let py = pos.y;
+    let pz = pos.z;
+
+    // Hash each axis with different seeds (matches shader hash_f32 logic)
+    let hx = hash_f32_cpu(px * 73.17 + pz * 37.91);
+    let hy = hash_f32_cpu(py * 127.31 + px * 53.47);
+    let hz = hash_f32_cpu(pz * 91.53 + py * 67.13);
+
+    let explosion_speed = 150.0_f32;
+    let gs = shared::constants::GRID_SIZE as f32;
+
+    // Convert grid-space velocity to world-space (divide by grid size)
+    let vel = Vec3::new(
+        hx * explosion_speed / gs,
+        hy.abs() * explosion_speed / gs + 80.0 / gs,
+        hz * explosion_speed / gs,
+    );
+    particle.set_velocity(vel);
+    particle.set_temperature(3000.0);
+}
+
+/// CPU-side pseudo-random hash matching shader hash_f32.
+///
+/// Reinterprets float bits and applies xorshift mixing.
+fn hash_f32_cpu(x: f32) -> f32 {
+    let mut bits = x.to_bits();
+    bits ^= bits >> 16;
+    bits = bits.wrapping_mul(0x45d9f3b);
+    bits ^= bits >> 16;
+    (bits & 0xFFFF) as f32 / 32768.0 - 1.0
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- **Thermal blend 0.005/step** (was instant 1.0): lava cools to solidification in ~3-5s, not instantly. Closes #170.
- **Gunpowder explosion velocity**: pseudo-random outward velocity (150 grid-units/s) using xorshift hash. Calibrated against gravity for visible debris arc (~30-60 grid units). Closes #169.
- **Gas thermal pressure**: hot gas (T>100) expands with pressure `temp * 0.05`, capped at 200. Drives explosion shockwave.
- **Radiative cooling**: Newton's cooling law (0.002/step toward 20C ambient) prevents thermal runaway from repeated explosions.
- **Ignition threshold sync**: gunpowder at 150C in both shader and shared (was 200C in shared).
- **Server build.rs**: `rerun-if-changed` for shader source directory.

All changes synced between GPU shaders and CPU sim-cpu reference implementation.

## Test plan

- [x] `cargo test -p shared` — 51 tests pass (incl. phase transition threshold)
- [x] `cargo test -p sim-cpu --lib` — 28 tests pass (incl. `lava_cools_to_stone`, `thermal_diffusion_through_grid`)
- [x] `cargo build -p server` — shader SPIR-V compilation succeeds
- [ ] Visual smoke test: lava placed on stone floor should cool and solidify in ~3-5 seconds
- [ ] Visual smoke test: gunpowder explosion should produce visible outward debris, not just float away
- [ ] Verify no thermal runaway: repeated explosions should cool down over time

Closes #170
Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)