### PR TITLE
feat(server): integrate brick sleep buffers and passes

### DIFF
--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -19,10 +19,10 @@ pub mod simulation;
 // ---------------------------------------------------------------------------
 
 pub use push_constants::{
-    ExplosionPushConstants, G2pPushConstants, GridUpdatePushConstants,
-    GridUpdateSparsePushConstants, MarkActivePushConstants, P2gPushConstants,
-    ReactPushConstants, RenderPushConstants, ToolbarPushConstants, VoxelizePushConstants,
-    TOOLBAR_MAX_MATERIALS,
+    ComputeActivityPushConstants, ExplosionPushConstants, G2pPushConstants,
+    GridUpdatePushConstants, GridUpdateSparsePushConstants, MarkActivePushConstants,
+    P2gPushConstants, ReactPushConstants, RenderPushConstants, ToolbarPushConstants,
+    VoxelizePushConstants, TOOLBAR_MAX_MATERIALS,
 };
 pub use simulation::GpuSimulation;
 
@@ -82,6 +82,8 @@ mod tests {
         assert_eq!(mem::size_of::<MarkActivePushConstants>(), 16);
         // GridUpdateSparsePushConstants: u32 + f32 + f32 + u32 = 16 bytes
         assert_eq!(mem::size_of::<GridUpdateSparsePushConstants>(), 16);
+        // ComputeActivityPushConstants: 4 u32s = 16 bytes
+        assert_eq!(mem::size_of::<ComputeActivityPushConstants>(), 16);
         // RenderPushConstants: 4 u32s (16 bytes) + 2 Vec4s (32 bytes) = 48 bytes
         assert_eq!(mem::size_of::<RenderPushConstants>(), 48);
         // ToolbarPushConstants: 4 u32s (16 bytes) + 8 Vec4s (128 bytes) = 144 bytes

--- a/crates/server/src/push_constants.rs
+++ b/crates/server/src/push_constants.rs
@@ -135,6 +135,34 @@ pub struct GridUpdateSparsePushConstants {
     pub _pad: u32,
 }
 
+/// Push constants for the compute_activity shader.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Pod, bytemuck::Zeroable)]
+pub struct ComputeActivityPushConstants {
+    /// Grid dimension (cells per axis).
+    pub grid_size: u32,
+    /// Total number of active particles.
+    pub num_particles: u32,
+    /// Brick size (voxels per brick axis, e.g. 8).
+    pub brick_size: u32,
+    /// Padding to 16-byte alignment.
+    pub _pad: u32,
+}
+
+/// Push constants for the update_sleep shader.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Pod, bytemuck::Zeroable)]
+pub struct UpdateSleepPushConstants {
+    /// Total number of bricks in the grid.
+    pub total_bricks: u32,
+    /// Frames of zero activity before a brick enters sleep state.
+    pub sleep_threshold: u32,
+    /// Padding to 16-byte alignment.
+    pub _pad0: u32,
+    /// Padding to 16-byte alignment.
+    pub _pad1: u32,
+}
+
 /// Maximum number of material slots in the toolbar.
 pub const TOOLBAR_MAX_MATERIALS: usize = 8;
 

--- a/crates/server/src/readback.rs
+++ b/crates/server/src/readback.rs
@@ -47,6 +47,14 @@ impl GpuSimulation {
         self.render_output_buffer.buffer
     }
 
+    /// Returns a reference to the activity map buffer (for readback/debug).
+    ///
+    /// The buffer contains one `u32` per brick, where each entry holds the
+    /// number of active particles in that brick after the last `step_physics`.
+    pub fn activity_map_buffer(&self) -> &GpuBuffer {
+        &self.activity_map_buffer
+    }
+
     /// Returns a reference to the render output [`GpuBuffer`].
     ///
     /// Useful for readback operations (e.g., headless screenshot).
@@ -54,4 +62,5 @@ impl GpuSimulation {
     pub fn render_output_gpu_buffer(&self) -> &GpuBuffer {
         &self.render_output_buffer
     }
+
 }

--- a/crates/server/src/simulation.rs
+++ b/crates/server/src/simulation.rs
@@ -10,7 +10,7 @@ use gpu_core::{
 };
 use shared::{
     GRID_CELL_COUNT, GRID_SIZE, GridCell, MAX_ACTIVE_CELLS, MAX_PARTICLES, Particle,
-    RENDER_HEIGHT, RENDER_WIDTH,
+    RENDER_HEIGHT, RENDER_WIDTH, SLEEP_THRESHOLD, TOTAL_BRICKS,
     material::{self, MATERIAL_COUNT, MaterialParams},
     reaction::{self, MAX_PHASE_RULES, PhaseTransitionRule},
 };
@@ -37,6 +37,13 @@ pub struct GpuSimulation {
     pub(crate) material_buffer: GpuBuffer,
     pub(crate) reaction_buffer: GpuBuffer,
 
+    // Activity tracking
+    pub(crate) activity_map_buffer: GpuBuffer,
+
+    // Brick sleep
+    sleep_counter_buffer: GpuBuffer,
+    sleep_state_buffer: GpuBuffer,
+
     // Sparse dispatch buffers
     mark_buffer: GpuBuffer,
     active_cells_buffer: GpuBuffer,
@@ -54,6 +61,12 @@ pub struct GpuSimulation {
     toolbar_overlay_pass: ComputePass,
     react_pass: ComputePass,
     explosion_pass: ComputePass,
+
+    // Activity tracking pass
+    compute_activity_pass: ComputePass,
+
+    // Brick sleep pass
+    update_sleep_pass: ComputePass,
 
     // Sparse compute passes
     mark_active_pass: ComputePass,
@@ -181,6 +194,33 @@ impl GpuSimulation {
             reaction_buf_size
         );
 
+        // -- Activity map buffer (1 u32 per brick, 128 KB) --
+        let activity_map_buffer = buffer::create_device_local_buffer(
+            ctx,
+            (TOTAL_BRICKS as usize * 4) as vk::DeviceSize,
+            vk::BufferUsageFlags::STORAGE_BUFFER | vk::BufferUsageFlags::TRANSFER_DST,
+            "activity-map-buffer",
+        )?;
+
+        // -- Brick sleep buffers (1 u32 per brick each, 128 KB) --
+        // All bricks start awake (zeroed). Without explicit init, P2G would read
+        // garbage from sleep_state and skip particles on the first frame.
+        let sleep_counter_buffer = buffer::create_device_local_buffer(
+            ctx,
+            (TOTAL_BRICKS as usize * 4) as vk::DeviceSize,
+            vk::BufferUsageFlags::STORAGE_BUFFER | vk::BufferUsageFlags::TRANSFER_DST,
+            "sleep-counter-buffer",
+        )?;
+        let sleep_state_buffer = buffer::create_device_local_buffer(
+            ctx,
+            (TOTAL_BRICKS as usize * 4) as vk::DeviceSize,
+            vk::BufferUsageFlags::STORAGE_BUFFER | vk::BufferUsageFlags::TRANSFER_DST,
+            "sleep-state-buffer",
+        )?;
+        let zeros = vec![0u32; TOTAL_BRICKS as usize];
+        buffer::upload(ctx, &zeros, &sleep_counter_buffer)?;
+        buffer::upload(ctx, &zeros, &sleep_state_buffer)?;
+
         // -- Sparse dispatch buffers --
         let mark_buffer = buffer::create_device_local_buffer(
             ctx,
@@ -204,13 +244,13 @@ impl GpuSimulation {
             buffer::create_indirect_buffer(ctx, "indirect-dispatch-buffer")?;
 
         // -- Descriptor pool --
-        // 14 passes, max 4 bindings each = up to 56 storage buffer descriptors
+        // 16 passes, max 5 bindings each = up to 80 storage buffer descriptors
         let pool_sizes = [vk::DescriptorPoolSize {
             ty: vk::DescriptorType::STORAGE_BUFFER,
-            descriptor_count: 56,
+            descriptor_count: 80,
         }];
         let descriptor_pool =
-            pipeline::create_descriptor_pool(ctx, &pool_sizes, 14, "sim-descriptor-pool")?;
+            pipeline::create_descriptor_pool(ctx, &pool_sizes, 16, "sim-descriptor-pool")?;
 
         // -- Create each compute pass --
         // Entry point names are fully qualified module paths in rust-gpu SPIR-V.
@@ -228,7 +268,7 @@ impl GpuSimulation {
             ctx,
             shader_module,
             c"compute::p2g::p2g",
-            &[&particle_buffer, &grid_buffer, &material_buffer],
+            &[&particle_buffer, &grid_buffer, &material_buffer, &sleep_state_buffer],
             mem::size_of::<P2gPushConstants>() as u32,
             descriptor_pool,
             "p2g",
@@ -248,7 +288,7 @@ impl GpuSimulation {
             ctx,
             shader_module,
             c"compute::g2p::g2p",
-            &[&particle_buffer, &grid_buffer, &voxel_buffer, &reaction_buffer],
+            &[&particle_buffer, &grid_buffer, &voxel_buffer, &reaction_buffer, &sleep_state_buffer],
             mem::size_of::<G2pPushConstants>() as u32,
             descriptor_pool,
             "g2p",
@@ -314,6 +354,30 @@ impl GpuSimulation {
             "explosion",
         )?;
 
+        // -- Activity tracking pass --
+        // compute_activity: particles(r), activity_map(rw)
+        let compute_activity_pass = passes::create_pass(
+            ctx,
+            shader_module,
+            c"compute::compute_activity::compute_activity",
+            &[&particle_buffer, &activity_map_buffer],
+            mem::size_of::<ComputeActivityPushConstants>() as u32,
+            descriptor_pool,
+            "compute-activity",
+        )?;
+
+        // -- Brick sleep pass --
+        // update_sleep: activity_map(r), sleep_counter(rw), sleep_state(w)
+        let update_sleep_pass = passes::create_pass(
+            ctx,
+            shader_module,
+            c"compute::update_sleep::update_sleep",
+            &[&activity_map_buffer, &sleep_counter_buffer, &sleep_state_buffer],
+            mem::size_of::<UpdateSleepPushConstants>() as u32,
+            descriptor_pool,
+            "update-sleep",
+        )?;
+
         // -- Sparse dispatch passes --
         // mark_active: particles(r), mark(rw), active_cells(w), active_count(rw)
         let mark_active_pass = passes::create_pass(
@@ -368,6 +432,9 @@ impl GpuSimulation {
             render_output_buffer,
             material_buffer,
             reaction_buffer,
+            activity_map_buffer,
+            sleep_counter_buffer,
+            sleep_state_buffer,
             mark_buffer,
             active_cells_buffer,
             active_count_buffer,
@@ -382,6 +449,8 @@ impl GpuSimulation {
             toolbar_overlay_pass,
             react_pass,
             explosion_pass,
+            compute_activity_pass,
+            update_sleep_pass,
             mark_active_pass,
             prepare_indirect_pass,
             clear_grid_sparse_pass,
@@ -575,7 +644,65 @@ impl GpuSimulation {
         );
         passes::barrier(cmd, &self.device);
 
-        // 8. Clear voxels (dense — kept for now)
+        // 8. Activity tracking: clear activity map, then compute per-brick activity
+        unsafe {
+            self.device
+                .cmd_fill_buffer(cmd, self.activity_map_buffer.buffer, 0, vk::WHOLE_SIZE, 0);
+        }
+        // Barrier: TRANSFER → COMPUTE
+        {
+            let memory_barrier = vk::MemoryBarrier::default()
+                .src_access_mask(vk::AccessFlags::TRANSFER_WRITE)
+                .dst_access_mask(vk::AccessFlags::SHADER_READ | vk::AccessFlags::SHADER_WRITE);
+            unsafe {
+                self.device.cmd_pipeline_barrier(
+                    cmd,
+                    vk::PipelineStageFlags::TRANSFER,
+                    vk::PipelineStageFlags::COMPUTE_SHADER,
+                    vk::DependencyFlags::empty(),
+                    &[memory_barrier],
+                    &[],
+                    &[],
+                );
+            }
+        }
+        let activity_pc = ComputeActivityPushConstants {
+            grid_size,
+            num_particles,
+            brick_size: shared::BRICK_SIZE,
+            _pad: 0,
+        };
+        passes::dispatch(
+            &self.device,
+            cmd,
+            &self.compute_activity_pass,
+            particle_wg,
+            1,
+            1,
+            bytemuck::bytes_of(&activity_pc),
+        );
+        passes::barrier(cmd, &self.device);
+
+        // 9. Update brick sleep state from activity map
+        let sleep_pc = UpdateSleepPushConstants {
+            total_bricks: TOTAL_BRICKS,
+            sleep_threshold: SLEEP_THRESHOLD,
+            _pad0: 0,
+            _pad1: 0,
+        };
+        let brick_wg = (TOTAL_BRICKS + 63) / 64;
+        passes::dispatch(
+            &self.device,
+            cmd,
+            &self.update_sleep_pass,
+            brick_wg,
+            1,
+            1,
+            bytemuck::bytes_of(&sleep_pc),
+        );
+        passes::barrier(cmd, &self.device);
+
+        // 10. Clear voxels (dense)
         let vox_pc = VoxelizePushConstants {
             grid_size,
             num_particles,
@@ -593,7 +720,7 @@ impl GpuSimulation {
         );
         passes::barrier(cmd, &self.device);
 
-        // 9. Voxelize (particle dispatch)
+        // 10. Voxelize (particle dispatch)
         passes::dispatch(
             &self.device,
             cmd,
@@ -798,6 +925,8 @@ impl GpuSimulation {
             &self.toolbar_overlay_pass,
             &self.react_pass,
             &self.explosion_pass,
+            &self.compute_activity_pass,
+            &self.update_sleep_pass,
             &self.mark_active_pass,
             &self.prepare_indirect_pass,
             &self.clear_grid_sparse_pass,
@@ -865,6 +994,30 @@ impl GpuSimulation {
                 size: 0,
             },
         );
+        let activity_map_buf = std::mem::replace(
+            &mut self.activity_map_buffer,
+            GpuBuffer {
+                buffer: vk::Buffer::null(),
+                allocation: None,
+                size: 0,
+            },
+        );
+        let sleep_counter_buf = std::mem::replace(
+            &mut self.sleep_counter_buffer,
+            GpuBuffer {
+                buffer: vk::Buffer::null(),
+                allocation: None,
+                size: 0,
+            },
+        );
+        let sleep_state_buf = std::mem::replace(
+            &mut self.sleep_state_buffer,
+            GpuBuffer {
+                buffer: vk::Buffer::null(),
+                allocation: None,
+                size: 0,
+            },
+        );
         let mark_buf = std::mem::replace(
             &mut self.mark_buffer,
             GpuBuffer {
@@ -903,6 +1056,9 @@ impl GpuSimulation {
         buffer::destroy_buffer(ctx, render_output_buf);
         buffer::destroy_buffer(ctx, material_buf);
         buffer::destroy_buffer(ctx, reaction_buf);
+        buffer::destroy_buffer(ctx, activity_map_buf);
+        buffer::destroy_buffer(ctx, sleep_counter_buf);
+        buffer::destroy_buffer(ctx, sleep_state_buf);
         buffer::destroy_buffer(ctx, mark_buf);
         buffer::destroy_buffer(ctx, active_cells_buf);
         buffer::destroy_buffer(ctx, active_count_buf);

--- a/crates/shaders/src/compute/compute_activity.rs
+++ b/crates/shaders/src/compute/compute_activity.rs
@@ -1,0 +1,131 @@
+//! Per-brick activity tracking compute shader.
+//!
+//! Runs per-particle (1D dispatch, 64 threads/workgroup). For each particle,
+//! checks whether it has significant velocity and atomically increments the
+//! activity counter of the brick containing it.
+//!
+//! The activity_map buffer has one u32 per brick (total = (grid_size/brick_size)^3).
+//! It must be cleared to zero before dispatch. After dispatch, each entry holds
+//! the number of active particles in that brick.
+
+use crate::types::Particle;
+use spirv_std::glam::UVec3;
+use spirv_std::spirv;
+
+/// Push constants for the compute_activity shader.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct ComputeActivityPushConstants {
+    /// Grid dimension (cells per axis).
+    pub grid_size: u32,
+    /// Total number of particles.
+    pub num_particles: u32,
+    /// Brick size (voxels per brick axis, e.g. 8).
+    pub brick_size: u32,
+    /// Padding for 16-byte alignment.
+    pub _pad: u32,
+}
+
+/// Squared velocity threshold below which a particle is considered inactive.
+const SPEED_SQ_THRESHOLD: f32 = 0.01;
+
+/// Atomically add a value to a u32 in a buffer, returning the old value.
+///
+/// Uses `spirv_std::arch::atomic_i_add` on SPIR-V targets.
+/// Falls back to non-atomic increment on CPU (for testing).
+///
+/// # Safety
+/// Caller must ensure `buffer[index]` is valid and properly aligned for atomic access.
+#[inline]
+pub unsafe fn atomic_add_u32(buffer: &mut [u32], index: usize, value: u32) -> u32 {
+    #[cfg(target_arch = "spirv")]
+    {
+        unsafe { spirv_std::arch::atomic_i_add::<u32, 1u32, 0x0u32>(&mut buffer[index], value) }
+    }
+    #[cfg(not(target_arch = "spirv"))]
+    {
+        let old = buffer[index];
+        buffer[index] = old + value;
+        old
+    }
+}
+
+/// Check whether a particle is active and, if so, increment the activity
+/// counter for the brick it belongs to.
+///
+/// A particle is active if its squared velocity exceeds `SPEED_SQ_THRESHOLD`.
+/// Pinned solids (phase 0) with negligible velocity are naturally excluded.
+///
+/// This is extracted as a helper to satisfy trap #4a (entry points must call
+/// at least one helper function).
+pub fn process_particle(
+    pos_x: f32,
+    pos_y: f32,
+    pos_z: f32,
+    vel_x: f32,
+    vel_y: f32,
+    vel_z: f32,
+    grid_size: u32,
+    brick_size: u32,
+    activity_map: &mut [u32],
+) {
+    // Squared speed check
+    let speed_sq = vel_x * vel_x + vel_y * vel_y + vel_z * vel_z;
+    if speed_sq <= SPEED_SQ_THRESHOLD {
+        return;
+    }
+
+    // Compute brick coordinates from particle position
+    let bx = (pos_x as u32) / brick_size;
+    let by = (pos_y as u32) / brick_size;
+    let bz = (pos_z as u32) / brick_size;
+    let bricks_per_axis = grid_size / brick_size;
+
+    // Bounds check
+    if bx >= bricks_per_axis || by >= bricks_per_axis || bz >= bricks_per_axis {
+        return;
+    }
+
+    // ZYX order matching grid indexing convention
+    let brick_idx = bz * bricks_per_axis * bricks_per_axis + by * bricks_per_axis + bx;
+
+    // Atomic increment activity counter for this brick
+    unsafe {
+        atomic_add_u32(activity_map, brick_idx as usize, 1);
+    }
+}
+
+/// Compute shader entry point: per-brick activity tracking.
+///
+/// Descriptor set 0, binding 0: storage buffer of `Particle` (read).
+/// Descriptor set 0, binding 1: storage buffer of `u32` (activity_map, read-write).
+/// Push constants: `ComputeActivityPushConstants`.
+/// Dispatch with `(ceil(num_particles / 64), 1, 1)` workgroups.
+#[spirv(compute(threads(64)))]
+pub fn compute_activity(
+    #[spirv(global_invocation_id)] id: UVec3,
+    #[spirv(push_constant)] push: &ComputeActivityPushConstants,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] particles: &[Particle],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] activity_map: &mut [u32],
+) {
+    let idx = id.x;
+    if idx >= push.num_particles {
+        return;
+    }
+
+    // Copy particle fields to locals (trap #21: no references to buffer elements)
+    let pos_mass = particles[idx as usize].pos_mass;
+    let vel_temp = particles[idx as usize].vel_temp;
+
+    process_particle(
+        pos_mass.x,
+        pos_mass.y,
+        pos_mass.z,
+        vel_temp.x,
+        vel_temp.y,
+        vel_temp.z,
+        push.grid_size,
+        push.brick_size,
+        activity_map,
+    );
+}

--- a/crates/shaders/src/compute/g2p.rs
+++ b/crates/shaders/src/compute/g2p.rs
@@ -441,12 +441,31 @@ fn reset_deformation_gradient(particle: &mut Particle) {
     particle.f_col2 = Vec4::new(0.0, 0.0, 1.0, 0.0);
 }
 
+/// Check whether the brick containing a particle position is sleeping.
+///
+/// Computes the brick index from position and looks up the sleep state buffer.
+/// Returns `true` if the brick is marked as sleeping (value != 0).
+/// Out-of-bounds positions return `false` (not sleeping) as a safe default.
+pub fn is_brick_sleeping(pos_x: f32, pos_y: f32, pos_z: f32, sleep_state: &[u32]) -> bool {
+    let brick_size: u32 = 8;
+    let bricks_per_axis: u32 = 32; // 256 / 8
+    let bx = (pos_x as u32) / brick_size;
+    let by = (pos_y as u32) / brick_size;
+    let bz = (pos_z as u32) / brick_size;
+    if bx >= bricks_per_axis || by >= bricks_per_axis || bz >= bricks_per_axis {
+        return false; // out of bounds = not sleeping
+    }
+    let brick_idx = bz * bricks_per_axis * bricks_per_axis + by * bricks_per_axis + bx;
+    sleep_state[brick_idx as usize] != 0
+}
+
 /// Compute shader entry point: Grid-to-Particle transfer.
 ///
 /// Descriptor set 0, binding 0: storage buffer of `Particle` (read-write).
 /// Descriptor set 0, binding 1: storage buffer of `GridCell` (read).
 /// Descriptor set 0, binding 2: storage buffer of `u32` (voxel grid, 4 per cell, read).
 /// Descriptor set 0, binding 3: storage buffer of `PhaseTransitionRule` (read).
+/// Descriptor set 0, binding 4: storage buffer of `u32` (sleep_state per brick, read).
 /// Push constants: `G2pPushConstants`.
 /// Dispatch with `(ceil(num_particles / 64), 1, 1)` workgroups.
 #[spirv(compute(threads(64)))]
@@ -457,11 +476,19 @@ pub fn g2p(
     #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] grid: &[GridCell],
     #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] voxels: &[u32],
     #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] reactions: &[PhaseTransitionRule],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 4)] sleep_state: &[u32],
 ) {
     let idx = id.x as usize;
     if id.x >= push.num_particles {
         return;
     }
+
+    // Copy position to locals (trap #21) and check sleep state before gathering
+    let pos_mass = particles[idx].pos_mass;
+    if is_brick_sleeping(pos_mass.x, pos_mass.y, pos_mass.z, sleep_state) {
+        return;
+    }
+
     gather_particle(
         &mut particles[idx],
         grid,

--- a/crates/shaders/src/compute/mod.rs
+++ b/crates/shaders/src/compute/mod.rs
@@ -11,6 +11,7 @@
 
 pub mod clear_grid;
 pub mod clear_grid_sparse;
+pub mod compute_activity;
 pub mod explosion;
 pub mod g2p;
 pub mod grid_update;
@@ -21,6 +22,7 @@ pub mod prepare_indirect;
 pub mod react;
 pub mod render;
 pub mod toolbar_overlay;
+pub mod update_sleep;
 pub mod voxelize;
 
 /// Compute 1D quadratic B-spline weights for a particle at fractional position `fx`.

--- a/crates/shaders/src/compute/p2g.rs
+++ b/crates/shaders/src/compute/p2g.rs
@@ -309,12 +309,31 @@ pub fn scatter_particle(
     }
 }
 
+/// Check whether the brick containing a particle position is sleeping.
+///
+/// Computes the brick index from position and looks up the sleep state buffer.
+/// Returns `true` if the brick is marked as sleeping (value != 0).
+/// Out-of-bounds positions return `false` (not sleeping) as a safe default.
+pub fn is_brick_sleeping(pos_x: f32, pos_y: f32, pos_z: f32, sleep_state: &[u32]) -> bool {
+    let brick_size: u32 = 8;
+    let bricks_per_axis: u32 = 32; // 256 / 8
+    let bx = (pos_x as u32) / brick_size;
+    let by = (pos_y as u32) / brick_size;
+    let bz = (pos_z as u32) / brick_size;
+    if bx >= bricks_per_axis || by >= bricks_per_axis || bz >= bricks_per_axis {
+        return false; // out of bounds = not sleeping
+    }
+    let brick_idx = bz * bricks_per_axis * bricks_per_axis + by * bricks_per_axis + bx;
+    sleep_state[brick_idx as usize] != 0
+}
+
 /// Compute shader entry point: Particle-to-Grid transfer.
 ///
 /// Descriptor set 0, binding 0: storage buffer of `Particle` (read).
 /// Descriptor set 0, binding 1: storage buffer of `f32` (grid, read-write with atomics).
 ///   Layout: 12 floats per cell `[vel_x, vel_y, vel_z, mass, force_x, force_y, force_z, solid_flag, temp, pad, pad, pad]`.
 /// Descriptor set 0, binding 2: storage buffer of `MaterialParams` (material table, read).
+/// Descriptor set 0, binding 3: storage buffer of `u32` (sleep_state per brick, read).
 /// Push constants: `P2gPushConstants`.
 /// Dispatch with `(ceil(num_particles / 64), 1, 1)` workgroups.
 #[spirv(compute(threads(64)))]
@@ -324,10 +343,18 @@ pub fn p2g(
     #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] particles: &[Particle],
     #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] grid: &mut [f32],
     #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] materials: &[MaterialParams],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] sleep_state: &[u32],
 ) {
     let idx = id.x as usize;
     if id.x >= push.num_particles {
         return;
     }
+
+    // Copy position to locals (trap #21) and check sleep state before scattering
+    let pos_mass = particles[idx].pos_mass;
+    if is_brick_sleeping(pos_mass.x, pos_mass.y, pos_mass.z, sleep_state) {
+        return;
+    }
+
     scatter_particle(&particles[idx], grid, push.grid_size, push.dt, materials);
 }

--- a/crates/shaders/src/compute/update_sleep.rs
+++ b/crates/shaders/src/compute/update_sleep.rs
@@ -1,0 +1,78 @@
+//! Per-brick sleep state update compute shader.
+//!
+//! Runs per-brick (1D dispatch, 64 threads/workgroup). For each brick,
+//! reads the activity counter from the activity map. If the brick has been
+//! inactive for `sleep_threshold` consecutive frames, it is marked as sleeping.
+//! Active bricks reset their sleep counter immediately.
+//!
+//! Sleeping bricks are skipped by P2G and G2P to save compute bandwidth.
+
+use spirv_std::glam::UVec3;
+use spirv_std::spirv;
+
+/// Push constants for the update_sleep shader.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct UpdateSleepPushConstants {
+    /// Total number of bricks in the grid.
+    pub total_bricks: u32,
+    /// Number of inactive frames before a brick is put to sleep.
+    pub sleep_threshold: u32,
+    /// Padding for 16-byte alignment.
+    pub _pad0: u32,
+    /// Padding for 16-byte alignment.
+    pub _pad1: u32,
+}
+
+/// Update sleep state for a single brick based on its activity counter.
+///
+/// Returns `(new_counter, new_sleep_state)`:
+/// - If the brick was active (`activity > 0`): counter resets to 0, state = awake (0).
+/// - If inactive: counter increments. Once it reaches the threshold, state = sleeping (1).
+///
+/// This helper satisfies trap #4a (entry points must call at least one helper).
+pub fn update_brick(activity: u32, counter: u32, threshold: u32) -> (u32, u32) {
+    if activity > 0 {
+        // Brick had active particles this frame: reset counter, mark awake
+        (0, 0)
+    } else {
+        let new_counter = counter + 1;
+        if new_counter >= threshold {
+            // Brick has been inactive long enough: mark sleeping
+            (new_counter, 1)
+        } else {
+            // Still counting inactive frames, not sleeping yet
+            (new_counter, 0)
+        }
+    }
+}
+
+/// Compute shader entry point: update per-brick sleep state.
+///
+/// Descriptor set 0, binding 0: storage buffer of `u32` (activity_map, read).
+/// Descriptor set 0, binding 1: storage buffer of `u32` (sleep_counter, read-write).
+/// Descriptor set 0, binding 2: storage buffer of `u32` (sleep_state, write).
+/// Push constants: `UpdateSleepPushConstants`.
+/// Dispatch with `(ceil(total_bricks / 64), 1, 1)` workgroups.
+#[spirv(compute(threads(64)))]
+pub fn update_sleep(
+    #[spirv(global_invocation_id)] id: UVec3,
+    #[spirv(push_constant)] push: &UpdateSleepPushConstants,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] activity_map: &[u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] sleep_counter: &mut [u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] sleep_state: &mut [u32],
+) {
+    let idx = id.x;
+    if idx >= push.total_bricks {
+        return;
+    }
+
+    // Copy to locals to avoid reference issues (trap #21)
+    let activity = activity_map[idx as usize];
+    let counter = sleep_counter[idx as usize];
+
+    let (new_counter, new_state) = update_brick(activity, counter, push.sleep_threshold);
+
+    sleep_counter[idx as usize] = new_counter;
+    sleep_state[idx as usize] = new_state;
+}

--- a/crates/shared/src/constants.rs
+++ b/crates/shared/src/constants.rs
@@ -45,3 +45,32 @@ pub const MAX_ACTIVE_CELLS: u32 = GRID_CELL_COUNT / 4;
 
 /// Workgroup size for 1D sparse dispatches over active cell lists.
 pub const SPARSE_WORKGROUP_SIZE: u32 = 64;
+
+/// Total number of bricks in the grid (BRICKS_PER_AXIS³).
+pub const TOTAL_BRICKS: u32 = BRICKS_PER_AXIS * BRICKS_PER_AXIS * BRICKS_PER_AXIS;
+
+/// Velocity² threshold below which a particle is considered inactive.
+/// Particles with speed² <= this won't increment the activity counter.
+pub const ACTIVITY_VELOCITY_THRESHOLD_SQ: f32 = 0.01;
+
+/// Frames of zero activity before a brick enters sleep state.
+/// At 60 Hz physics, 30 frames = 0.5 seconds of calm before sleeping.
+pub const SLEEP_THRESHOLD: u32 = 30;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn total_bricks_matches_grid_layout() {
+        // With GRID_SIZE=256 and BRICK_SIZE=8, BRICKS_PER_AXIS=32, so 32³=32768.
+        assert_eq!(TOTAL_BRICKS, 32_768);
+        assert_eq!(BRICKS_PER_AXIS, 32);
+        assert_eq!(TOTAL_BRICKS, BRICKS_PER_AXIS.pow(3));
+    }
+
+    #[test]
+    fn sleep_threshold_is_positive() {
+        assert!(SLEEP_THRESHOLD > 0);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `sleep_counter_buffer` and `sleep_state_buffer` (128KB each, zeroed on init)
- Add `update_sleep_pass` compute pass dispatched after `compute_activity`
- Wire `sleep_state_buffer` into P2G (binding 3) and G2P (binding 4) descriptor sets
- Add `UpdateSleepPushConstants` to push_constants.rs
- Bump descriptor pool to 16 passes / 80 descriptors

After SLEEP_THRESHOLD (30) frames of zero particle activity, bricks are marked sleeping. P2G/G2P skip particles in sleeping bricks, saving compute for calm regions.

Note: `water_falls_under_gravity` test failure is pre-existing (fails at commit 26f1bb9, before any activity/sleep work).

Closes #214

## Test plan
- [x] `cargo build` passes
- [x] `cargo test -p shared -p sim-cpu -p protocol -p content` — all CPU tests pass
- [ ] Visual verification with `cargo run -p app` — water should still flow, calm areas should sleep

🤖 Generated with [Claude Code](https://claude.com/claude-code)