### PR TITLE
fix(server): clear mark_buffer every frame (#221)

### DIFF
--- a/crates/server/src/simulation.rs
+++ b/crates/server/src/simulation.rs
@@ -518,10 +518,15 @@ impl GpuSimulation {
         passes::dispatch(&self.device, cmd, &self.clear_grid_pass, grid_wg, grid_wg, grid_wg, &[]);
         passes::barrier(cmd, &self.device);
 
-        // 2. Reset active_count to 0 for this frame's mark_active pass
+        // 2. Reset active_count to 0 AND clear mark_buffer for this frame.
+        // mark_buffer must be zeroed every frame — otherwise mark_active finds
+        // cells already marked from the previous frame, skips adding them to
+        // active_cells, and grid_update_sparse processes 0 cells (#221).
         unsafe {
             self.device
                 .cmd_fill_buffer(cmd, self.active_count_buffer.buffer, 0, 4, 0);
+            self.device
+                .cmd_fill_buffer(cmd, self.mark_buffer.buffer, 0, vk::WHOLE_SIZE, 0);
         }
         // Barrier: TRANSFER_WRITE → SHADER_READ | SHADER_WRITE
         {


### PR DESCRIPTION
## Summary
- Add `cmd_fill_buffer(mark_buffer, 0)` before mark_active each frame
- Fixes stale marks from previous frame preventing active cell list from being rebuilt
- Water now falls under gravity correctly (test passes)

Closes #221

## Test plan
- [x] `cargo test -p server -- --test-threads=1 water_falls` passes (water fell 16.50 → 16.38)
- [x] `cargo build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)