### PR TITLE
feat(gpu-core): add indirect dispatch support

### DIFF
--- a/crates/gpu-core/src/buffer.rs
+++ b/crates/gpu-core/src/buffer.rs
@@ -196,6 +196,24 @@ pub fn readback<T: Pod>(ctx: &VulkanContext, src: &GpuBuffer, count: usize) -> R
     Ok(result)
 }
 
+/// Size in bytes of a `VkDispatchIndirectCommand` (3 x `u32`), padded to 16 bytes
+/// for safe alignment when used as a storage buffer.
+pub const DISPATCH_INDIRECT_SIZE: vk::DeviceSize = 16;
+
+/// Create a device-local indirect dispatch buffer.
+///
+/// The buffer is sized for a single `VkDispatchIndirectCommand` (3 x `u32`, 16 bytes
+/// with padding) and has `STORAGE_BUFFER | INDIRECT_BUFFER` usage flags so it can be
+/// written by a compute shader and consumed by `vkCmdDispatchIndirect`.
+pub fn create_indirect_buffer(ctx: &VulkanContext, name: &str) -> Result<GpuBuffer> {
+    create_device_local_buffer(
+        ctx,
+        DISPATCH_INDIRECT_SIZE,
+        vk::BufferUsageFlags::STORAGE_BUFFER | vk::BufferUsageFlags::INDIRECT_BUFFER,
+        name,
+    )
+}
+
 /// Destroy a GPU buffer and free its memory allocation.
 pub fn destroy_buffer(ctx: &VulkanContext, mut buf: GpuBuffer) {
     unsafe {
@@ -234,6 +252,18 @@ mod tests {
 
         destroy_buffer(&ctx, device_buf);
         destroy_buffer(&ctx, staging_buf);
+    }
+
+    #[test]
+    fn create_indirect_buffer_works() {
+        let ctx = VulkanContext::new().expect("Failed to create VulkanContext");
+
+        let buf = create_indirect_buffer(&ctx, "test-indirect-buf")
+            .expect("Failed to create indirect buffer");
+        assert_ne!(buf.buffer, vk::Buffer::null());
+        assert_eq!(buf.size, DISPATCH_INDIRECT_SIZE);
+
+        destroy_buffer(&ctx, buf);
     }
 
     #[test]

--- a/crates/gpu-core/src/pipeline.rs
+++ b/crates/gpu-core/src/pipeline.rs
@@ -208,6 +208,29 @@ pub fn update_descriptor_sets(ctx: &VulkanContext, bindings: &[BufferBinding<'_>
     }
 }
 
+/// Record an indirect dispatch command.
+///
+/// Reads the workgroup counts from `buffer` at the given byte `offset`.
+/// The buffer must contain a valid `VkDispatchIndirectCommand` (3 x `u32`:
+/// group_count_x, group_count_y, group_count_z) at that offset.
+///
+/// # Safety
+///
+/// The caller must ensure:
+/// - `cmd` is in the recording state with a compute pipeline bound.
+/// - `buffer` contains a valid `VkDispatchIndirectCommand` at `offset`.
+/// - `buffer` was created with `INDIRECT_BUFFER` usage.
+pub fn cmd_dispatch_indirect(
+    device: &ash::Device,
+    cmd: vk::CommandBuffer,
+    buffer: &crate::buffer::GpuBuffer,
+    offset: vk::DeviceSize,
+) {
+    unsafe {
+        device.cmd_dispatch_indirect(cmd, buffer.buffer, offset);
+    }
+}
+
 /// Destroy a shader module.
 pub fn destroy_shader_module(ctx: &VulkanContext, module: vk::ShaderModule) {
     unsafe {


### PR DESCRIPTION
## Summary
- Add `create_indirect_buffer(ctx, name)` in `buffer.rs` — creates a 16-byte device-local buffer with `STORAGE_BUFFER | INDIRECT_BUFFER` usage for `VkDispatchIndirectCommand`
- Add `cmd_dispatch_indirect(device, cmd, buffer, offset)` in `pipeline.rs` — records a `vkCmdDispatchIndirect` command
- Add `DISPATCH_INDIRECT_SIZE` constant (16 bytes)
- Add unit test for indirect buffer creation

Closes #198, Part of #154

## Test plan
- [x] `cargo check -p gpu-core` passes
- [ ] `cargo test -p gpu-core -- --test-threads=1` passes (requires GPU)

🤖 Generated with [Claude Code](https://claude.com/claude-code)