### PR TITLE
feat(content): data-driven material loading from RON files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "client",
+ "content",
  "glam",
  "gpu-core",
  "image",
@@ -164,6 +165,12 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bit-set"
@@ -445,6 +452,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "content"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "approx",
+ "glam",
+ "ron",
+ "serde",
+ "shared",
+ "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -1875,6 +1896,18 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "ron"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+dependencies = [
+ "base64",
+ "bitflags 2.11.0",
+ "serde",
+ "serde_derive",
+]
 
 [[package]]
 name = "rspirv"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/app",
     "crates/bootstrap-test",
     "crates/shader-builder",
+    "crates/content",
 ]
 # These crates are compiled to SPIR-V by spirv-builder, not native
 exclude = ["crates/shaders", "crates/bootstrap-shader"]
@@ -51,6 +52,7 @@ sim-cpu = { path = "crates/sim-cpu" }
 gpu-core = { path = "crates/gpu-core" }
 server = { path = "crates/server" }
 client = { path = "crates/client" }
+content = { path = "crates/content" }
 
 [profile.dev.build-override]
 opt-level = 3

--- a/assets/materials.ron
+++ b/assets/materials.ron
@@ -1,0 +1,256 @@
+// Material database for the VOX voxel engine.
+//
+// Float sentinel values:
+//   3.4028235e38  = f32::MAX (material doesn't melt/boil/glow)
+//  -3.4028235e38  = f32::MIN (always triggers if below temp_max)
+(
+    materials: [
+        // 0: Stone (solid)
+        (
+            name: "Stone",
+            id: 0,
+            default_phase: Solid,
+            elastic: (
+                youngs_modulus: 1e6,
+                poissons_ratio: 0.3,
+                yield_stress: 1e4,
+                viscosity: 0.0,
+            ),
+            thermal: (
+                melting_point: 1500.0,
+                boiling_point: 3.4028235e38,
+                heat_conductivity: 1.0,
+                specific_heat: 800.0,
+            ),
+            visual: (
+                density: 2700.0,
+                emissive_temp: 3.4028235e38,
+                opacity: 1.0,
+                color: (0.5, 0.5, 0.5),
+            ),
+        ),
+        // 1: Water (liquid)
+        (
+            name: "Water",
+            id: 1,
+            default_phase: Liquid,
+            elastic: (
+                youngs_modulus: 0.0,
+                poissons_ratio: 0.0,
+                yield_stress: 0.0,
+                viscosity: 1e-3,
+            ),
+            thermal: (
+                melting_point: 0.0,
+                boiling_point: 100.0,
+                heat_conductivity: 0.6,
+                specific_heat: 4186.0,
+            ),
+            visual: (
+                density: 1000.0,
+                emissive_temp: 3.4028235e38,
+                opacity: 0.3,
+                color: (0.2, 0.4, 0.9),
+            ),
+        ),
+        // 2: Lava (liquid, hot)
+        (
+            name: "Lava",
+            id: 2,
+            default_phase: Liquid,
+            elastic: (
+                youngs_modulus: 0.0,
+                poissons_ratio: 0.0,
+                yield_stress: 0.0,
+                viscosity: 100.0,
+            ),
+            thermal: (
+                melting_point: 1500.0,
+                boiling_point: 3.4028235e38,
+                heat_conductivity: 1.5,
+                specific_heat: 1000.0,
+            ),
+            visual: (
+                density: 2500.0,
+                emissive_temp: 800.0,
+                opacity: 1.0,
+                color: (1.0, 0.3, 0.0),
+            ),
+        ),
+        // 3: Wood (solid, flammable)
+        (
+            name: "Wood",
+            id: 3,
+            default_phase: Solid,
+            elastic: (
+                youngs_modulus: 1e5,
+                poissons_ratio: 0.3,
+                yield_stress: 5e3,
+                viscosity: 0.0,
+            ),
+            thermal: (
+                melting_point: 3.4028235e38,
+                boiling_point: 3.4028235e38,
+                heat_conductivity: 0.2,
+                specific_heat: 2000.0,
+            ),
+            visual: (
+                density: 600.0,
+                emissive_temp: 300.0,
+                opacity: 1.0,
+                color: (0.55, 0.35, 0.15),
+            ),
+        ),
+        // 4: Ash (solid, crumbly)
+        (
+            name: "Ash",
+            id: 4,
+            default_phase: Solid,
+            elastic: (
+                youngs_modulus: 1e3,
+                poissons_ratio: 0.2,
+                yield_stress: 100.0,
+                viscosity: 0.0,
+            ),
+            thermal: (
+                melting_point: 3.4028235e38,
+                boiling_point: 3.4028235e38,
+                heat_conductivity: 0.1,
+                specific_heat: 800.0,
+            ),
+            visual: (
+                density: 200.0,
+                emissive_temp: 3.4028235e38,
+                opacity: 1.0,
+                color: (0.4, 0.4, 0.4),
+            ),
+        ),
+        // 5: Ice (solid, brittle)
+        (
+            name: "Ice",
+            id: 5,
+            default_phase: Solid,
+            elastic: (
+                youngs_modulus: 1e6,
+                poissons_ratio: 0.3,
+                yield_stress: 3000.0,
+                viscosity: 0.0,
+            ),
+            thermal: (
+                melting_point: 0.0,
+                boiling_point: 100.0,
+                heat_conductivity: 2.0,
+                specific_heat: 2090.0,
+            ),
+            visual: (
+                density: 917.0,
+                emissive_temp: 3.4028235e38,
+                opacity: 0.6,
+                color: (0.7, 0.85, 0.95),
+            ),
+        ),
+        // 6: Gunpowder (solid, crumbly, explosive)
+        (
+            name: "Gunpowder",
+            id: 6,
+            default_phase: Solid,
+            elastic: (
+                youngs_modulus: 0.0,
+                poissons_ratio: 0.0,
+                yield_stress: 500.0,
+                viscosity: 0.0,
+            ),
+            thermal: (
+                melting_point: 3.4028235e38,
+                boiling_point: 3.4028235e38,
+                heat_conductivity: 5.0,
+                specific_heat: 800.0,
+            ),
+            visual: (
+                density: 1800.0,
+                emissive_temp: 150.0,
+                opacity: 1.0,
+                color: (0.25, 0.2, 0.15),
+            ),
+        ),
+    ],
+
+    phase_transitions: [
+        // Stone (solid) + T > 1500 -> Lava (liquid)
+        (
+            from_material: 0,
+            from_phase: Solid,
+            to_material: 2,
+            to_phase: Liquid,
+            temp_min: 1500.0,
+            temp_max: 3.4028235e38,
+            reset_deformation: true,
+        ),
+        // Water (liquid) + T > 100 -> Steam (gas)
+        (
+            from_material: 1,
+            from_phase: Liquid,
+            to_material: 1,
+            to_phase: Gas,
+            temp_min: 100.0,
+            temp_max: 3.4028235e38,
+            reset_deformation: true,
+        ),
+        // Water (liquid) + T < 0 -> Ice (solid)
+        (
+            from_material: 1,
+            from_phase: Liquid,
+            to_material: 5,
+            to_phase: Solid,
+            temp_min: -3.4028235e38,
+            temp_max: 0.0,
+            reset_deformation: true,
+        ),
+        // Ice (solid) + T > 0 -> Water (liquid)
+        (
+            from_material: 5,
+            from_phase: Solid,
+            to_material: 1,
+            to_phase: Liquid,
+            temp_min: 0.0,
+            temp_max: 3.4028235e38,
+            reset_deformation: true,
+        ),
+        // Lava (liquid) + T < 1500 -> Stone (solid)
+        (
+            from_material: 2,
+            from_phase: Liquid,
+            to_material: 0,
+            to_phase: Solid,
+            temp_min: -3.4028235e38,
+            temp_max: 1500.0,
+            reset_deformation: true,
+        ),
+        // Gunpowder (solid) + T > 150 -> Gas (explosion)
+        (
+            from_material: 6,
+            from_phase: Solid,
+            to_material: 6,
+            to_phase: Gas,
+            temp_min: 150.0,
+            temp_max: 3.4028235e38,
+            reset_deformation: true,
+            explosion: true,
+        ),
+    ],
+
+    reactions: [
+        // Water + Lava -> Stone + Steam
+        (
+            reactant_a: 1,
+            reactant_b: 2,
+            product_a_material: 0,
+            product_a_phase: Solid,
+            product_b_material: 1,
+            product_b_phase: Gas,
+            min_temperature: -3.4028235e38,
+            product_a_temp: 300.0,
+            product_b_temp: 100.0,
+        ),
+    ],
+)

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 server = { workspace = true }
 client = { workspace = true }
+content = { workspace = true }
 shared = { workspace = true, features = ["std"] }
 protocol = { workspace = true }
 gpu-core = { workspace = true }

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use client::{Camera, PlayerController, Renderer, renderer::required_instance_extensions};
+use content::MaterialDatabase;
 use glam::Vec3;
 use gpu_core::VulkanContext;
 use server::{GpuSimulation, ToolbarPushConstants, TOOLBAR_MAX_MATERIALS};
@@ -50,6 +51,7 @@ pub(crate) struct App {
     selected_material: usize,
     palette: Vec<MaterialSlot>,
     pending_explosion: Option<[f32; 3]>,
+    material_db: Option<MaterialDatabase>,
 }
 
 impl App {
@@ -57,6 +59,21 @@ impl App {
     pub(crate) fn new(substeps: u32) -> Self {
         let particles = create_island_particles();
         tracing::info!("Created {} initial particles", particles.len());
+
+        // Try loading materials from RON file, fall back to hardcoded defaults
+        let material_db = match content::load_material_database("assets/materials.ron") {
+            Ok(db) => {
+                tracing::info!("Loaded material database from assets/materials.ron");
+                Some(db)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to load assets/materials.ron, using hardcoded defaults: {}",
+                    e
+                );
+                None
+            }
+        };
 
         let gs = GRID_SIZE as f32;
         let camera = Camera::look_at(
@@ -79,6 +96,7 @@ impl App {
             selected_material: 0,
             palette: material_palette(),
             pending_explosion: None,
+            material_db,
         }
     }
 
@@ -217,7 +235,13 @@ impl ApplicationHandler for App {
             Ok(r) => r,
             Err(e) => { tracing::error!("Failed to create Renderer: {}", e); event_loop.exit(); return; }
         };
-        let mut sim = match GpuSimulation::new(&ctx) {
+        let mut sim = match if let Some(db) = &self.material_db {
+            let materials = db.material_params();
+            let (transitions, count) = db.phase_transition_rules();
+            GpuSimulation::new_with_materials(&ctx, &materials, &transitions, count)
+        } else {
+            GpuSimulation::new(&ctx)
+        } {
             Ok(s) => s,
             Err(e) => { tracing::error!("Failed to create GpuSimulation: {}", e); event_loop.exit(); return; }
         };

--- a/crates/app/src/headless.rs
+++ b/crates/app/src/headless.rs
@@ -14,7 +14,21 @@ use crate::Args;
 pub(crate) fn run_headless(args: &Args) -> Result<()> {
     tracing::info!("Headless mode: {} frames, {} substeps/frame", args.frames, args.substeps);
     let ctx = VulkanContext::new()?;
-    let mut sim = GpuSimulation::new(&ctx)?;
+    let mut sim = match content::load_material_database("assets/materials.ron") {
+        Ok(db) => {
+            tracing::info!("Loaded material database from assets/materials.ron");
+            let materials = db.material_params();
+            let (transitions, count) = db.phase_transition_rules();
+            GpuSimulation::new_with_materials(&ctx, &materials, &transitions, count)?
+        }
+        Err(e) => {
+            tracing::warn!(
+                "Failed to load assets/materials.ron, using hardcoded defaults: {}",
+                e
+            );
+            GpuSimulation::new(&ctx)?
+        }
+    };
     let particles = create_island_particles();
     sim.init_particles(&ctx, &particles)?;
 

--- a/crates/content/Cargo.toml
+++ b/crates/content/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "content"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+shared = { workspace = true, features = ["std"] }
+glam = { workspace = true }
+serde = { workspace = true }
+ron = { workspace = true }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+approx = { workspace = true }

--- a/crates/content/src/convert.rs
+++ b/crates/content/src/convert.rs
@@ -1,0 +1,352 @@
+//! Conversion from RON-deserialized types to GPU-friendly `shared` structs.
+
+use std::collections::HashSet;
+
+use glam::Vec4;
+use shared::{
+    material::{MATERIAL_COUNT, MaterialParams},
+    reaction::{
+        FLAG_EXPLOSION, FLAG_RESET_F, MAX_PHASE_RULES, PhaseTransitionRule, ReactionRule,
+    },
+};
+
+use crate::{
+    ContentError,
+    types::{MaterialDatabaseDef, MaterialDef, PhaseTransitionDef, ReactionDef},
+};
+
+/// Validated material database ready for GPU upload.
+///
+/// Created via [`MaterialDatabase::from_def`] which validates all
+/// cross-references and constraints. Use the accessor methods to obtain
+/// GPU-friendly arrays for upload to storage buffers.
+#[derive(Debug)]
+pub struct MaterialDatabase {
+    materials: Vec<MaterialDef>,
+    phase_transitions: Vec<PhaseTransitionDef>,
+    reactions: Vec<ReactionDef>,
+}
+
+impl MaterialDatabase {
+    /// Validate and construct a [`MaterialDatabase`] from a parsed RON definition.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ContentError`] if:
+    /// - Any material IDs are duplicated
+    /// - Phase transitions reference unknown material IDs
+    /// - Reactions reference unknown material IDs
+    /// - Too many phase transition rules for the GPU buffer
+    pub fn from_def(def: MaterialDatabaseDef) -> std::result::Result<Self, ContentError> {
+        // Check for duplicate material ids
+        let mut seen_ids = HashSet::new();
+        for mat in &def.materials {
+            if !seen_ids.insert(mat.id) {
+                return Err(ContentError::DuplicateMaterialId(mat.id));
+            }
+        }
+
+        // Validate phase transition material references
+        for pt in &def.phase_transitions {
+            if !seen_ids.contains(&pt.from_material) {
+                return Err(ContentError::UnknownTransitionMaterial(pt.from_material));
+            }
+            if !seen_ids.contains(&pt.to_material) {
+                return Err(ContentError::UnknownTransitionMaterial(pt.to_material));
+            }
+        }
+
+        // Validate reaction material references
+        for r in &def.reactions {
+            if !seen_ids.contains(&r.reactant_a) {
+                return Err(ContentError::UnknownReactionMaterial(r.reactant_a));
+            }
+            if !seen_ids.contains(&r.reactant_b) {
+                return Err(ContentError::UnknownReactionMaterial(r.reactant_b));
+            }
+            if !seen_ids.contains(&r.product_a_material) {
+                return Err(ContentError::UnknownReactionMaterial(r.product_a_material));
+            }
+            if !seen_ids.contains(&r.product_b_material) {
+                return Err(ContentError::UnknownReactionMaterial(r.product_b_material));
+            }
+        }
+
+        if def.phase_transitions.len() > MAX_PHASE_RULES {
+            return Err(ContentError::TooManyPhaseRules {
+                count: def.phase_transitions.len(),
+                max: MAX_PHASE_RULES,
+            });
+        }
+
+        tracing::info!(
+            "Loaded {} materials, {} phase transitions, {} reactions",
+            def.materials.len(),
+            def.phase_transitions.len(),
+            def.reactions.len(),
+        );
+
+        Ok(Self {
+            materials: def.materials,
+            phase_transitions: def.phase_transitions,
+            reactions: def.reactions,
+        })
+    }
+
+    /// Convert materials to the GPU-friendly array indexed by material ID.
+    ///
+    /// Returns a fixed-size array of [`MaterialParams`] where each material
+    /// is placed at its `id` index. Unused slots are zeroed.
+    pub fn material_params(&self) -> [MaterialParams; MATERIAL_COUNT] {
+        let mut table = [MaterialParams {
+            elastic: Vec4::ZERO,
+            thermal: Vec4::ZERO,
+            visual: Vec4::ZERO,
+            color: Vec4::ZERO,
+        }; MATERIAL_COUNT];
+
+        for mat in &self.materials {
+            let idx = mat.id as usize;
+            if idx < MATERIAL_COUNT {
+                table[idx] = MaterialParams {
+                    elastic: Vec4::new(
+                        mat.elastic.youngs_modulus,
+                        mat.elastic.poissons_ratio,
+                        mat.elastic.yield_stress,
+                        mat.elastic.viscosity,
+                    ),
+                    thermal: Vec4::new(
+                        mat.thermal.melting_point,
+                        mat.thermal.boiling_point,
+                        mat.thermal.heat_conductivity,
+                        mat.thermal.specific_heat,
+                    ),
+                    visual: Vec4::new(
+                        mat.visual.density,
+                        mat.visual.emissive_temp,
+                        mat.visual.opacity,
+                        0.0,
+                    ),
+                    color: Vec4::new(mat.visual.color[0], mat.visual.color[1], mat.visual.color[2], 0.0),
+                };
+            }
+        }
+
+        table
+    }
+
+    /// Convert phase transitions to the GPU-friendly fixed-size array.
+    ///
+    /// Returns the array and the count of valid entries. Entries beyond `count`
+    /// are zeroed.
+    pub fn phase_transition_rules(&self) -> ([PhaseTransitionRule; MAX_PHASE_RULES], usize) {
+        let mut table = [PhaseTransitionRule {
+            materials: glam::UVec4::ZERO,
+            conditions: Vec4::ZERO,
+        }; MAX_PHASE_RULES];
+
+        for (i, pt) in self.phase_transitions.iter().enumerate() {
+            if i >= MAX_PHASE_RULES {
+                break;
+            }
+            let mut flags: u32 = 0;
+            if pt.reset_deformation {
+                flags |= FLAG_RESET_F;
+            }
+            if pt.explosion {
+                flags |= FLAG_EXPLOSION;
+            }
+            table[i] = PhaseTransitionRule {
+                materials: glam::UVec4::new(
+                    pt.from_material,
+                    pt.from_phase.to_u32(),
+                    pt.to_material,
+                    pt.to_phase.to_u32(),
+                ),
+                conditions: Vec4::new(pt.temp_min, pt.temp_max, flags as f32, 0.0),
+            };
+        }
+
+        (table, self.phase_transitions.len().min(MAX_PHASE_RULES))
+    }
+
+    /// Convert reactions to shared [`ReactionRule`] structs.
+    ///
+    /// Returns a `Vec` of reaction rules ready for use by the simulation.
+    pub fn reaction_rules(&self) -> Vec<ReactionRule> {
+        self.reactions
+            .iter()
+            .map(|r| ReactionRule {
+                reactant_a_material: r.reactant_a,
+                reactant_b_material: r.reactant_b,
+                product_a_material: r.product_a_material,
+                product_a_phase: r.product_a_phase.to_u32(),
+                product_b_material: r.product_b_material,
+                product_b_phase: r.product_b_phase.to_u32(),
+                min_temperature: r.min_temperature,
+                product_a_temp: r.product_a_temp,
+                product_b_temp: r.product_b_temp,
+            })
+            .collect()
+    }
+
+    /// Get the list of material definitions.
+    pub fn materials(&self) -> &[MaterialDef] {
+        &self.materials
+    }
+
+    /// Get the list of phase transition definitions.
+    pub fn phase_transitions(&self) -> &[PhaseTransitionDef] {
+        &self.phase_transitions
+    }
+
+    /// Get the list of reaction definitions.
+    pub fn reactions(&self) -> &[ReactionDef] {
+        &self.reactions
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use shared::material;
+    use shared::reaction;
+
+    use crate::parse_material_database;
+
+    /// Load the canonical RON file and compare with hardcoded defaults.
+    #[test]
+    fn ron_matches_hardcoded_materials() {
+        let ron_str = include_str!("../../../assets/materials.ron");
+        let db = parse_material_database(ron_str).expect("Failed to parse materials.ron");
+        let loaded = db.material_params();
+        let hardcoded = material::default_material_table();
+
+        for i in 0..material::MATERIAL_COUNT {
+            let l = &loaded[i];
+            let h = &hardcoded[i];
+            assert!(
+                vecs_approx_eq(l.elastic, h.elastic),
+                "Material {i} elastic mismatch: loaded={:?} hardcoded={:?}",
+                l.elastic,
+                h.elastic,
+            );
+            assert!(
+                vecs_approx_eq(l.thermal, h.thermal),
+                "Material {i} thermal mismatch: loaded={:?} hardcoded={:?}",
+                l.thermal,
+                h.thermal,
+            );
+            assert!(
+                vecs_approx_eq(l.visual, h.visual),
+                "Material {i} visual mismatch: loaded={:?} hardcoded={:?}",
+                l.visual,
+                h.visual,
+            );
+            assert!(
+                vecs_approx_eq(l.color, h.color),
+                "Material {i} color mismatch: loaded={:?} hardcoded={:?}",
+                l.color,
+                h.color,
+            );
+        }
+    }
+
+    #[test]
+    fn ron_matches_hardcoded_phase_transitions() {
+        let ron_str = include_str!("../../../assets/materials.ron");
+        let db = parse_material_database(ron_str).expect("Failed to parse materials.ron");
+        let (loaded, loaded_count) = db.phase_transition_rules();
+        let (hardcoded, hardcoded_count) = reaction::default_phase_transition_table();
+
+        assert_eq!(loaded_count, hardcoded_count, "Phase rule count mismatch");
+        for i in 0..loaded_count {
+            assert_eq!(
+                loaded[i].materials, hardcoded[i].materials,
+                "Phase rule {i} materials mismatch"
+            );
+            assert!(
+                vecs_approx_eq(loaded[i].conditions, hardcoded[i].conditions),
+                "Phase rule {i} conditions mismatch: loaded={:?} hardcoded={:?}",
+                loaded[i].conditions,
+                hardcoded[i].conditions,
+            );
+        }
+    }
+
+    #[test]
+    fn ron_matches_hardcoded_reactions() {
+        let ron_str = include_str!("../../../assets/materials.ron");
+        let db = parse_material_database(ron_str).expect("Failed to parse materials.ron");
+        let loaded = db.reaction_rules();
+        let hardcoded = reaction::default_reaction_table();
+
+        assert_eq!(loaded.len(), hardcoded.len(), "Reaction count mismatch");
+        for (i, (l, h)) in loaded.iter().zip(hardcoded.iter()).enumerate() {
+            assert_eq!(l.reactant_a_material, h.reactant_a_material, "Reaction {i} reactant_a");
+            assert_eq!(l.reactant_b_material, h.reactant_b_material, "Reaction {i} reactant_b");
+            assert_eq!(l.product_a_material, h.product_a_material, "Reaction {i} product_a_mat");
+            assert_eq!(l.product_a_phase, h.product_a_phase, "Reaction {i} product_a_phase");
+            assert_eq!(l.product_b_material, h.product_b_material, "Reaction {i} product_b_mat");
+            assert_eq!(l.product_b_phase, h.product_b_phase, "Reaction {i} product_b_phase");
+            assert!(
+                floats_approx_eq(l.min_temperature, h.min_temperature),
+                "Reaction {i} min_temp mismatch",
+            );
+            assert!(
+                floats_approx_eq(l.product_a_temp, h.product_a_temp),
+                "Reaction {i} product_a_temp mismatch",
+            );
+            assert!(
+                floats_approx_eq(l.product_b_temp, h.product_b_temp),
+                "Reaction {i} product_b_temp mismatch",
+            );
+        }
+    }
+
+    #[test]
+    fn duplicate_material_id_rejected() {
+        let ron = r#"(
+            materials: [
+                (name: "A", id: 0, default_phase: Solid, elastic: (youngs_modulus: 0.0, poissons_ratio: 0.0, yield_stress: 0.0, viscosity: 0.0), thermal: (melting_point: Inf, boiling_point: Inf, heat_conductivity: 0.0, specific_heat: 0.0), visual: (density: 0.0, emissive_temp: Inf, opacity: 1.0, color: [0.0, 0.0, 0.0])),
+                (name: "B", id: 0, default_phase: Solid, elastic: (youngs_modulus: 0.0, poissons_ratio: 0.0, yield_stress: 0.0, viscosity: 0.0), thermal: (melting_point: Inf, boiling_point: Inf, heat_conductivity: 0.0, specific_heat: 0.0), visual: (density: 0.0, emissive_temp: Inf, opacity: 1.0, color: [0.0, 0.0, 0.0])),
+            ],
+            phase_transitions: [],
+            reactions: [],
+        )"#;
+        let result = parse_material_database(ron);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn unknown_transition_material_rejected() {
+        let ron = r#"(
+            materials: [
+                (name: "A", id: 0, default_phase: Solid, elastic: (youngs_modulus: 0.0, poissons_ratio: 0.0, yield_stress: 0.0, viscosity: 0.0), thermal: (melting_point: Inf, boiling_point: Inf, heat_conductivity: 0.0, specific_heat: 0.0), visual: (density: 0.0, emissive_temp: Inf, opacity: 1.0, color: [0.0, 0.0, 0.0])),
+            ],
+            phase_transitions: [
+                (from_material: 0, from_phase: Solid, to_material: 99, to_phase: Liquid, temp_min: 100.0, temp_max: Inf, reset_deformation: true),
+            ],
+            reactions: [],
+        )"#;
+        let result = parse_material_database(ron);
+        assert!(result.is_err());
+    }
+
+    /// Compare two Vec4s with tolerance, treating f32::MAX == f32::MAX as equal.
+    fn vecs_approx_eq(a: glam::Vec4, b: glam::Vec4) -> bool {
+        floats_approx_eq(a.x, b.x)
+            && floats_approx_eq(a.y, b.y)
+            && floats_approx_eq(a.z, b.z)
+            && floats_approx_eq(a.w, b.w)
+    }
+
+    fn floats_approx_eq(a: f32, b: f32) -> bool {
+        if a == b {
+            return true; // handles infinity, MAX, MIN
+        }
+        if a.is_nan() && b.is_nan() {
+            return true;
+        }
+        (a - b).abs() < 1e-3
+    }
+}

--- a/crates/content/src/lib.rs
+++ b/crates/content/src/lib.rs
@@ -1,0 +1,70 @@
+//! # content
+//!
+//! Data-driven material, phase transition, and reaction loading from RON files.
+//!
+//! This crate bridges the gap between human-readable RON definition files in
+//! `assets/` and the GPU-friendly `#[repr(C)]` structs defined in `shared`.
+//! It is CPU-only (not `no_std`) and depends on `serde` + `ron`.
+
+mod convert;
+mod types;
+
+pub use convert::MaterialDatabase;
+pub use types::*;
+
+/// Errors that can occur when loading content files.
+#[derive(Debug, thiserror::Error)]
+pub enum ContentError {
+    /// Failed to read the file from disk.
+    #[error("failed to read content file: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// Failed to parse the RON content.
+    #[error("failed to parse RON: {0}")]
+    Ron(#[from] ron::error::SpannedError),
+
+    /// A material definition has a duplicate id.
+    #[error("duplicate material id {0}")]
+    DuplicateMaterialId(u32),
+
+    /// A phase transition references an unknown material id.
+    #[error("phase transition references unknown material id {0}")]
+    UnknownTransitionMaterial(u32),
+
+    /// A reaction references an unknown material id.
+    #[error("reaction references unknown material id {0}")]
+    UnknownReactionMaterial(u32),
+
+    /// Too many phase transition rules for the GPU buffer.
+    #[error("too many phase transition rules: {count} exceeds maximum {max}")]
+    TooManyPhaseRules { count: usize, max: usize },
+}
+
+/// Load a [`MaterialDatabase`] from a RON file at the given path.
+///
+/// Parses the file, validates all cross-references, and returns a database
+/// ready to be converted into GPU-friendly structs via its accessor methods.
+///
+/// # Errors
+///
+/// Returns [`ContentError`] if the file cannot be read, parsed, or if
+/// validation fails (duplicate ids, unknown material references, etc.).
+pub fn load_material_database(path: &str) -> std::result::Result<MaterialDatabase, ContentError> {
+    let content = std::fs::read_to_string(path)?;
+    parse_material_database(&content)
+}
+
+/// Parse a [`MaterialDatabase`] from a RON string.
+///
+/// Same as [`load_material_database`] but operates on an in-memory string.
+/// Useful for testing without filesystem access.
+///
+/// # Errors
+///
+/// Returns [`ContentError`] if parsing or validation fails.
+pub fn parse_material_database(
+    ron_str: &str,
+) -> std::result::Result<MaterialDatabase, ContentError> {
+    let raw: types::MaterialDatabaseDef = ron::from_str(ron_str)?;
+    MaterialDatabase::from_def(raw)
+}

--- a/crates/content/src/types.rs
+++ b/crates/content/src/types.rs
@@ -1,0 +1,153 @@
+//! RON-deserializable type definitions for material content.
+//!
+//! These types mirror the GPU-friendly structs in `shared` but use
+//! human-readable field names and nested grouping suitable for RON files.
+
+use serde::Deserialize;
+
+/// Top-level RON structure containing all material definitions.
+#[derive(Debug, Deserialize)]
+pub struct MaterialDatabaseDef {
+    /// All material definitions, indexed by their `id` field.
+    pub materials: Vec<MaterialDef>,
+    /// Phase transition rules (temperature-driven).
+    pub phase_transitions: Vec<PhaseTransitionDef>,
+    /// Chemical reaction rules (contact-driven).
+    pub reactions: Vec<ReactionDef>,
+}
+
+/// A single material definition in the RON file.
+#[derive(Debug, Deserialize)]
+pub struct MaterialDef {
+    /// Human-readable name (e.g. "Stone", "Water").
+    pub name: String,
+    /// Numeric material ID. Must match the constants in `shared::material`.
+    pub id: u32,
+    /// Default phase for freshly-spawned particles of this material.
+    pub default_phase: PhaseDef,
+    /// Elastic / mechanical properties.
+    pub elastic: ElasticDef,
+    /// Thermal properties.
+    pub thermal: ThermalDef,
+    /// Visual / rendering properties.
+    pub visual: VisualDef,
+}
+
+/// Phase identifier used in RON files.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+pub enum PhaseDef {
+    /// Solid phase (0).
+    Solid,
+    /// Liquid phase (1).
+    Liquid,
+    /// Gas phase (2).
+    Gas,
+}
+
+impl PhaseDef {
+    /// Convert to the `u32` constant used by `shared`.
+    pub fn to_u32(self) -> u32 {
+        match self {
+            PhaseDef::Solid => shared::material::PHASE_SOLID,
+            PhaseDef::Liquid => shared::material::PHASE_LIQUID,
+            PhaseDef::Gas => shared::material::PHASE_GAS,
+        }
+    }
+}
+
+/// Elastic / mechanical properties of a material.
+#[derive(Debug, Deserialize)]
+pub struct ElasticDef {
+    /// Young's modulus (stiffness). 0 for liquids/gas.
+    pub youngs_modulus: f32,
+    /// Poisson's ratio.
+    pub poissons_ratio: f32,
+    /// Yield stress (fracture threshold). 0 for liquids.
+    pub yield_stress: f32,
+    /// Dynamic viscosity. 0 for solids.
+    pub viscosity: f32,
+}
+
+/// Thermal properties of a material.
+#[derive(Debug, Deserialize)]
+pub struct ThermalDef {
+    /// Temperature at which material melts. Use `3.4028235e38` if it doesn't melt.
+    pub melting_point: FloatOrInf,
+    /// Temperature at which material boils. Use `3.4028235e38` if it doesn't boil.
+    pub boiling_point: FloatOrInf,
+    /// Heat conductivity coefficient.
+    pub heat_conductivity: f32,
+    /// Specific heat capacity.
+    pub specific_heat: f32,
+}
+
+/// Visual / rendering properties of a material.
+#[derive(Debug, Deserialize)]
+pub struct VisualDef {
+    /// Density in kg/m^3.
+    pub density: f32,
+    /// Temperature above which the material glows. Use `3.4028235e38` if it never glows.
+    pub emissive_temp: FloatOrInf,
+    /// Opacity (0.0 = transparent, 1.0 = opaque).
+    pub opacity: f32,
+    /// RGB color as [r, g, b] in 0..1 range.
+    pub color: [f32; 3],
+}
+
+/// Wrapper for float values that may represent `f32::MAX` or `f32::MIN`.
+///
+/// In RON files, use numeric values directly. For sentinel values, use:
+/// - `3.4028235e38` for `f32::MAX` (material doesn't melt/boil/glow)
+/// - `-3.4028235e38` for `f32::MIN` (always triggers if below max)
+pub type FloatOrInf = f32;
+
+/// A phase transition rule definition in the RON file.
+#[derive(Debug, Deserialize)]
+pub struct PhaseTransitionDef {
+    /// Material ID of the source particle.
+    pub from_material: u32,
+    /// Phase the source particle must be in.
+    pub from_phase: PhaseDef,
+    /// Material ID after transition.
+    pub to_material: u32,
+    /// Phase after transition.
+    pub to_phase: PhaseDef,
+    /// Minimum temperature to trigger. Use `-3.4028235e38` for "always if below max".
+    pub temp_min: FloatOrInf,
+    /// Maximum temperature to trigger. Use `3.4028235e38` for "always if above min".
+    pub temp_max: FloatOrInf,
+    /// Whether to reset deformation gradient F to identity.
+    #[serde(default)]
+    pub reset_deformation: bool,
+    /// Whether to apply explosion behavior.
+    #[serde(default)]
+    pub explosion: bool,
+}
+
+/// A chemical reaction rule definition in the RON file.
+#[derive(Debug, Deserialize)]
+pub struct ReactionDef {
+    /// Material ID of the first reactant.
+    pub reactant_a: u32,
+    /// Material ID of the second reactant.
+    pub reactant_b: u32,
+    /// Material ID that reactant A becomes.
+    pub product_a_material: u32,
+    /// Phase that reactant A becomes.
+    pub product_a_phase: PhaseDef,
+    /// Material ID that reactant B becomes.
+    pub product_b_material: u32,
+    /// Phase that reactant B becomes.
+    pub product_b_phase: PhaseDef,
+    /// Minimum temperature to trigger. Use `-3.4028235e38` for instant.
+    pub min_temperature: FloatOrInf,
+    /// Temperature to assign to product A.
+    pub product_a_temp: FloatOrNan,
+    /// Temperature to assign to product B.
+    pub product_b_temp: FloatOrNan,
+}
+
+/// Wrapper for float values that may represent `f32::NAN`.
+///
+/// In RON files, use `nan` for "keep current temperature".
+pub type FloatOrNan = f32;

--- a/crates/server/src/simulation.rs
+++ b/crates/server/src/simulation.rs
@@ -65,11 +65,26 @@ pub struct GpuSimulation {
 }
 
 impl GpuSimulation {
-    /// Create a new GPU simulation orchestrator.
+    /// Create a new GPU simulation orchestrator with default (hardcoded) material tables.
     ///
     /// Loads the compiled SPIR-V shaders, creates GPU buffers and compute
     /// pipelines. The provided [`VulkanContext`] must outlive this struct.
     pub fn new(ctx: &VulkanContext) -> Result<Self> {
+        let material_table = material::default_material_table();
+        let (reaction_table, num_phase_rules) = reaction::default_phase_transition_table();
+        Self::new_with_materials(ctx, &material_table, &reaction_table, num_phase_rules)
+    }
+
+    /// Create a new GPU simulation orchestrator with externally-provided material tables.
+    ///
+    /// Use this to load data-driven materials from RON files via the `content` crate.
+    /// The provided [`VulkanContext`] must outlive this struct.
+    pub fn new_with_materials(
+        ctx: &VulkanContext,
+        material_table: &[MaterialParams; MATERIAL_COUNT],
+        reaction_table: &[PhaseTransitionRule; MAX_PHASE_RULES],
+        num_phase_rules: usize,
+    ) -> Result<Self> {
         tracing::info!("Creating GpuSimulation");
 
         // -- Shader module --
@@ -127,9 +142,8 @@ impl GpuSimulation {
             "material-buffer",
         )?;
 
-        // Upload default material table
-        let material_table = material::default_material_table();
-        buffer::upload(ctx, &material_table, &material_buffer)?;
+        // Upload material table
+        buffer::upload(ctx, material_table, &material_buffer)?;
         tracing::info!(
             "Uploaded {} materials ({} bytes) to GPU",
             MATERIAL_COUNT,
@@ -146,9 +160,8 @@ impl GpuSimulation {
             "reaction-buffer",
         )?;
 
-        // Upload default phase transition table
-        let (reaction_table, num_phase_rules) = reaction::default_phase_transition_table();
-        buffer::upload(ctx, &reaction_table, &reaction_buffer)?;
+        // Upload phase transition table
+        buffer::upload(ctx, reaction_table, &reaction_buffer)?;
         tracing::info!(
             "Uploaded {} phase transition rules ({} bytes) to GPU",
             num_phase_rules,


### PR DESCRIPTION
## Summary

- New `crates/content/` crate: loads materials, phase transitions, and reactions from `assets/materials.ron` using `serde` + `ron`
- New `assets/materials.ron`: all 7 current materials with exact same values as the hardcoded `default_material_table()`
- `GpuSimulation::new_with_materials()`: accepts externally-provided material/reaction tables instead of using hardcoded defaults
- App and headless mode try loading from RON first, fall back to hardcoded defaults if file is missing

## Details

The `content` crate defines RON-deserializable types (`MaterialDef`, `PhaseTransitionDef`, `ReactionDef`) that convert to `shared`'s GPU-friendly `MaterialParams` and `PhaseTransitionRule` structs. Validation checks for duplicate IDs, unknown material references, and rule count limits.

`shared` remains `no_std` — no serde dependency was added there.

## Test plan

- [x] `cargo test -p content` — 5 tests pass (round-trip comparison with hardcoded defaults, validation error cases)
- [x] `cargo build` — full workspace builds clean
- [ ] `cargo run -p app` — verify engine runs identically with RON-loaded materials

Closes #55, Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)