### PR TITLE
feat(shaders): brick sleep optimization for P2G/G2P

### DIFF
--- a/crates/shaders/src/compute/g2p.rs
+++ b/crates/shaders/src/compute/g2p.rs
@@ -441,12 +441,31 @@ fn reset_deformation_gradient(particle: &mut Particle) {
     particle.f_col2 = Vec4::new(0.0, 0.0, 1.0, 0.0);
 }
 
+/// Check whether the brick containing a particle position is sleeping.
+///
+/// Computes the brick index from position and looks up the sleep state buffer.
+/// Returns `true` if the brick is marked as sleeping (value != 0).
+/// Out-of-bounds positions return `false` (not sleeping) as a safe default.
+pub fn is_brick_sleeping(pos_x: f32, pos_y: f32, pos_z: f32, sleep_state: &[u32]) -> bool {
+    let brick_size: u32 = 8;
+    let bricks_per_axis: u32 = 32; // 256 / 8
+    let bx = (pos_x as u32) / brick_size;
+    let by = (pos_y as u32) / brick_size;
+    let bz = (pos_z as u32) / brick_size;
+    if bx >= bricks_per_axis || by >= bricks_per_axis || bz >= bricks_per_axis {
+        return false; // out of bounds = not sleeping
+    }
+    let brick_idx = bz * bricks_per_axis * bricks_per_axis + by * bricks_per_axis + bx;
+    sleep_state[brick_idx as usize] != 0
+}
+
 /// Compute shader entry point: Grid-to-Particle transfer.
 ///
 /// Descriptor set 0, binding 0: storage buffer of `Particle` (read-write).
 /// Descriptor set 0, binding 1: storage buffer of `GridCell` (read).
 /// Descriptor set 0, binding 2: storage buffer of `u32` (voxel grid, 4 per cell, read).
 /// Descriptor set 0, binding 3: storage buffer of `PhaseTransitionRule` (read).
+/// Descriptor set 0, binding 4: storage buffer of `u32` (sleep_state per brick, read).
 /// Push constants: `G2pPushConstants`.
 /// Dispatch with `(ceil(num_particles / 64), 1, 1)` workgroups.
 #[spirv(compute(threads(64)))]
@@ -457,11 +476,19 @@ pub fn g2p(
     #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] grid: &[GridCell],
     #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] voxels: &[u32],
     #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] reactions: &[PhaseTransitionRule],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 4)] sleep_state: &[u32],
 ) {
     let idx = id.x as usize;
     if id.x >= push.num_particles {
         return;
     }
+
+    // Copy position to locals (trap #21) and check sleep state before gathering
+    let pos_mass = particles[idx].pos_mass;
+    if is_brick_sleeping(pos_mass.x, pos_mass.y, pos_mass.z, sleep_state) {
+        return;
+    }
+
     gather_particle(
         &mut particles[idx],
         grid,

--- a/crates/shaders/src/compute/mod.rs
+++ b/crates/shaders/src/compute/mod.rs
@@ -22,6 +22,7 @@ pub mod prepare_indirect;
 pub mod react;
 pub mod render;
 pub mod toolbar_overlay;
+pub mod update_sleep;
 pub mod voxelize;
 
 /// Compute 1D quadratic B-spline weights for a particle at fractional position `fx`.

--- a/crates/shaders/src/compute/p2g.rs
+++ b/crates/shaders/src/compute/p2g.rs
@@ -309,12 +309,31 @@ pub fn scatter_particle(
     }
 }
 
+/// Check whether the brick containing a particle position is sleeping.
+///
+/// Computes the brick index from position and looks up the sleep state buffer.
+/// Returns `true` if the brick is marked as sleeping (value != 0).
+/// Out-of-bounds positions return `false` (not sleeping) as a safe default.
+pub fn is_brick_sleeping(pos_x: f32, pos_y: f32, pos_z: f32, sleep_state: &[u32]) -> bool {
+    let brick_size: u32 = 8;
+    let bricks_per_axis: u32 = 32; // 256 / 8
+    let bx = (pos_x as u32) / brick_size;
+    let by = (pos_y as u32) / brick_size;
+    let bz = (pos_z as u32) / brick_size;
+    if bx >= bricks_per_axis || by >= bricks_per_axis || bz >= bricks_per_axis {
+        return false; // out of bounds = not sleeping
+    }
+    let brick_idx = bz * bricks_per_axis * bricks_per_axis + by * bricks_per_axis + bx;
+    sleep_state[brick_idx as usize] != 0
+}
+
 /// Compute shader entry point: Particle-to-Grid transfer.
 ///
 /// Descriptor set 0, binding 0: storage buffer of `Particle` (read).
 /// Descriptor set 0, binding 1: storage buffer of `f32` (grid, read-write with atomics).
 ///   Layout: 12 floats per cell `[vel_x, vel_y, vel_z, mass, force_x, force_y, force_z, solid_flag, temp, pad, pad, pad]`.
 /// Descriptor set 0, binding 2: storage buffer of `MaterialParams` (material table, read).
+/// Descriptor set 0, binding 3: storage buffer of `u32` (sleep_state per brick, read).
 /// Push constants: `P2gPushConstants`.
 /// Dispatch with `(ceil(num_particles / 64), 1, 1)` workgroups.
 #[spirv(compute(threads(64)))]
@@ -324,10 +343,18 @@ pub fn p2g(
     #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] particles: &[Particle],
     #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] grid: &mut [f32],
     #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] materials: &[MaterialParams],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] sleep_state: &[u32],
 ) {
     let idx = id.x as usize;
     if id.x >= push.num_particles {
         return;
     }
+
+    // Copy position to locals (trap #21) and check sleep state before scattering
+    let pos_mass = particles[idx].pos_mass;
+    if is_brick_sleeping(pos_mass.x, pos_mass.y, pos_mass.z, sleep_state) {
+        return;
+    }
+
     scatter_particle(&particles[idx], grid, push.grid_size, push.dt, materials);
 }

--- a/crates/shaders/src/compute/update_sleep.rs
+++ b/crates/shaders/src/compute/update_sleep.rs
@@ -1,0 +1,78 @@
+//! Per-brick sleep state update compute shader.
+//!
+//! Runs per-brick (1D dispatch, 64 threads/workgroup). For each brick,
+//! reads the activity counter from the activity map. If the brick has been
+//! inactive for `sleep_threshold` consecutive frames, it is marked as sleeping.
+//! Active bricks reset their sleep counter immediately.
+//!
+//! Sleeping bricks are skipped by P2G and G2P to save compute bandwidth.
+
+use spirv_std::glam::UVec3;
+use spirv_std::spirv;
+
+/// Push constants for the update_sleep shader.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct UpdateSleepPushConstants {
+    /// Total number of bricks in the grid.
+    pub total_bricks: u32,
+    /// Number of inactive frames before a brick is put to sleep.
+    pub sleep_threshold: u32,
+    /// Padding for 16-byte alignment.
+    pub _pad0: u32,
+    /// Padding for 16-byte alignment.
+    pub _pad1: u32,
+}
+
+/// Update sleep state for a single brick based on its activity counter.
+///
+/// Returns `(new_counter, new_sleep_state)`:
+/// - If the brick was active (`activity > 0`): counter resets to 0, state = awake (0).
+/// - If inactive: counter increments. Once it reaches the threshold, state = sleeping (1).
+///
+/// This helper satisfies trap #4a (entry points must call at least one helper).
+pub fn update_brick(activity: u32, counter: u32, threshold: u32) -> (u32, u32) {
+    if activity > 0 {
+        // Brick had active particles this frame: reset counter, mark awake
+        (0, 0)
+    } else {
+        let new_counter = counter + 1;
+        if new_counter >= threshold {
+            // Brick has been inactive long enough: mark sleeping
+            (new_counter, 1)
+        } else {
+            // Still counting inactive frames, not sleeping yet
+            (new_counter, 0)
+        }
+    }
+}
+
+/// Compute shader entry point: update per-brick sleep state.
+///
+/// Descriptor set 0, binding 0: storage buffer of `u32` (activity_map, read).
+/// Descriptor set 0, binding 1: storage buffer of `u32` (sleep_counter, read-write).
+/// Descriptor set 0, binding 2: storage buffer of `u32` (sleep_state, write).
+/// Push constants: `UpdateSleepPushConstants`.
+/// Dispatch with `(ceil(total_bricks / 64), 1, 1)` workgroups.
+#[spirv(compute(threads(64)))]
+pub fn update_sleep(
+    #[spirv(global_invocation_id)] id: UVec3,
+    #[spirv(push_constant)] push: &UpdateSleepPushConstants,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] activity_map: &[u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] sleep_counter: &mut [u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] sleep_state: &mut [u32],
+) {
+    let idx = id.x;
+    if idx >= push.total_bricks {
+        return;
+    }
+
+    // Copy to locals to avoid reference issues (trap #21)
+    let activity = activity_map[idx as usize];
+    let counter = sleep_counter[idx as usize];
+
+    let (new_counter, new_state) = update_brick(activity, counter, push.sleep_threshold);
+
+    sleep_counter[idx as usize] = new_counter;
+    sleep_state[idx as usize] = new_state;
+}


### PR DESCRIPTION
## Summary
- New `update_sleep` compute shader (`crates/shaders/src/compute/update_sleep.rs`) that reads per-brick activity counters and maintains sleep counters/state buffers. Bricks with no active particles for `sleep_threshold` consecutive frames are marked sleeping.
- P2G entry point (`p2g`) gains binding 3 (`sleep_state: &[u32]`) — particles in sleeping bricks skip the scatter pass entirely.
- G2P entry point (`g2p`) gains binding 4 (`sleep_state: &[u32]`) — particles in sleeping bricks skip the gather pass entirely.
- Both P2G and G2P use `is_brick_sleeping` helper (BRICK_SIZE=8, BRICKS_PER_AXIS=32, ZYX indexing matching existing conventions).

Closes #213

## Test plan
- [x] `cargo build` passes (shaders compile to SPIR-V without errors)
- [ ] Server-side integration: create `sleep_counter` and `sleep_state` GPU buffers, bind to update_sleep pipeline, bind sleep_state to P2G (binding 3) and G2P (binding 4)
- [ ] Verify sleeping bricks are skipped correctly and wake up when disturbed

🤖 Generated with [Claude Code](https://claude.com/claude-code)