### PR TITLE
feat(shared): active cell list types and constants

### DIFF
--- a/crates/shared/src/constants.rs
+++ b/crates/shared/src/constants.rs
@@ -39,3 +39,9 @@ pub const PHYSICS_HZ: u32 = 60;
 
 /// Number of frames in flight for GPU synchronization.
 pub const FRAMES_IN_FLIGHT: u32 = 2;
+
+/// Upper bound for the active cell list (one quarter of total grid cells).
+pub const MAX_ACTIVE_CELLS: u32 = GRID_CELL_COUNT / 4;
+
+/// Workgroup size for 1D sparse dispatches over active cell lists.
+pub const SPARSE_WORKGROUP_SIZE: u32 = 64;

--- a/crates/shared/src/indirect.rs
+++ b/crates/shared/src/indirect.rs
@@ -1,0 +1,40 @@
+//! Types for GPU indirect dispatch.
+
+use bytemuck::{Pod, Zeroable};
+
+/// Arguments for `vkCmdDispatchIndirect`.
+///
+/// Matches `VkDispatchIndirectCommand` layout with padding to 16-byte alignment.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+pub struct IndirectDispatchArgs {
+    /// Number of workgroups in X dimension.
+    pub group_x: u32,
+    /// Number of workgroups in Y dimension.
+    pub group_y: u32,
+    /// Number of workgroups in Z dimension.
+    pub group_z: u32,
+    /// Padding for 16-byte alignment.
+    pub _pad: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::{align_of, size_of};
+
+    #[test]
+    fn indirect_dispatch_args_layout() {
+        assert_eq!(size_of::<IndirectDispatchArgs>(), 16);
+        assert!(align_of::<IndirectDispatchArgs>() >= 4);
+    }
+
+    #[test]
+    fn indirect_dispatch_args_is_zeroable() {
+        let args = IndirectDispatchArgs::zeroed();
+        assert_eq!(args.group_x, 0);
+        assert_eq!(args.group_y, 0);
+        assert_eq!(args.group_z, 0);
+        assert_eq!(args._pad, 0);
+    }
+}

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod config;
 pub mod constants;
+pub mod indirect;
 pub mod material;
 pub mod particle;
 pub mod phase;
@@ -19,5 +20,6 @@ pub mod svd;
 
 pub use config::*;
 pub use constants::*;
+pub use indirect::IndirectDispatchArgs;
 pub use material::*;
 pub use particle::*;


### PR DESCRIPTION
## Summary
- Add `MAX_ACTIVE_CELLS` (GRID_CELL_COUNT / 4) and `SPARSE_WORKGROUP_SIZE` (64) constants to `shared::constants`
- Add `IndirectDispatchArgs` struct in new `shared::indirect` module, matching `VkDispatchIndirectCommand` layout with 16-byte alignment
- Export new types and constants from `shared::lib`

Closes #199, Part of #154

## Test plan
- [x] `cargo test -p shared` passes (58 tests including 2 new layout/zeroable tests)
- [x] `size_of::<IndirectDispatchArgs>() == 16` verified
- [x] `align_of::<IndirectDispatchArgs>() >= 4` verified
- [x] `#[repr(C)]` + `Pod` + `Zeroable` on GPU struct
- [x] No `std` usage (crate is `no_std` compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)