### PR TITLE
docs(gpu-core): improve validation layer setup and docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,20 @@ Shader entry points are dropped during SPIR-V linking if the entry point body ha
 ### 5. Vulkan Validation Layers
 ALWAYS enabled in debug builds. If crash with no message → check `VK_LAYER_KHRONOS_validation` is active.
 
+**Setup (Windows):**
+1. Download and install LunarG Vulkan SDK from https://vulkan.lunarg.com/
+2. After install, `VK_LAYER_KHRONOS_validation` should be available automatically.
+3. If layers are still not found, ensure `VK_LAYER_PATH` env var points to the SDK's
+   `Bin` directory (e.g., `C:\VulkanSDK\1.x.y.z\Bin`).
+4. Verify with: `vulkaninfo --summary` — should list the validation layer.
+
+**How it works in gpu-core:**
+- `VulkanContext` checks for `VK_LAYER_KHRONOS_validation` at instance creation (debug builds only).
+- If available: enables the layer + `VK_EXT_debug_utils` extension + installs a debug messenger
+  that routes Vulkan errors/warnings to `tracing::error!()` / `tracing::warn!()`.
+- If unavailable: logs a warning with install instructions and continues without validation.
+- The debug messenger is destroyed in `VulkanContext::Drop`.
+
 ### 6. Grid Clear
 Grid buffer MUST be zeroed before every P2G pass. Without this → mass/momentum accumulation from previous frame.
 

--- a/crates/gpu-core/src/context.rs
+++ b/crates/gpu-core/src/context.rs
@@ -171,7 +171,11 @@ impl VulkanContext {
                 _debug_utils_enabled = true;
                 tracing::info!("Vulkan validation layers enabled");
             } else {
-                tracing::warn!("Vulkan validation layer not available, running without validation");
+                tracing::warn!(
+                    "Vulkan validation layer not available. \
+                     Install LunarG Vulkan SDK (https://vulkan.lunarg.com/) for debug validation. \
+                     See CLAUDE.md trap #5."
+                );
             }
         }
 


### PR DESCRIPTION
## Summary
- Improved the validation-layer-unavailable warning in `gpu-core/src/context.rs` to include the LunarG SDK install URL and a pointer to CLAUDE.md trap #5
- Expanded CLAUDE.md trap #5 with Windows setup instructions (SDK install, VK_LAYER_PATH, vulkaninfo verification) and documented how the existing debug messenger plumbing works

Note: the debug callback (`VK_EXT_debug_utils` messenger routing to `tracing`) was already implemented. This PR focuses on documentation and a more actionable warning message.

Closes #40

## Test plan
- [x] `cargo build -p gpu-core` passes
- [ ] Verify warning message appears when running without Vulkan SDK installed
- [ ] Verify validation messages appear via tracing when SDK is installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)