### PR TITLE
fix(physics): improve falling solid support check and enforce minimum fall speed

### DIFF
--- a/crates/shaders/src/compute/g2p.rs
+++ b/crates/shaders/src/compute/g2p.rs
@@ -32,10 +32,34 @@ const PIC_RATIO: f32 = 0.5;
 /// Number of u32 values per voxel cell (must match voxelize.rs layout).
 const U32S_PER_VOXEL: u32 = 4;
 
+/// Check if a voxel cell at (vx, vy, vz) is occupied by a solid (phase==0).
+///
+/// Returns `true` if the cell is in-bounds, occupied, and has phase==0.
+fn is_solid_voxel(vx: u32, vy: u32, vz: u32, voxels: &[u32], grid_size: u32) -> bool {
+    if vx >= grid_size || vy >= grid_size || vz >= grid_size {
+        return false;
+    }
+    let idx = (vz * grid_size * grid_size + vy * grid_size + vx) as usize;
+    let base = idx * U32S_PER_VOXEL as usize;
+
+    // Check occupied flag (offset +3)
+    let occupied = voxels[base + 3] > 0;
+    if !occupied {
+        return false;
+    }
+
+    // Unpack phase from packed_material at offset +0: (weight<<24 | mat<<16 | phase<<8 | 0xFF)
+    let packed = voxels[base];
+    let phase_below = (packed >> 8) & 0xFF;
+    phase_below == 0
+}
+
 /// Check if a solid particle has support from a solid voxel below it.
 ///
 /// Reads the voxel buffer (from the previous frame's voxelize pass) to see
-/// if the cell directly below this particle is occupied by a solid (phase==0).
+/// if the cell below this particle is occupied by a solid (phase==0).
+/// Checks 2 cells below to avoid stale-read issues where adjacent solids
+/// at the same Y level see each other's old positions as support.
 /// Particles at the grid floor (vy <= 1) are always considered supported.
 pub fn check_solid_support(pos: spirv_std::glam::Vec3, voxels: &[u32], grid_size: u32) -> bool {
     let vx = pos.x as u32;
@@ -47,25 +71,20 @@ pub fn check_solid_support(pos: spirv_std::glam::Vec3, voxels: &[u32], grid_size
         return true;
     }
 
-    // Check cell below
-    let below_y = vy - 1;
-    if vx >= grid_size || below_y >= grid_size || vz >= grid_size {
-        return true; // out of bounds = treat as supported (safe default)
+    // Check cell directly below (vy - 1)
+    if is_solid_voxel(vx, vy - 1, vz, voxels, grid_size) {
+        return true;
     }
 
-    let below_idx = (vz * grid_size * grid_size + below_y * grid_size + vx) as usize;
-    let base = below_idx * U32S_PER_VOXEL as usize;
-
-    // Check occupied flag (offset +3) and that the occupant is solid (phase==0)
-    let occupied = voxels[base + 3] > 0;
-    if !occupied {
-        return false;
+    // Check 2 cells below (vy - 2) to catch cases where the voxel buffer
+    // is stale by one frame and the support has shifted down by 1 cell.
+    if vy >= 3 {
+        if is_solid_voxel(vx, vy - 2, vz, voxels, grid_size) {
+            return true;
+        }
     }
 
-    // Unpack phase from packed_material at offset +0: (weight<<24 | mat<<16 | phase<<8 | 0xFF)
-    let packed = voxels[base];
-    let phase_below = (packed >> 8) & 0xFF;
-    phase_below == 0 // supported only if the voxel below is also solid
+    false
 }
 
 /// Gather velocity from the grid and update one particle.
@@ -234,7 +253,7 @@ pub fn gather_particle(
 
     // Solids: check if the particle has support from a solid voxel below.
     // Supported solids update F and C only (pinned, prevents floor drift #45).
-    // Unsupported solids fall through to full position/velocity update.
+    // Unsupported solids fall normally with minimum fall speed to overcome grid friction.
     if phase == 0 {
         let supported = check_solid_support(pos, voxels, grid_size);
         if supported {
@@ -251,7 +270,11 @@ pub fn gather_particle(
             apply_phase_transitions(particle);
             return;
         }
-        // Unsupported: fall through to position/velocity update below
+        // Unsupported solid: enforce minimum fall speed to overcome grid friction.
+        // Grid coupling with neighboring solids creates artificial friction that
+        // prevents free-fall. Override with gravity-based minimum downward velocity.
+        // GRAVITY is -196.0, so min_fall_speed is negative (downward).
+        new_vel = apply_min_fall_speed(new_vel, dt);
     }
 
     // Write back to particle (liquids and gases only)
@@ -266,6 +289,30 @@ pub fn gather_particle(
 
     // Phase transitions by temperature
     apply_phase_transitions(particle);
+}
+
+/// Enforce minimum fall speed for unsupported solid particles.
+///
+/// Grid coupling with neighboring solids creates artificial friction that
+/// prevents free-fall. This ensures unsupported solids always have at least
+/// a minimum downward velocity proportional to accumulated gravity over ~10 frames.
+/// Also zeros out horizontal velocity to prevent wall-sliding artifacts.
+fn apply_min_fall_speed(vel: Vec3, dt: f32) -> Vec3 {
+    // Gravity = -196.0 grid-units/s^2. Over 10 frames at dt=0.001:
+    // min_fall_speed = -196.0 * 0.001 * 10 = -1.96 grid-units/s
+    let gravity = -196.0_f32;
+    let min_fall_speed = gravity * dt * 10.0;
+
+    let mut result = vel;
+    // Ensure downward velocity is at least min_fall_speed (both are negative)
+    if result.y > min_fall_speed {
+        result.y = min_fall_speed;
+    }
+    // Dampen horizontal velocity to prevent wall-sliding and lateral sticking.
+    // Solids should fall straight down, not drift sideways from grid coupling.
+    result.x *= 0.5;
+    result.z *= 0.5;
+    result
 }
 
 /// Apply radiative cooling (Newton's cooling law) to a temperature value.

--- a/crates/sim-cpu/src/grid.rs
+++ b/crates/sim-cpu/src/grid.rs
@@ -278,7 +278,11 @@ pub fn build_solid_occupancy(particles: &[Particle]) -> Vec<bool> {
 ///
 /// A particle is considered supported if:
 /// - It is at the grid floor (iy <= 1), or
-/// - The cell directly below it in the occupancy grid is occupied by a solid.
+/// - The cell directly below (iy-1) or 2 cells below (iy-2) in the occupancy
+///   grid is occupied by a solid.
+///
+/// Checking 2 cells below avoids stale-read artifacts where the voxel buffer
+/// lags by one frame, causing adjacent falling solids to lose support prematurely.
 ///
 /// # Arguments
 /// - `pos`: particle position in world space [0, 1]
@@ -295,11 +299,23 @@ pub fn check_solid_support(pos: Vec3, solid_occupancy: &[bool]) -> bool {
         return true;
     }
 
-    // Check cell below
-    match grid_index(ix, iy - 1, iz) {
-        Some(idx) => solid_occupancy[idx],
-        None => true, // out of bounds = treat as supported
+    // Check cell directly below
+    if let Some(idx) = grid_index(ix, iy - 1, iz) {
+        if solid_occupancy[idx] {
+            return true;
+        }
     }
+
+    // Check 2 cells below to handle stale voxel buffer
+    if iy >= 3 {
+        if let Some(idx) = grid_index(ix, iy - 2, iz) {
+            if solid_occupancy[idx] {
+                return true;
+            }
+        }
+    }
+
+    false
 }
 
 /// Grid-to-Particle transfer (G2P).
@@ -424,7 +440,7 @@ pub fn g2p(particles: &mut [Particle], grid: &[GridCell], solid_occupancy: &[boo
 
         // Solids: check if the particle has support from a solid voxel below.
         // Supported solids update F and C only (pinned, prevents floor drift).
-        // Unsupported solids fall through to full position/velocity update.
+        // Unsupported solids fall normally with minimum fall speed to overcome grid friction.
         if particle.phase() == 0 && !solid_occupancy.is_empty() {
             let supported = check_solid_support(pos, solid_occupancy);
             if supported {
@@ -434,7 +450,16 @@ pub fn g2p(particles: &mut [Particle], grid: &[GridCell], solid_occupancy: &[boo
                 particle.set_temperature(new_temp);
                 continue;
             }
-            // Unsupported: fall through to position/velocity update
+            // Unsupported solid: enforce minimum fall speed to overcome grid friction.
+            // Grid coupling with neighboring solids creates artificial friction that
+            // prevents free-fall. Override with gravity-based minimum downward velocity.
+            let min_fall_speed = GRAVITY * dt * 10.0; // ~10 frames of gravity
+            if final_vel.y > min_fall_speed {
+                final_vel.y = min_fall_speed;
+            }
+            // Dampen horizontal velocity to prevent wall-sliding and lateral sticking
+            final_vel.x *= 0.5;
+            final_vel.z *= 0.5;
         }
 
         // Update velocity and temperature


### PR DESCRIPTION
## Summary
- **Support check improvement**: `check_solid_support` now checks 2 cells below (vy-1 and vy-2) instead of just 1, avoiding stale voxel buffer reads that caused solids to hang in mid-air after explosion debris cooled
- **Minimum fall speed**: Unsupported solids now get a minimum downward velocity (~10 frames of accumulated gravity = -1.96 grid-units/s) to overcome artificial friction from grid coupling between adjacent falling blocks
- **Horizontal damping**: Falling solids have horizontal velocity dampened by 50% to prevent wall-sliding artifacts
- Both GPU (`crates/shaders/src/compute/g2p.rs`) and CPU (`crates/sim-cpu/src/grid.rs`) implementations updated in sync

Closes #171
Closes #164

## Test plan
- [x] `cargo test -p sim-cpu` — all 28 tests pass
- [x] `cargo test -p shared` — all 51 tests pass
- [x] `cargo build` — full build including shader compilation succeeds
- [ ] Visual test: single solid block in air should fall at near free-fall speed
- [ ] Visual test: two adjacent solid blocks should both fall, not stick together
- [ ] Visual test: explosion debris that cools to stone should not hang in mid-air

🤖 Generated with [Claude Code](https://claude.com/claude-code)