### PR TITLE
feat(shaders): sparse grid dispatch compute shaders

### DIFF
--- a/crates/shaders/src/compute/clear_grid_sparse.rs
+++ b/crates/shaders/src/compute/clear_grid_sparse.rs
@@ -1,0 +1,48 @@
+//! Sparse clear grid compute shader.
+//!
+//! Zeros only the active grid cells (identified by the mark_active pass)
+//! instead of clearing the entire grid. Also resets the mark buffer entries
+//! for those cells, preparing them for the next frame's mark_active pass.
+//!
+//! Dispatched indirectly using the output of prepare_indirect.
+//! Workgroup size: 64 threads, 1D dispatch.
+
+use crate::types::GridCell;
+use spirv_std::glam::{UVec3, Vec4};
+use spirv_std::spirv;
+
+/// Zero out a single grid cell's fields.
+///
+/// Separated into a helper function for the rust-gpu linker bug workaround
+/// (see CLAUDE.md trap #4a).
+pub fn zero_active_cell(grid: &mut [GridCell], mark: &mut [u32], cell_idx: u32) {
+    let i = cell_idx as usize;
+    grid[i].velocity_mass = Vec4::ZERO;
+    grid[i].force_pad = Vec4::ZERO;
+    grid[i].temp_pad = Vec4::ZERO;
+    mark[i] = 0;
+}
+
+/// Compute shader entry point: sparse grid clear.
+///
+/// Descriptor set 0, binding 0: storage buffer of `u32` (active_cells list, read).
+/// Descriptor set 0, binding 1: storage buffer of `GridCell` (grid, write).
+/// Descriptor set 0, binding 2: storage buffer of `u32` (mark buffer, write).
+/// Descriptor set 0, binding 3: storage buffer of `u32` (active_count, read).
+/// Dispatched indirectly via `vkCmdDispatchIndirect`.
+#[spirv(compute(threads(64)))]
+pub fn clear_grid_sparse(
+    #[spirv(global_invocation_id)] id: UVec3,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] active_cells: &[u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] grid: &mut [GridCell],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] mark: &mut [u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] active_count: &[u32],
+) {
+    let idx = id.x;
+    let count = active_count[0];
+    if idx >= count {
+        return;
+    }
+    let cell_idx = active_cells[idx as usize];
+    zero_active_cell(grid, mark, cell_idx);
+}

--- a/crates/shaders/src/compute/grid_update_sparse.rs
+++ b/crates/shaders/src/compute/grid_update_sparse.rs
@@ -1,0 +1,160 @@
+//! Sparse grid update compute shader.
+//!
+//! Processes only active grid cells (identified by the mark_active pass)
+//! instead of iterating the entire grid. Each thread processes one active cell:
+//! converts accumulated momentum to velocity, applies gravity, and enforces
+//! boundary conditions.
+//!
+//! Dispatched indirectly using the output of prepare_indirect.
+//! Workgroup size: 64 threads, 1D dispatch.
+
+use crate::types::GridCell;
+use spirv_std::glam::{UVec3, Vec4};
+use spirv_std::spirv;
+
+/// Push constants for the sparse grid update shader.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct GridUpdateSparsePushConstants {
+    /// Grid dimension (cells per axis).
+    pub grid_size: u32,
+    /// Simulation timestep.
+    pub dt: f32,
+    /// Gravity acceleration (negative Y, e.g., -196.0).
+    pub gravity: f32,
+    /// Padding for alignment.
+    pub _pad: u32,
+}
+
+/// Apply boundary damping for cells at grid edges.
+///
+/// Returns the (possibly clamped) velocity components.
+/// Helper to keep the main update logic concise (trap #15).
+pub fn apply_boundary(
+    vx: f32,
+    vy: f32,
+    vz: f32,
+    ix: u32,
+    iy: u32,
+    iz: u32,
+    grid_size: u32,
+) -> (f32, f32, f32) {
+    let boundary = 1_u32;
+    let upper = grid_size - boundary - 1;
+    let mut out_vx = vx;
+    let mut out_vy = vy;
+    let mut out_vz = vz;
+    if ix <= boundary || ix >= upper {
+        out_vx = 0.0;
+    }
+    if iy <= boundary || iy >= upper {
+        out_vy = 0.0;
+    }
+    if iz <= boundary || iz >= upper {
+        out_vz = 0.0;
+    }
+    (out_vx, out_vy, out_vz)
+}
+
+/// Apply solid boundary damping based on the solid flag accumulated by P2G.
+///
+/// Deep inside solid (flag > 2.0): fully zero velocity.
+/// At boundary (flag > 0.5): strongly damp but allow some flow.
+/// Helper to keep the main update logic concise (trap #15).
+pub fn apply_solid_damping(vx: f32, vy: f32, vz: f32, solid_flag: f32) -> (f32, f32, f32) {
+    if solid_flag > 2.0 {
+        return (0.0, 0.0, 0.0);
+    }
+    if solid_flag > 0.5 {
+        let damp = 1.0 - (solid_flag / 3.0).min(0.9);
+        return (vx * damp, vy * damp, vz * damp);
+    }
+    (vx, vy, vz)
+}
+
+/// Update a single active grid cell: momentum -> velocity, gravity, boundaries.
+///
+/// Contains the same physics logic as `grid_update::update_cell` but takes a
+/// flat cell index and grid_size for index decomposition.
+/// Separated into a helper function for the rust-gpu linker bug workaround (trap #4a).
+pub fn update_active_cell(
+    cell: &mut GridCell,
+    ix: u32,
+    iy: u32,
+    iz: u32,
+    grid_size: u32,
+    dt: f32,
+    gravity: f32,
+) {
+    let mass = cell.velocity_mass.w;
+
+    // Skip empty cells (mass below threshold)
+    if mass < 1.0e-6 {
+        cell.velocity_mass = Vec4::ZERO;
+        cell.temp_pad = Vec4::ZERO;
+        return;
+    }
+
+    // Convert momentum to velocity: v = momentum / mass
+    let mut vx = cell.velocity_mass.x / mass;
+    let mut vy = cell.velocity_mass.y / mass;
+    let mut vz = cell.velocity_mass.z / mass;
+
+    // Add force contribution: v += (force / mass) * dt
+    vx += (cell.force_pad.x / mass) * dt;
+    vy += (cell.force_pad.y / mass) * dt;
+    vz += (cell.force_pad.z / mass) * dt;
+
+    // Apply gravity
+    vy += gravity * dt;
+
+    // Apply boundary conditions
+    let (bx, by, bz) = apply_boundary(vx, vy, vz, ix, iy, iz, grid_size);
+    vx = bx;
+    vy = by;
+    vz = bz;
+
+    // Apply solid damping
+    let solid_flag = cell.force_pad.w;
+    let (sx, sy, sz) = apply_solid_damping(vx, vy, vz, solid_flag);
+    vx = sx;
+    vy = sy;
+    vz = sz;
+
+    cell.velocity_mass = Vec4::new(vx, vy, vz, mass);
+
+    // Normalize accumulated temperature by mass
+    let cell_temp = cell.temp_pad.x / mass;
+    cell.temp_pad = Vec4::new(cell_temp, 0.0, 0.0, 0.0);
+}
+
+/// Compute shader entry point: sparse grid velocity update.
+///
+/// Descriptor set 0, binding 0: storage buffer of `u32` (active_cells, read).
+/// Descriptor set 0, binding 1: storage buffer of `GridCell` (grid, read-write).
+/// Descriptor set 0, binding 2: storage buffer of `u32` (active_count, read).
+/// Push constants: `GridUpdateSparsePushConstants`.
+/// Dispatched indirectly via `vkCmdDispatchIndirect`.
+#[spirv(compute(threads(64)))]
+pub fn grid_update_sparse(
+    #[spirv(global_invocation_id)] id: UVec3,
+    #[spirv(push_constant)] push: &GridUpdateSparsePushConstants,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] active_cells: &[u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] grid: &mut [GridCell],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] active_count: &[u32],
+) {
+    let idx = id.x;
+    let count = active_count[0];
+    if idx >= count {
+        return;
+    }
+    let cell_idx = active_cells[idx as usize] as usize;
+
+    // Convert flat index back to 3D for boundary checks
+    let gz = push.grid_size;
+    let ix = (cell_idx as u32) / (gz * gz);
+    let iy = ((cell_idx as u32) / gz) % gz;
+    let iz = (cell_idx as u32) % gz;
+
+    update_active_cell(&mut grid[cell_idx], ix, iy, iz, gz, push.dt, push.gravity);
+}

--- a/crates/shaders/src/compute/mark_active.rs
+++ b/crates/shaders/src/compute/mark_active.rs
@@ -1,0 +1,180 @@
+//! Mark active grid cells compute shader.
+//!
+//! Runs per-particle (1D dispatch, 64 threads/workgroup). For each particle,
+//! marks the 3x3x3 neighborhood of grid cells that the particle influences.
+//! Uses atomic operations to build a compact list of unique active cell indices.
+//!
+//! The mark buffer (one u32 per grid cell) tracks which cells have already been
+//! added to the active list, avoiding duplicates. An atomic counter tracks the
+//! total number of active cells.
+
+use crate::types::Particle;
+use spirv_std::glam::UVec3;
+use spirv_std::spirv;
+
+/// Push constants for the mark_active shader.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct MarkActivePushConstants {
+    /// Grid dimension (cells per axis).
+    pub grid_size: u32,
+    /// Total number of particles.
+    pub num_particles: u32,
+    /// Padding for alignment.
+    pub _pad0: u32,
+    /// Padding for alignment.
+    pub _pad1: u32,
+}
+
+/// Atomically try to set a mark buffer entry from 0 to 1, returning the old value.
+///
+/// Uses `atomic_u_max` with value 1 on SPIR-V targets. Since marks are 0 or 1,
+/// max(0, 1) = 1 sets the mark, and the returned old value tells us whether
+/// this thread was the first to mark it.
+///
+/// Falls back to non-atomic read-write on CPU (for testing).
+///
+/// # Safety
+/// Caller must ensure `mark[index]` is valid and properly aligned for atomic access.
+#[inline]
+pub unsafe fn mark_atomic_set(mark: &mut [u32], index: usize) -> u32 {
+    #[cfg(target_arch = "spirv")]
+    {
+        unsafe { spirv_std::arch::atomic_u_max::<u32, 1u32, 0x0u32>(&mut mark[index], 1) }
+    }
+    #[cfg(not(target_arch = "spirv"))]
+    {
+        let old = mark[index];
+        mark[index] = 1;
+        old
+    }
+}
+
+/// Atomically increment a u32 counter, returning the old value (used as a slot index).
+///
+/// Uses `spirv_std::arch::atomic_i_add` on SPIR-V targets (works for unsigned too
+/// since the bit pattern addition is the same).
+///
+/// Falls back to non-atomic increment on CPU (for testing).
+///
+/// # Safety
+/// Caller must ensure `counter[index]` is valid and properly aligned for atomic access.
+#[inline]
+pub unsafe fn atomic_add_u32(counter: &mut [u32], index: usize, value: u32) -> u32 {
+    #[cfg(target_arch = "spirv")]
+    {
+        unsafe { spirv_std::arch::atomic_i_add::<u32, 1u32, 0x0u32>(&mut counter[index], value) }
+    }
+    #[cfg(not(target_arch = "spirv"))]
+    {
+        let old = counter[index];
+        counter[index] = old + value;
+        old
+    }
+}
+
+/// Try to mark a single grid cell as active.
+///
+/// If the cell coordinates are in bounds and the cell hasn't been marked yet,
+/// atomically marks it and appends its flat index to the active_cells list.
+///
+/// Helper function to avoid long if/else chains in the 3x3x3 loop (trap #15)
+/// and to satisfy the entry-point-must-call-helper requirement (trap #4a).
+pub fn try_mark_cell(
+    ci: i32,
+    cj: i32,
+    ck: i32,
+    grid_size: u32,
+    mark: &mut [u32],
+    active_cells: &mut [u32],
+    active_count: &mut [u32],
+) {
+    let gs = grid_size as i32;
+    if ci < 0 || ci >= gs || cj < 0 || cj >= gs || ck < 0 || ck >= gs {
+        return;
+    }
+    let cell_idx = (ci as u32) * grid_size * grid_size + (cj as u32) * grid_size + (ck as u32);
+
+    // Atomically try to mark this cell. If old value was 0, we are the first thread.
+    let old = unsafe { mark_atomic_set(mark, cell_idx as usize) };
+    if old == 0 {
+        // We won the race — append to active list
+        let slot = unsafe { atomic_add_u32(active_count, 0, 1) };
+        active_cells[slot as usize] = cell_idx;
+    }
+}
+
+/// Scatter marks for a single particle's 3x3x3 grid neighborhood.
+///
+/// Iterates over the 27 neighboring cells and calls `try_mark_cell` for each.
+/// Uses while-loops (not for-loops) since rust-gpu doesn't support range iteration.
+/// Copies particle fields to locals to avoid buffer references in loops (trap #21).
+pub fn scatter_marks(
+    pos_x: f32,
+    pos_y: f32,
+    pos_z: f32,
+    grid_size: u32,
+    mark: &mut [u32],
+    active_cells: &mut [u32],
+    active_count: &mut [u32],
+) {
+    let base_x = pos_x as i32 - 1;
+    let base_y = pos_y as i32 - 1;
+    let base_z = pos_z as i32 - 1;
+
+    let mut di = 0i32;
+    while di < 3 {
+        let mut dj = 0i32;
+        while dj < 3 {
+            let mut dk = 0i32;
+            while dk < 3 {
+                try_mark_cell(
+                    base_x + di,
+                    base_y + dj,
+                    base_z + dk,
+                    grid_size,
+                    mark,
+                    active_cells,
+                    active_count,
+                );
+                dk += 1;
+            }
+            dj += 1;
+        }
+        di += 1;
+    }
+}
+
+/// Compute shader entry point: mark active grid cells.
+///
+/// Descriptor set 0, binding 0: storage buffer of `Particle` (read).
+/// Descriptor set 0, binding 1: storage buffer of `u32` (mark buffer, read-write).
+/// Descriptor set 0, binding 2: storage buffer of `u32` (active cells list, write).
+/// Descriptor set 0, binding 3: storage buffer of `u32` (active count atomic, read-write).
+/// Push constants: `MarkActivePushConstants`.
+/// Dispatch with `(ceil(num_particles / 64), 1, 1)` workgroups.
+#[spirv(compute(threads(64)))]
+pub fn mark_active(
+    #[spirv(global_invocation_id)] id: UVec3,
+    #[spirv(push_constant)] push: &MarkActivePushConstants,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] particles: &[Particle],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] mark: &mut [u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] active_cells: &mut [u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] active_count: &mut [u32],
+) {
+    let idx = id.x;
+    if idx >= push.num_particles {
+        return;
+    }
+    // Copy particle position to locals (trap #21: no references to buffer elements in loops)
+    let pos_mass = particles[idx as usize].pos_mass;
+    scatter_marks(
+        pos_mass.x,
+        pos_mass.y,
+        pos_mass.z,
+        push.grid_size,
+        mark,
+        active_cells,
+        active_count,
+    );
+}

--- a/crates/shaders/src/compute/mod.rs
+++ b/crates/shaders/src/compute/mod.rs
@@ -10,10 +10,14 @@
 //! Both views alias the same GPU buffer. Each `GridCell` = 12 contiguous f32s.
 
 pub mod clear_grid;
+pub mod clear_grid_sparse;
 pub mod explosion;
 pub mod g2p;
 pub mod grid_update;
+pub mod grid_update_sparse;
+pub mod mark_active;
 pub mod p2g;
+pub mod prepare_indirect;
 pub mod react;
 pub mod render;
 pub mod toolbar_overlay;

--- a/crates/shaders/src/compute/prepare_indirect.rs
+++ b/crates/shaders/src/compute/prepare_indirect.rs
@@ -1,0 +1,33 @@
+//! Prepare indirect dispatch arguments compute shader.
+//!
+//! Single-invocation shader that reads the active cell count and writes
+//! the indirect dispatch arguments (group_x, group_y, group_z) for the
+//! sparse grid passes (clear_grid_sparse, grid_update_sparse).
+
+use spirv_std::glam::UVec3;
+use spirv_std::spirv;
+
+/// Compute the indirect dispatch group counts from the active cell count.
+///
+/// Writes `(ceil(count / 64), 1, 1)` to the indirect args buffer.
+/// Helper function to satisfy the entry-point-must-call-helper requirement (trap #4a).
+pub fn write_indirect_args(active_count: &[u32], indirect_args: &mut [u32]) {
+    let count = active_count[0];
+    indirect_args[0] = (count + 63) / 64;
+    indirect_args[1] = 1;
+    indirect_args[2] = 1;
+}
+
+/// Compute shader entry point: prepare indirect dispatch arguments.
+///
+/// Descriptor set 0, binding 0: storage buffer of `u32` (active_count, read).
+/// Descriptor set 0, binding 1: storage buffer of `u32` (indirect_args[3], write).
+/// Dispatch with `(1, 1, 1)` workgroups.
+#[spirv(compute(threads(1)))]
+pub fn prepare_indirect(
+    #[spirv(global_invocation_id)] _id: UVec3,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] active_count: &[u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] indirect_args: &mut [u32],
+) {
+    write_indirect_args(active_count, indirect_args);
+}


### PR DESCRIPTION
## Summary
- Add `mark_active` shader: per-particle (64 threads/wg) that scans 3x3x3 neighborhoods, atomically marks cells, and builds a compact active-cell list with an atomic counter
- Add `prepare_indirect` shader: single-invocation that writes `vkCmdDispatchIndirect` args from the active count
- Add `clear_grid_sparse` shader: zeros only active grid cells and resets mark buffer (indirect dispatch)
- Add `grid_update_sparse` shader: same physics as `grid_update` but processes only active cells (indirect dispatch)

All shaders follow existing patterns: trap #4a (helper functions in entry points), trap #15 (no long if/else chains), trap #21 (copy buffer fields to locals), proper `#[repr(C)]` push constants, `spirv_std::arch` atomics with cfg fallbacks for CPU testing.

Entry point SPIR-V names:
- `compute::mark_active::mark_active`
- `compute::prepare_indirect::prepare_indirect`
- `compute::clear_grid_sparse::clear_grid_sparse`
- `compute::grid_update_sparse::grid_update_sparse`

Closes #200, Part of #154

## Test plan
- [x] `cargo check -p shaders` passes (native target, no errors)
- [ ] Full SPIR-V compilation via `spirv-builder` (verified when `cargo build -p server` runs)
- [ ] GPU integration: wire up in server pipeline with new buffers and indirect dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)