### PR TITLE
fix(sim-cpu): solid cell boundary to prevent water leaking through walls

### DIFF
--- a/crates/sim-cpu/src/grid.rs
+++ b/crates/sim-cpu/src/grid.rs
@@ -207,6 +207,13 @@ pub fn p2g_sized(
                     cell.velocity_mass.z += w * momentum.z + force_contrib.z;
                     cell.velocity_mass.w += w * mass;
 
+                    // Mark cells touched by solid particles (phase == 0)
+                    // so grid_update can enforce solid boundary conditions.
+                    // Uses force_pad.w as a solid flag (mirrors GPU p2g.rs).
+                    if particle.phase() == 0 {
+                        cell.force_pad.w += 1.0;
+                    }
+
                     // Scatter weighted temperature (temp * mass * weight).
                     // Normalized by mass in grid_update to get average temperature.
                     cell.temp_pad.x += temp * w * mass;
@@ -281,6 +288,24 @@ pub fn grid_update_sized(grid: &mut [GridCell], dt: f32, grid_size: u32) {
                 }
                 if iz < boundary || iz >= gs - boundary {
                     cell.velocity_mass.z = 0.0;
+                }
+
+                // Solid boundary conditions: zero velocity at cells with solid contributions.
+                // The solid flag is accumulated by P2G into force_pad.w.
+                // Deep inside solid (many overlapping particles) -> fully zero velocity.
+                // At boundary (few solid particles) -> strongly damp velocity.
+                // This prevents momentum from bleeding through solid walls.
+                // Mirrors the GPU grid_update.rs logic.
+                let solid_flag = cell.force_pad.w;
+                if solid_flag > 2.0 {
+                    cell.velocity_mass.x = 0.0;
+                    cell.velocity_mass.y = 0.0;
+                    cell.velocity_mass.z = 0.0;
+                } else if solid_flag > 0.5 {
+                    let damp = 1.0 - (solid_flag / 3.0_f32).min(0.9);
+                    cell.velocity_mass.x *= damp;
+                    cell.velocity_mass.y *= damp;
+                    cell.velocity_mass.z *= damp;
                 }
 
                 // Normalize accumulated temperature by mass.

--- a/crates/sim-cpu/tests/behavior.rs
+++ b/crates/sim-cpu/tests/behavior.rs
@@ -304,6 +304,67 @@ fn no_nan_with_mixed_materials() {
     }
 }
 
+/// Water should not leak through a 3-cell-thick solid wall.
+///
+/// Builds a stone wall spanning the full YZ plane at x=14..17 (in grid coords),
+/// places a block of water on the left side, and runs 50 steps. No water particle
+/// should cross to the right side of the wall.
+#[test]
+fn water_doesnt_leak_through_solid_wall() {
+    let mut w = TestWorld::new(); // grid_size=32
+    let dx = 1.0 / 32.0;
+
+    // Build a 3-cell-thick stone wall at x=14..16 (full YZ extent)
+    for y in 0..32_i32 {
+        for z in 0..32_i32 {
+            for wx in 14..17_i32 {
+                w.spawn(
+                    Vec3::new(
+                        wx as f32 * dx + dx * 0.5,
+                        y as f32 * dx + dx * 0.5,
+                        z as f32 * dx + dx * 0.5,
+                    ),
+                    MAT_STONE,
+                    PHASE_SOLID,
+                    20.0,
+                );
+            }
+        }
+    }
+
+    // Water block on the left side (x=8..12, y=5..9, z=10..19)
+    for y in 5..10_i32 {
+        for z in 10..20_i32 {
+            for x in 8..13_i32 {
+                w.spawn(
+                    Vec3::new(
+                        x as f32 * dx + dx * 0.5,
+                        y as f32 * dx + dx * 0.5,
+                        z as f32 * dx + dx * 0.5,
+                    ),
+                    MAT_WATER,
+                    PHASE_LIQUID,
+                    20.0,
+                );
+            }
+        }
+    }
+
+    w.step_n(50);
+
+    // No water should have crossed to x > 17*dx
+    let wall_right = 17.0 * dx + dx;
+    let leaked = w
+        .particles()
+        .iter()
+        .filter(|p| p.material_id() == MAT_WATER && p.position().x > wall_right)
+        .count();
+    assert_eq!(
+        leaked, 0,
+        "Water leaked through wall: {leaked} particles crossed"
+    );
+}
+
 /// Mass must be conserved through the full pipeline (MPM + thermal + transitions).
 #[test]
 fn mass_conserved_through_full_pipeline() {


### PR DESCRIPTION
## Summary
- CPU `p2g_sized` now marks grid cells touched by solid particles (`force_pad.w += 1.0`), matching the GPU P2G shader
- CPU `grid_update_sized` enforces solid boundary conditions: cells deep inside solids (`solid_flag > 2.0`) get zero velocity; boundary cells (`solid_flag > 0.5`) get strong damping — same logic as GPU `grid_update.rs`
- Added `water_doesnt_leak_through_solid_wall` behavior test: 3-cell-thick stone wall with water on one side, verifies no particles cross after 50 steps

## Test plan
- [x] `cargo test -p sim-cpu` — all 43 tests pass (28 unit + 10 behavior + 5 proptest)
- [x] `cargo build -p server` — shaders compile successfully
- [ ] `cargo run -p app` — visual smoke test (water stays in basin)

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)