### PR TITLE
feat: data-driven phase transitions via reaction table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,12 @@ Scene must produce particles under MAX_PARTICLES. Never hand off broken builds.
 G2P skips velocity/position update for phase=0 (solid). Falling solids check voxel below for support.
 Explosion debris must be converted to liquid (phase=1) + heated above melting point to fly properly.
 
+### 21. No references to storage buffer elements inside loops
+Taking `&buffer[i]` inside a `while` loop generates an `OpPhi` with pointer operands in SPIR-V,
+which requires `VariablePointers` capability that we don't enable. **WORKAROUND:** Copy the struct
+fields into local variables instead: `let mat = buffer[i].materials; let cond = buffer[i].conditions;`
+This avoids the phi node and works without extra capabilities.
+
 ### 20. Shader build.rs must track shader source files
 spirv-builder compiles shaders in a **separate** cargo invocation inside `crates/server/build.rs`.
 Cargo's build-script caching only watches files the build script itself reads, so it has no idea

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -21,6 +21,7 @@ use gpu_core::{
 use shared::{
     GRID_CELL_COUNT, GRID_SIZE, GridCell, MAX_PARTICLES, Particle, RENDER_HEIGHT, RENDER_WIDTH,
     material::{self, MATERIAL_COUNT, MaterialParams},
+    reaction::{self, MAX_PHASE_RULES, PhaseTransitionRule},
 };
 
 /// Compiled SPIR-V shader module bytes, included at compile time.
@@ -68,8 +69,8 @@ pub struct G2pPushConstants {
     pub dt: f32,
     /// Total number of active particles.
     pub num_particles: u32,
-    /// Padding to 16-byte alignment.
-    pub _pad: u32,
+    /// Number of valid phase transition rules.
+    pub num_rules: u32,
 }
 
 /// Push constants for the voxelize / clear_voxels shaders.
@@ -200,6 +201,7 @@ pub struct GpuSimulation {
     voxel_buffer: GpuBuffer,
     render_output_buffer: GpuBuffer,
     material_buffer: GpuBuffer,
+    reaction_buffer: GpuBuffer,
 
     // Compute passes
     clear_grid_pass: ComputePass,
@@ -221,6 +223,7 @@ pub struct GpuSimulation {
 
     // State
     num_particles: u32,
+    num_phase_rules: u32,
 
     // Reference to context (not owned — caller must keep alive)
     // We store raw device handle for recording commands; the context
@@ -300,11 +303,30 @@ impl GpuSimulation {
             material_buf_size
         );
 
+        // Phase transition rules buffer: MAX_PHASE_RULES * 32 bytes
+        let reaction_buf_size =
+            (MAX_PHASE_RULES * mem::size_of::<PhaseTransitionRule>()) as vk::DeviceSize;
+        let reaction_buffer = buffer::create_device_local_buffer(
+            ctx,
+            reaction_buf_size,
+            vk::BufferUsageFlags::STORAGE_BUFFER,
+            "reaction-buffer",
+        )?;
+
+        // Upload default phase transition table
+        let (reaction_table, num_phase_rules) = reaction::default_phase_transition_table();
+        buffer::upload(ctx, &reaction_table, &reaction_buffer)?;
+        tracing::info!(
+            "Uploaded {} phase transition rules ({} bytes) to GPU",
+            num_phase_rules,
+            reaction_buf_size
+        );
+
         // -- Descriptor pool --
-        // 10 passes, max 3 bindings each = up to 30 storage buffer descriptors
+        // 10 passes, max 4 bindings each = up to 40 storage buffer descriptors
         let pool_sizes = [vk::DescriptorPoolSize {
             ty: vk::DescriptorType::STORAGE_BUFFER,
-            descriptor_count: 30,
+            descriptor_count: 40,
         }];
         let descriptor_pool =
             pipeline::create_descriptor_pool(ctx, &pool_sizes, 10, "sim-descriptor-pool")?;
@@ -345,7 +367,7 @@ impl GpuSimulation {
             ctx,
             shader_module,
             c"compute::g2p::g2p",
-            &[&particle_buffer, &grid_buffer, &voxel_buffer],
+            &[&particle_buffer, &grid_buffer, &voxel_buffer, &reaction_buffer],
             mem::size_of::<G2pPushConstants>() as u32,
             descriptor_pool,
             "g2p",
@@ -419,6 +441,7 @@ impl GpuSimulation {
             voxel_buffer,
             render_output_buffer,
             material_buffer,
+            reaction_buffer,
             clear_grid_pass,
             p2g_pass,
             grid_update_pass,
@@ -432,6 +455,7 @@ impl GpuSimulation {
             shader_module,
             descriptor_pool,
             num_particles: 0,
+            num_phase_rules: num_phase_rules as u32,
             device: ctx.device.clone(),
         })
     }
@@ -512,7 +536,7 @@ impl GpuSimulation {
             grid_size,
             dt,
             num_particles,
-            _pad: 0,
+            num_rules: self.num_phase_rules,
         };
         self.dispatch(
             cmd,
@@ -963,11 +987,20 @@ impl GpuSimulation {
                 size: 0,
             },
         );
+        let reaction_buf = std::mem::replace(
+            &mut self.reaction_buffer,
+            GpuBuffer {
+                buffer: vk::Buffer::null(),
+                allocation: None,
+                size: 0,
+            },
+        );
         buffer::destroy_buffer(ctx, particle_buf);
         buffer::destroy_buffer(ctx, grid_buf);
         buffer::destroy_buffer(ctx, voxel_buf);
         buffer::destroy_buffer(ctx, render_output_buf);
         buffer::destroy_buffer(ctx, material_buf);
+        buffer::destroy_buffer(ctx, reaction_buf);
     }
 }
 

--- a/crates/shaders/src/compute/g2p.rs
+++ b/crates/shaders/src/compute/g2p.rs
@@ -5,7 +5,7 @@
 //! Updates particle velocity (PIC/FLIP blend), temperature, APIC C matrix,
 //! deformation gradient F, position, and phase transitions.
 
-use crate::types::{GridCell, Particle};
+use crate::types::{GridCell, Particle, PhaseTransitionRule, FLAG_EXPLOSION, FLAG_RESET_F, MAX_PHASE_RULES};
 use spirv_std::glam::{UVec3, Vec3, Vec4};
 use spirv_std::spirv;
 
@@ -21,8 +21,8 @@ pub struct G2pPushConstants {
     pub dt: f32,
     /// Total number of particles.
     pub num_particles: u32,
-    /// Padding for alignment.
-    pub _pad: u32,
+    /// Number of valid phase transition rules.
+    pub num_rules: u32,
 }
 
 /// PIC/FLIP blend ratio (0.0 = pure FLIP, 1.0 = pure PIC).
@@ -76,7 +76,7 @@ pub fn check_solid_support(pos: spirv_std::glam::Vec3, voxels: &[u32], grid_size
 /// 3. Compute APIC affine momentum matrix C
 /// 4. Update deformation gradient F
 /// 5. Advect position
-/// 6. Check phase transitions by temperature
+/// 6. Check phase transitions by temperature (data-driven via reaction table)
 ///
 /// For solid particles (phase==0), checks support from the voxel below.
 /// Supported solids update only F/C (pinned). Unsupported solids fall normally.
@@ -84,8 +84,10 @@ pub fn gather_particle(
     particle: &mut Particle,
     grid: &[GridCell],
     voxels: &[u32],
+    reactions: &[PhaseTransitionRule],
     grid_size: u32,
     dt: f32,
+    num_rules: u32,
 ) {
     let pos = particle.pos_mass.truncate();
     let old_vel = particle.vel_temp.truncate();
@@ -248,7 +250,7 @@ pub fn gather_particle(
             particle.vel_temp = Vec4::new(
                 particle.vel_temp.x, particle.vel_temp.y, particle.vel_temp.z, new_temp,
             );
-            apply_phase_transitions(particle);
+            apply_phase_transitions(particle, reactions, num_rules);
             return;
         }
         // Unsupported: fall through to position/velocity update below
@@ -264,8 +266,8 @@ pub fn gather_particle(
     particle.c_col1 = c_col1.extend(0.0);
     particle.c_col2 = c_col2.extend(0.0);
 
-    // Phase transitions by temperature
-    apply_phase_transitions(particle);
+    // Phase transitions by temperature (data-driven)
+    apply_phase_transitions(particle, reactions, num_rules);
 }
 
 /// Apply radiative cooling (Newton's cooling law) to a temperature value.
@@ -316,7 +318,7 @@ fn apply_gunpowder_explosion(particle: &mut Particle) {
     let hz = hash_f32(pz * 91.53 + py * 67.13);
 
     // Explosion speed: 150 grid-units/s.
-    // Against gravity=-196, max vertical rise = v^2/(2*g) ≈ 57 grid units.
+    // Against gravity=-196, max vertical rise = v^2/(2*g) ~ 57 grid units.
     // Horizontal spread is unimpeded. Good visual for 256-grid.
     let explosion_speed = 150.0_f32;
     particle.vel_temp = Vec4::new(
@@ -331,73 +333,71 @@ fn apply_gunpowder_explosion(particle: &mut Particle) {
     particle.f_col2 = Vec4::new(0.0, 0.0, 1.0, 0.0);
 }
 
-/// Check and apply phase transitions based on temperature thresholds.
+/// Check and apply phase transitions using the data-driven reaction table.
 ///
-/// - Stone (mat=0) T > 1500 -> Liquid (lava, mat=2)
-/// - Water (mat=1) T > 100 -> Gas (steam)
-/// - Water (mat=1) T < 0 -> Solid (ice, mat=5)
-/// - Lava (mat=2) T < 1500 -> Solid (stone, mat=0)
-/// - Ice (mat=5) T > 0 -> Liquid (water, mat=1)
+/// Loops over the reaction rules and applies the first matching rule.
+/// This replaces the previous hardcoded match block, avoiding trap #15
+/// (rust-gpu drops later branches in long if/else chains).
 ///
 /// On phase change: reset F = Identity, as per CLAUDE.md trap #8.
-pub fn apply_phase_transitions(particle: &mut Particle) {
+pub fn apply_phase_transitions(
+    particle: &mut Particle,
+    reactions: &[PhaseTransitionRule],
+    num_rules: u32,
+) {
     let material_id = particle.ids.x;
     let phase = particle.ids.y;
     let temp = particle.vel_temp.w;
 
-    let mut new_phase = phase;
-    let mut new_material = material_id;
+    let count = if (num_rules as usize) < MAX_PHASE_RULES {
+        num_rules
+    } else {
+        MAX_PHASE_RULES as u32
+    };
 
-    match material_id {
-        // Stone
-        0 => {
-            if phase == 0 && temp > 1500.0 {
-                new_phase = 1; // solid -> liquid (becomes lava)
-                new_material = 2; // MAT_LAVA
-            }
-        }
-        // Water
-        1 => {
-            if phase == 1 && temp > 100.0 {
-                new_phase = 2; // liquid -> gas (steam)
-            } else if phase == 1 && temp < 0.0 {
-                new_phase = 0; // liquid -> solid (ice)
-                new_material = 5; // MAT_ICE
-            }
-        }
-        // Lava
-        2 => {
-            if phase == 1 && temp < 1500.0 {
-                new_phase = 0; // liquid -> solid (becomes stone)
-                new_material = 0; // MAT_STONE
-            }
-        }
-        // Ice
-        5 => {
-            if phase == 0 && temp > 0.0 {
-                new_phase = 1; // solid -> liquid (melts to water)
-                new_material = 1; // MAT_WATER
-            }
-        }
-        // Gunpowder
-        6 => {
-            if phase == 0 && temp > 150.0 {
-                new_phase = 2; // solid -> gas (explosion)
-                // Explosion: outward velocity with pseudo-random direction per particle.
-                apply_gunpowder_explosion(particle);
-            }
-        }
-        _ => {}
-    }
+    let mut i = 0u32;
+    while i < count {
+        // Copy values out of storage buffer to avoid OpPhi pointer issues
+        // in SPIR-V (rust-gpu generates phi nodes for &reactions[i] across loop iterations).
+        let rule_materials = reactions[i as usize].materials;
+        let rule_conditions = reactions[i as usize].conditions;
+        if rule_materials.x == material_id && rule_materials.y == phase {
+            let temp_min = rule_conditions.x;
+            let temp_max = rule_conditions.y;
+            if temp > temp_min && temp < temp_max {
+                let flags = rule_conditions.z as u32;
+                let new_material = rule_materials.z;
+                let new_phase = rule_materials.w;
 
-    if new_phase != phase || new_material != material_id {
-        particle.ids.x = new_material;
-        particle.ids.y = new_phase;
-        // Reset deformation gradient on phase change (CLAUDE.md trap #8)
-        particle.f_col0 = Vec4::new(1.0, 0.0, 0.0, 0.0);
-        particle.f_col1 = Vec4::new(0.0, 1.0, 0.0, 0.0);
-        particle.f_col2 = Vec4::new(0.0, 0.0, 1.0, 0.0);
+                // Apply transition
+                particle.ids.x = new_material;
+                particle.ids.y = new_phase;
+
+                // Reset F if flag is set (trap #8)
+                if flags & FLAG_RESET_F != 0 {
+                    reset_deformation_gradient(particle);
+                }
+
+                // Apply explosion if flag is set
+                if flags & FLAG_EXPLOSION != 0 {
+                    apply_gunpowder_explosion(particle);
+                }
+
+                return;
+            }
+        }
+        i += 1;
     }
+}
+
+/// Reset the deformation gradient F to identity.
+///
+/// Helper function extracted to satisfy trap #4a (entry points must call
+/// at least one helper function).
+fn reset_deformation_gradient(particle: &mut Particle) {
+    particle.f_col0 = Vec4::new(1.0, 0.0, 0.0, 0.0);
+    particle.f_col1 = Vec4::new(0.0, 1.0, 0.0, 0.0);
+    particle.f_col2 = Vec4::new(0.0, 0.0, 1.0, 0.0);
 }
 
 /// Compute shader entry point: Grid-to-Particle transfer.
@@ -405,6 +405,7 @@ pub fn apply_phase_transitions(particle: &mut Particle) {
 /// Descriptor set 0, binding 0: storage buffer of `Particle` (read-write).
 /// Descriptor set 0, binding 1: storage buffer of `GridCell` (read).
 /// Descriptor set 0, binding 2: storage buffer of `u32` (voxel grid, 4 per cell, read).
+/// Descriptor set 0, binding 3: storage buffer of `PhaseTransitionRule` (read).
 /// Push constants: `G2pPushConstants`.
 /// Dispatch with `(ceil(num_particles / 64), 1, 1)` workgroups.
 #[spirv(compute(threads(64)))]
@@ -414,10 +415,19 @@ pub fn g2p(
     #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] particles: &mut [Particle],
     #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] grid: &[GridCell],
     #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] voxels: &[u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] reactions: &[PhaseTransitionRule],
 ) {
     let idx = id.x as usize;
     if id.x >= push.num_particles {
         return;
     }
-    gather_particle(&mut particles[idx], grid, voxels, push.grid_size, push.dt);
+    gather_particle(
+        &mut particles[idx],
+        grid,
+        voxels,
+        reactions,
+        push.grid_size,
+        push.dt,
+        push.num_rules,
+    );
 }

--- a/crates/shaders/src/types.rs
+++ b/crates/shaders/src/types.rs
@@ -99,3 +99,25 @@ pub const MAT_GUNPOWDER: u32 = 6;
 
 /// Number of materials in the table (synced with shared::material).
 pub const MATERIAL_COUNT: usize = 7;
+
+/// Maximum number of phase transition rules (synced with shared::reaction).
+pub const MAX_PHASE_RULES: usize = 16;
+
+/// Flags for phase transition behavior (synced with shared::reaction).
+pub const FLAG_RESET_F: u32 = 1;
+/// Flag to apply explosion behavior on transition.
+pub const FLAG_EXPLOSION: u32 = 2;
+
+/// A single phase transition rule. 32 bytes, 16-byte aligned.
+///
+/// Mirrors `shared::reaction::PhaseTransitionRule` layout exactly.
+/// - `materials`: x=from_material, y=from_phase, z=to_material, w=to_phase
+/// - `conditions`: x=temp_min, y=temp_max, z=flags (as f32), w=pad
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct PhaseTransitionRule {
+    /// x = from_material_id, y = from_phase, z = to_material_id, w = to_phase.
+    pub materials: UVec4,
+    /// x = temp_min, y = temp_max, z = flags (as f32), w = pad.
+    pub conditions: Vec4,
+}

--- a/crates/shared/src/phase.rs
+++ b/crates/shared/src/phase.rs
@@ -1,17 +1,14 @@
 //! Phase transition rules for MPM particles.
 //!
-//! Defines temperature-based phase transitions:
-//! - Stone T > 1500 -> Lava (liquid)
-//! - Water T > 100 -> Steam (gas)
-//! - Water T < 0 -> Ice (solid)
-//! - Lava T < 1500 -> Stone (solid)
-//! - Gunpowder T > 150 -> Gas (explosion)
+//! Uses data-driven phase transition table from `reaction::PhaseTransitionRule`.
+//! No more hardcoded match blocks — adding a new material only requires
+//! adding a rule to `default_phase_transition_table()`.
 //!
 //! On transition: reset F = Identity, damage = 0, update phase.
 
 use crate::{
-    material::{MAT_GUNPOWDER, MAT_ICE, MAT_LAVA, MAT_STONE, MAT_WATER, PHASE_GAS, PHASE_LIQUID, PHASE_SOLID},
     particle::Particle,
+    reaction::PhaseTransitionRule,
 };
 
 /// Result of checking a phase transition for a particle.
@@ -25,73 +22,59 @@ pub enum PhaseTransition {
         new_material_id: u32,
         /// New phase after transition.
         new_phase: u32,
+        /// Behavior flags (bit 0 = reset_F, bit 1 = explosion).
+        flags: u32,
     },
 }
 
 /// Check if a particle should undergo a phase transition based on temperature.
 ///
-/// Returns the transition result (either no change or new material/phase).
+/// Iterates over the provided reaction rules and returns the first matching
+/// transition. Rules are matched by (material_id, phase) and temperature range.
 ///
-/// # Rules
-/// - Stone (material=0, phase=solid) + T > 1500 -> Lava (material=2, phase=liquid)
-/// - Water (material=1, phase=liquid) + T > 100 -> Steam (material=1, phase=gas)
-/// - Water (material=1, phase=liquid) + T < 0 -> Ice (material=5, phase=solid)
-/// - Lava (material=2, phase=liquid) + T < 1500 -> Stone (material=0, phase=solid)
-/// - Ice (material=5, phase=solid) + T > 0 -> Water (material=1, phase=liquid)
-/// - Gunpowder (material=6, phase=solid) + T > 200 -> Gas (material=6, phase=gas) [explosion]
-pub fn check_phase_transition(particle: &Particle) -> PhaseTransition {
+/// # Arguments
+/// - `particle`: the particle to check
+/// - `rules`: phase transition rule table (slice of valid entries)
+pub fn check_phase_transition(
+    particle: &Particle,
+    rules: &[PhaseTransitionRule],
+) -> PhaseTransition {
     let mat_id = particle.material_id();
     let phase = particle.phase();
     let temp = particle.temperature();
 
-    match (mat_id, phase) {
-        // Stone solid -> Lava liquid when T > 1500
-        (MAT_STONE, PHASE_SOLID) if temp > 1500.0 => PhaseTransition::Transition {
-            new_material_id: MAT_LAVA,
-            new_phase: PHASE_LIQUID,
-        },
-        // Water liquid -> Steam gas when T > 100
-        (MAT_WATER, PHASE_LIQUID) if temp > 100.0 => PhaseTransition::Transition {
-            new_material_id: MAT_WATER,
-            new_phase: PHASE_GAS,
-        },
-        // Water liquid -> Ice solid when T < 0
-        (MAT_WATER, PHASE_LIQUID) if temp < 0.0 => PhaseTransition::Transition {
-            new_material_id: MAT_ICE,
-            new_phase: PHASE_SOLID,
-        },
-        // Ice solid -> Water liquid when T > 0
-        (MAT_ICE, PHASE_SOLID) if temp > 0.0 => PhaseTransition::Transition {
-            new_material_id: MAT_WATER,
-            new_phase: PHASE_LIQUID,
-        },
-        // Lava liquid -> Stone solid when T < 1500
-        (MAT_LAVA, PHASE_LIQUID) if temp < 1500.0 => PhaseTransition::Transition {
-            new_material_id: MAT_STONE,
-            new_phase: PHASE_SOLID,
-        },
-        // Gunpowder solid -> Gas when T > 200 (explosion)
-        (MAT_GUNPOWDER, PHASE_SOLID) if temp > 150.0 => PhaseTransition::Transition {
-            new_material_id: MAT_GUNPOWDER,
-            new_phase: PHASE_GAS,
-        },
-        _ => PhaseTransition::None,
+    for rule in rules {
+        if rule.materials.x == mat_id && rule.materials.y == phase {
+            let temp_min = rule.conditions.x;
+            let temp_max = rule.conditions.y;
+            if temp > temp_min && temp < temp_max {
+                return PhaseTransition::Transition {
+                    new_material_id: rule.materials.z,
+                    new_phase: rule.materials.w,
+                    flags: rule.conditions.z as u32,
+                };
+            }
+        }
     }
+    PhaseTransition::None
 }
 
 /// Apply a phase transition to a particle.
 ///
-/// Resets deformation gradient to identity and damage to 0.
+/// Resets deformation gradient to identity and damage to 0 if FLAG_RESET_F is set.
 /// See CLAUDE.md trap #8: F must be reset on phase transition.
 pub fn apply_phase_transition(particle: &mut Particle, transition: PhaseTransition) {
     if let PhaseTransition::Transition {
         new_material_id,
         new_phase,
+        flags,
     } = transition
     {
         particle.ids.x = new_material_id;
         particle.set_phase(new_phase);
-        particle.reset_deformation_gradient();
+        if flags & crate::reaction::FLAG_RESET_F != 0 {
+            particle.reset_deformation_gradient();
+        }
         particle.set_damage(0.0);
     }
 }
@@ -101,17 +84,30 @@ mod tests {
     use glam::Vec3;
 
     use super::*;
+    use crate::material::{
+        MAT_GUNPOWDER, MAT_ICE, MAT_LAVA, MAT_STONE, MAT_WATER, PHASE_GAS, PHASE_LIQUID,
+        PHASE_SOLID,
+    };
+    use crate::reaction::{default_phase_transition_table, FLAG_EXPLOSION, FLAG_RESET_F};
+
+    /// Helper: get the valid rules slice from the default table.
+    fn rules() -> &'static [PhaseTransitionRule] {
+        static RULES: std::sync::LazyLock<([PhaseTransitionRule; 16], usize)> =
+            std::sync::LazyLock::new(default_phase_transition_table);
+        &RULES.0[..RULES.1]
+    }
 
     #[test]
     fn stone_melts_to_lava() {
         let mut p = Particle::new(Vec3::ZERO, 1.0, MAT_STONE, PHASE_SOLID);
         p.set_temperature(1600.0);
-        let tr = check_phase_transition(&p);
+        let tr = check_phase_transition(&p, rules());
         assert_eq!(
             tr,
             PhaseTransition::Transition {
                 new_material_id: MAT_LAVA,
                 new_phase: PHASE_LIQUID,
+                flags: FLAG_RESET_F,
             }
         );
     }
@@ -120,19 +116,20 @@ mod tests {
     fn stone_stays_solid_below_melting() {
         let mut p = Particle::new(Vec3::ZERO, 1.0, MAT_STONE, PHASE_SOLID);
         p.set_temperature(1000.0);
-        assert_eq!(check_phase_transition(&p), PhaseTransition::None);
+        assert_eq!(check_phase_transition(&p, rules()), PhaseTransition::None);
     }
 
     #[test]
     fn water_boils_to_steam() {
         let mut p = Particle::new(Vec3::ZERO, 1.0, MAT_WATER, PHASE_LIQUID);
         p.set_temperature(101.0);
-        let tr = check_phase_transition(&p);
+        let tr = check_phase_transition(&p, rules());
         assert_eq!(
             tr,
             PhaseTransition::Transition {
                 new_material_id: MAT_WATER,
                 new_phase: PHASE_GAS,
+                flags: FLAG_RESET_F,
             }
         );
     }
@@ -141,12 +138,13 @@ mod tests {
     fn water_freezes_to_ice() {
         let mut p = Particle::new(Vec3::ZERO, 1.0, MAT_WATER, PHASE_LIQUID);
         p.set_temperature(-5.0);
-        let tr = check_phase_transition(&p);
+        let tr = check_phase_transition(&p, rules());
         assert_eq!(
             tr,
             PhaseTransition::Transition {
                 new_material_id: MAT_ICE,
                 new_phase: PHASE_SOLID,
+                flags: FLAG_RESET_F,
             }
         );
     }
@@ -155,12 +153,13 @@ mod tests {
     fn ice_melts_to_water() {
         let mut p = Particle::new(Vec3::ZERO, 1.0, MAT_ICE, PHASE_SOLID);
         p.set_temperature(5.0);
-        let tr = check_phase_transition(&p);
+        let tr = check_phase_transition(&p, rules());
         assert_eq!(
             tr,
             PhaseTransition::Transition {
                 new_material_id: MAT_WATER,
                 new_phase: PHASE_LIQUID,
+                flags: FLAG_RESET_F,
             }
         );
     }
@@ -169,12 +168,13 @@ mod tests {
     fn lava_solidifies_to_stone() {
         let mut p = Particle::new(Vec3::ZERO, 1.0, MAT_LAVA, PHASE_LIQUID);
         p.set_temperature(1400.0);
-        let tr = check_phase_transition(&p);
+        let tr = check_phase_transition(&p, rules());
         assert_eq!(
             tr,
             PhaseTransition::Transition {
                 new_material_id: MAT_STONE,
                 new_phase: PHASE_SOLID,
+                flags: FLAG_RESET_F,
             }
         );
     }
@@ -183,12 +183,13 @@ mod tests {
     fn gunpowder_explodes_to_gas() {
         let mut p = Particle::new(Vec3::ZERO, 1.0, MAT_GUNPOWDER, PHASE_SOLID);
         p.set_temperature(250.0);
-        let tr = check_phase_transition(&p);
+        let tr = check_phase_transition(&p, rules());
         assert_eq!(
             tr,
             PhaseTransition::Transition {
                 new_material_id: MAT_GUNPOWDER,
                 new_phase: PHASE_GAS,
+                flags: FLAG_RESET_F | FLAG_EXPLOSION,
             }
         );
     }
@@ -197,19 +198,18 @@ mod tests {
     fn gunpowder_stays_solid_below_ignition() {
         let mut p = Particle::new(Vec3::ZERO, 1.0, MAT_GUNPOWDER, PHASE_SOLID);
         p.set_temperature(100.0);
-        assert_eq!(check_phase_transition(&p), PhaseTransition::None);
+        assert_eq!(check_phase_transition(&p, rules()), PhaseTransition::None);
     }
 
     #[test]
     fn apply_transition_resets_f_and_damage() {
         let mut p = Particle::new(Vec3::ZERO, 1.0, MAT_STONE, PHASE_SOLID);
         p.set_temperature(1600.0);
-        // Give it some deformation and damage
         use glam::Mat3;
         p.set_deformation_gradient(Mat3::from_diagonal(Vec3::new(1.5, 0.8, 1.2)));
         p.set_damage(0.7);
 
-        let tr = check_phase_transition(&p);
+        let tr = check_phase_transition(&p, rules());
         apply_phase_transition(&mut p, tr);
 
         assert_eq!(p.material_id(), MAT_LAVA);

--- a/crates/shared/src/reaction.rs
+++ b/crates/shared/src/reaction.rs
@@ -1,10 +1,101 @@
-//! Chemical reaction rules for particle interactions.
+//! Data-driven phase transition and chemical reaction rules.
 //!
-//! Reactions are checked when particles of different materials are in contact
-//! (overlapping grid cells). Each rule specifies two reactant materials and
-//! what they transform into.
+//! Phase transitions (temperature-based) and chemical reactions (contact-based)
+//! are encoded as GPU-friendly `PhaseTransitionRule` and `ReactionRule` structs.
+//! This replaces hardcoded match blocks and enables adding new materials
+//! without editing code in multiple places.
 
-/// A chemical reaction rule.
+use bytemuck::{Pod, Zeroable};
+use glam::{UVec4, Vec4};
+
+use crate::material::{
+    MAT_GUNPOWDER, MAT_ICE, MAT_LAVA, MAT_STONE, MAT_WATER, PHASE_GAS, PHASE_LIQUID, PHASE_SOLID,
+};
+
+/// Maximum number of phase transition rules in the table.
+pub const MAX_PHASE_RULES: usize = 16;
+
+/// Flags for phase transition behavior.
+///
+/// - Bit 0 (1): Reset deformation gradient F to identity.
+/// - Bit 1 (2): Apply gunpowder-style explosion (outward velocity + temp boost).
+pub const FLAG_RESET_F: u32 = 1;
+/// Flag to apply explosion behavior on transition.
+pub const FLAG_EXPLOSION: u32 = 2;
+
+/// A single phase transition rule. 32 bytes, 16-byte aligned.
+///
+/// GPU-friendly struct that encodes: "if a particle has material X in phase Y,
+/// and its temperature satisfies `temp_min < T < temp_max`, transition to
+/// material Z in phase W."
+///
+/// - `materials`: x=from_material, y=from_phase, z=to_material, w=to_phase
+/// - `conditions`: x=temp_min, y=temp_max, z=flags (as f32), w=pad
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Pod, Zeroable)]
+pub struct PhaseTransitionRule {
+    /// x = from_material_id, y = from_phase, z = to_material_id, w = to_phase.
+    pub materials: UVec4,
+    /// x = temp_min (trigger if T > this), y = temp_max (trigger if T < this),
+    /// z = flags (bit 0 = reset_F, bit 1 = explosion), w = pad.
+    pub conditions: Vec4,
+}
+
+/// Build the default phase transition table.
+///
+/// Returns a fixed-size array and the count of valid entries.
+/// Entries beyond `count` are zeroed.
+///
+/// # Rules
+/// - Stone (solid) + T > 1500 -> Lava (liquid)
+/// - Water (liquid) + T > 100 -> Steam (gas)
+/// - Water (liquid) + T < 0 -> Ice (solid)
+/// - Ice (solid) + T > 0 -> Water (liquid)
+/// - Lava (liquid) + T < 1500 -> Stone (solid)
+/// - Gunpowder (solid) + T > 150 -> Gas (explosion)
+pub fn default_phase_transition_table() -> ([PhaseTransitionRule; MAX_PHASE_RULES], usize) {
+    let mut table = [PhaseTransitionRule::zeroed(); MAX_PHASE_RULES];
+
+    // Stone (solid) + T > 1500 -> Lava (liquid)
+    table[0] = PhaseTransitionRule {
+        materials: UVec4::new(MAT_STONE, PHASE_SOLID, MAT_LAVA, PHASE_LIQUID),
+        conditions: Vec4::new(1500.0, f32::MAX, FLAG_RESET_F as f32, 0.0),
+    };
+    // Water (liquid) + T > 100 -> Steam (gas)
+    table[1] = PhaseTransitionRule {
+        materials: UVec4::new(MAT_WATER, PHASE_LIQUID, MAT_WATER, PHASE_GAS),
+        conditions: Vec4::new(100.0, f32::MAX, FLAG_RESET_F as f32, 0.0),
+    };
+    // Water (liquid) + T < 0 -> Ice (solid)
+    table[2] = PhaseTransitionRule {
+        materials: UVec4::new(MAT_WATER, PHASE_LIQUID, MAT_ICE, PHASE_SOLID),
+        conditions: Vec4::new(f32::MIN, 0.0, FLAG_RESET_F as f32, 0.0),
+    };
+    // Ice (solid) + T > 0 -> Water (liquid)
+    table[3] = PhaseTransitionRule {
+        materials: UVec4::new(MAT_ICE, PHASE_SOLID, MAT_WATER, PHASE_LIQUID),
+        conditions: Vec4::new(0.0, f32::MAX, FLAG_RESET_F as f32, 0.0),
+    };
+    // Lava (liquid) + T < 1500 -> Stone (solid)
+    table[4] = PhaseTransitionRule {
+        materials: UVec4::new(MAT_LAVA, PHASE_LIQUID, MAT_STONE, PHASE_SOLID),
+        conditions: Vec4::new(f32::MIN, 1500.0, FLAG_RESET_F as f32, 0.0),
+    };
+    // Gunpowder (solid) + T > 150 -> Gas (explosion)
+    table[5] = PhaseTransitionRule {
+        materials: UVec4::new(MAT_GUNPOWDER, PHASE_SOLID, MAT_GUNPOWDER, PHASE_GAS),
+        conditions: Vec4::new(
+            150.0,
+            f32::MAX,
+            (FLAG_RESET_F | FLAG_EXPLOSION) as f32,
+            0.0,
+        ),
+    };
+
+    (table, 6)
+}
+
+/// A chemical reaction rule (contact-based, between two particles).
 ///
 /// When `reactant_a` contacts `reactant_b`, they transform into
 /// `product_a` and `product_b` respectively.
@@ -30,7 +121,7 @@ pub struct ReactionRule {
     pub product_b_temp: f32,
 }
 
-/// Build the default reaction table.
+/// Build the default chemical reaction table.
 ///
 /// Currently includes:
 /// - Water + Lava -> Stone + Steam (instant contact reaction)
@@ -38,15 +129,15 @@ pub fn default_reaction_table() -> &'static [ReactionRule] {
     &[
         // Water + Lava -> Stone + Steam
         ReactionRule {
-            reactant_a_material: crate::material::MAT_WATER,
-            reactant_b_material: crate::material::MAT_LAVA,
-            product_a_material: crate::material::MAT_STONE,
-            product_a_phase: crate::material::PHASE_SOLID,
-            product_b_material: crate::material::MAT_WATER,
-            product_b_phase: crate::material::PHASE_GAS,
+            reactant_a_material: MAT_WATER,
+            reactant_b_material: MAT_LAVA,
+            product_a_material: MAT_STONE,
+            product_a_phase: PHASE_SOLID,
+            product_b_material: MAT_WATER,
+            product_b_phase: PHASE_GAS,
             min_temperature: f32::MIN,
-            product_a_temp: 300.0, // cooled stone
-            product_b_temp: 100.0, // steam at boiling point
+            product_a_temp: 300.0,
+            product_b_temp: 100.0,
         },
     ]
 }
@@ -75,6 +166,47 @@ pub fn find_reaction(
 mod tests {
     use super::*;
     use crate::material::{MAT_LAVA, MAT_STONE, MAT_WATER};
+
+    #[test]
+    fn phase_transition_rule_layout() {
+        assert_eq!(size_of::<PhaseTransitionRule>(), 32);
+        assert_eq!(align_of::<PhaseTransitionRule>(), 16);
+    }
+
+    #[test]
+    fn default_table_has_six_rules() {
+        let (table, count) = default_phase_transition_table();
+        assert_eq!(count, 6);
+        // Remaining entries should be zeroed
+        for i in count..MAX_PHASE_RULES {
+            assert_eq!(table[i].materials, UVec4::ZERO);
+        }
+    }
+
+    #[test]
+    fn default_table_bytemuck_cast() {
+        let (table, _) = default_phase_transition_table();
+        let bytes: &[u8] = bytemuck::cast_slice(&table);
+        assert_eq!(bytes.len(), MAX_PHASE_RULES * 32);
+    }
+
+    #[test]
+    fn stone_melting_rule() {
+        let (table, _) = default_phase_transition_table();
+        assert_eq!(table[0].materials.x, MAT_STONE);
+        assert_eq!(table[0].materials.y, PHASE_SOLID);
+        assert_eq!(table[0].materials.z, MAT_LAVA);
+        assert_eq!(table[0].materials.w, PHASE_LIQUID);
+        assert_eq!(table[0].conditions.x, 1500.0);
+    }
+
+    #[test]
+    fn gunpowder_has_explosion_flag() {
+        let (table, _) = default_phase_transition_table();
+        let gp_flags = table[5].conditions.z as u32;
+        assert_ne!(gp_flags & FLAG_EXPLOSION, 0);
+        assert_ne!(gp_flags & FLAG_RESET_F, 0);
+    }
 
     #[test]
     fn find_water_lava_reaction() {

--- a/crates/sim-cpu/src/test_world.rs
+++ b/crates/sim-cpu/src/test_world.rs
@@ -9,6 +9,7 @@ use shared::{
     constants::{DT, GRID_CELL_COUNT, GRID_SIZE},
     material::{MATERIAL_COUNT, MaterialParams, default_material_table},
     particle::{GridCell, Particle},
+    reaction::{PhaseTransitionRule, default_phase_transition_table},
 };
 
 use crate::grid::{build_solid_occupancy, clear_grid, g2p, grid_update, p2g};
@@ -35,11 +36,13 @@ pub struct TestWorld {
     particles: Vec<Particle>,
     materials: [MaterialParams; MATERIAL_COUNT],
     grid: Vec<GridCell>,
+    phase_rules: Vec<PhaseTransitionRule>,
 }
 
 impl TestWorld {
     /// Create a new empty test world with default materials.
     pub fn new() -> Self {
+        let (table, count) = default_phase_transition_table();
         Self {
             particles: Vec::new(),
             materials: default_material_table(),
@@ -51,6 +54,7 @@ impl TestWorld {
                 };
                 GRID_CELL_COUNT as usize
             ],
+            phase_rules: table[..count].to_vec(),
         }
     }
 
@@ -132,8 +136,8 @@ impl TestWorld {
         // 6. Thermal diffusion
         diffuse_temperature(&mut self.particles, &self.materials, DT);
 
-        // 7. Phase transitions
-        apply_phase_transitions(&mut self.particles);
+        // 7. Phase transitions (data-driven via reaction table)
+        apply_phase_transitions(&mut self.particles, &self.phase_rules);
     }
 
     /// Run `n` full simulation steps.

--- a/crates/sim-cpu/src/thermal.rs
+++ b/crates/sim-cpu/src/thermal.rs
@@ -1,14 +1,16 @@
 //! Temperature diffusion and phase transition processing.
 //!
 //! Heat diffusion via grid: `T += conductivity * (T_avg_neighbors - T) * dt`
-//! Phase transitions are checked after temperature update.
+//! Phase transitions are checked after temperature update using the data-driven
+//! reaction table from `shared::reaction::PhaseTransitionRule`.
 
 use glam::Vec3;
 use shared::{
     constants::GRID_SIZE,
     material::MaterialParams,
     particle::Particle,
-    phase::{apply_phase_transition, check_phase_transition},
+    phase::{apply_phase_transition, check_phase_transition, PhaseTransition},
+    reaction::{PhaseTransitionRule, FLAG_EXPLOSION},
 };
 
 use crate::grid::{bspline_weight, grid_index};
@@ -123,25 +125,25 @@ pub fn diffuse_temperature(particles: &mut [Particle], materials: &[MaterialPara
 
 /// Check and apply phase transitions for all particles.
 ///
-/// After temperature update, each particle is checked against phase
-/// transition rules. On transition: F = Identity, damage = 0.
+/// After temperature update, each particle is checked against the data-driven
+/// phase transition rules. On transition: F = Identity, damage = 0.
 ///
-/// Gunpowder explosion additionally sets outward velocity and boosts
-/// temperature to 3000C, matching the shader implementation in g2p.rs.
+/// Gunpowder explosion (FLAG_EXPLOSION) additionally sets outward velocity
+/// and boosts temperature to 3000C, matching the shader implementation in g2p.rs.
 ///
 /// # Arguments
 /// - `particles`: mutable particle slice
-pub fn apply_phase_transitions(particles: &mut [Particle]) {
+/// - `rules`: phase transition rule table (valid entries only)
+pub fn apply_phase_transitions(particles: &mut [Particle], rules: &[PhaseTransitionRule]) {
     for particle in particles.iter_mut() {
-        let was_gunpowder_solid = particle.material_id() == shared::material::MAT_GUNPOWDER
-            && particle.phase() == shared::material::PHASE_SOLID;
-        let transition = check_phase_transition(particle);
-        apply_phase_transition(particle, transition);
-
-        // Gunpowder explosion: apply outward velocity and boost temperature.
-        // Must match shader g2p.rs apply_gunpowder_explosion().
-        if was_gunpowder_solid && particle.phase() == shared::material::PHASE_GAS {
-            apply_gunpowder_explosion_cpu(particle);
+        let transition = check_phase_transition(particle, rules);
+        if let PhaseTransition::Transition { flags, .. } = transition {
+            apply_phase_transition(particle, transition);
+            // Gunpowder explosion: apply outward velocity and boost temperature.
+            // Must match shader g2p.rs apply_gunpowder_explosion().
+            if flags & FLAG_EXPLOSION != 0 {
+                apply_gunpowder_explosion_cpu(particle);
+            }
         }
     }
 }
@@ -187,11 +189,20 @@ fn hash_f32_cpu(x: f32) -> f32 {
 
 #[cfg(test)]
 mod tests {
-    use shared::material::{
-        MAT_LAVA, MAT_STONE, MAT_WATER, PHASE_LIQUID, PHASE_SOLID, default_material_table,
+    use shared::{
+        material::{
+            MAT_LAVA, MAT_STONE, MAT_WATER, PHASE_LIQUID, PHASE_SOLID, default_material_table,
+        },
+        reaction::default_phase_transition_table,
     };
 
     use super::*;
+
+    /// Helper: get the valid rules as a Vec.
+    fn rules() -> Vec<PhaseTransitionRule> {
+        let (table, count) = default_phase_transition_table();
+        table[..count].to_vec()
+    }
 
     #[test]
     fn temperature_diffusion_equalizes() {
@@ -233,13 +244,14 @@ mod tests {
 
     #[test]
     fn phase_transition_stone_to_lava() {
+        let r = rules();
         let mut particles = vec![{
             let mut p = Particle::new(Vec3::ZERO, 1.0, MAT_STONE, PHASE_SOLID);
             p.set_temperature(1600.0);
             p
         }];
 
-        apply_phase_transitions(&mut particles);
+        apply_phase_transitions(&mut particles, &r);
 
         assert_eq!(particles[0].material_id(), MAT_LAVA);
         assert_eq!(particles[0].phase(), PHASE_LIQUID);
@@ -247,13 +259,14 @@ mod tests {
 
     #[test]
     fn phase_transition_water_to_steam() {
+        let r = rules();
         let mut particles = vec![{
             let mut p = Particle::new(Vec3::ZERO, 1.0, MAT_WATER, PHASE_LIQUID);
             p.set_temperature(110.0);
             p
         }];
 
-        apply_phase_transitions(&mut particles);
+        apply_phase_transitions(&mut particles, &r);
 
         assert_eq!(particles[0].material_id(), MAT_WATER);
         assert_eq!(particles[0].phase(), shared::material::PHASE_GAS);
@@ -262,6 +275,7 @@ mod tests {
     #[test]
     fn lava_cools_to_stone() {
         let table = default_material_table();
+        let r = rules();
         let dx = 1.0 / shared::constants::GRID_SIZE as f32;
         let mut particles = vec![
             // Hot lava
@@ -286,7 +300,7 @@ mod tests {
         // Run many diffusion + transition steps
         for _ in 0..500 {
             diffuse_temperature(&mut particles, &table, 0.01);
-            apply_phase_transitions(&mut particles);
+            apply_phase_transitions(&mut particles, &r);
         }
 
         // The lava should have cooled and solidified


### PR DESCRIPTION
## Summary

- Replace hardcoded match blocks in `shared/phase.rs` and `shaders/g2p.rs` with a data-driven `PhaseTransitionRule` table (GPU-friendly `UVec4 + Vec4` struct, 32 bytes/rule)
- Adding new materials now requires only adding a rule to `default_phase_transition_table()` -- no code edits in 2+ places
- Reaction table is uploaded to GPU as a storage buffer and bound to the G2P pass (binding 3)
- Avoids CLAUDE.md trap #15 (>3 branches dropped by rust-gpu) by using a loop instead of match/if-else chains

### Files changed
| File | Change |
|------|--------|
| `shared/src/reaction.rs` | `PhaseTransitionRule` struct + `default_phase_transition_table()` (6 rules) |
| `shared/src/phase.rs` | `check_phase_transition()` now takes `&[PhaseTransitionRule]` |
| `shaders/src/types.rs` | GPU-side `PhaseTransitionRule` mirror type |
| `shaders/src/compute/g2p.rs` | Loop over reaction buffer instead of hardcoded match |
| `server/src/lib.rs` | Create + upload reaction buffer, bind to G2P (binding 3) |
| `sim-cpu/src/thermal.rs` | Pass rules to `apply_phase_transitions()` |
| `sim-cpu/src/test_world.rs` | Pass rules through TestWorld |
| `CLAUDE.md` | Add trap #21 (OpPhi pointer issue) |

Closes #175
Closes #176

## Test plan
- [x] `cargo test -p shared` -- 56 tests pass (includes new reaction table tests)
- [x] `cargo test -p sim-cpu --lib` -- 28 tests pass (thermal + phase transition tests updated)
- [x] `cargo build` -- full workspace builds including shader SPIR-V compilation
- [ ] `cargo test -p server -- --test-threads=1` -- GPU tests (requires RTX GPU)
- [ ] `cargo run -p app` -- smoke test (requires display)

🤖 Generated with [Claude Code](https://claude.com/claude-code)