### PR TITLE
feat(shaders): graduated tick intervals for brick sleep (#220)

### DIFF
--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -73,7 +73,7 @@ mod tests {
     fn push_constant_sizes() {
         assert_eq!(mem::size_of::<P2gPushConstants>(), 16);
         assert_eq!(mem::size_of::<GridUpdatePushConstants>(), 16);
-        assert_eq!(mem::size_of::<G2pPushConstants>(), 16);
+        assert_eq!(mem::size_of::<G2pPushConstants>(), 32);
         assert_eq!(mem::size_of::<VoxelizePushConstants>(), 16);
         assert_eq!(mem::size_of::<ReactPushConstants>(), 16);
         // ExplosionPushConstants: 2 Vec4s (32 bytes) + 1 u32 + 3 u32 pad (16 bytes) = 48 bytes

--- a/crates/server/src/push_constants.rs
+++ b/crates/server/src/push_constants.rs
@@ -15,8 +15,8 @@ pub struct P2gPushConstants {
     pub dt: f32,
     /// Total number of active particles.
     pub num_particles: u32,
-    /// Padding to 16-byte alignment.
-    pub _pad: u32,
+    /// Current simulation frame number (used with tick_period for graduated sleep).
+    pub frame_number: u32,
 }
 
 /// Push constants for the grid update shader.
@@ -45,6 +45,14 @@ pub struct G2pPushConstants {
     pub num_particles: u32,
     /// Number of valid phase transition rules.
     pub num_rules: u32,
+    /// Current simulation frame number (used with tick_period for graduated sleep).
+    pub frame_number: u32,
+    /// Padding to 32-byte alignment.
+    pub _pad0: u32,
+    /// Padding to 32-byte alignment.
+    pub _pad1: u32,
+    /// Padding to 32-byte alignment.
+    pub _pad2: u32,
 }
 
 /// Push constants for the voxelize / clear_voxels shaders.

--- a/crates/server/src/simulation.rs
+++ b/crates/server/src/simulation.rs
@@ -89,6 +89,8 @@ pub struct GpuSimulation {
     // State
     pub(crate) num_particles: u32,
     num_phase_rules: u32,
+    /// Monotonically increasing frame counter for graduated sleep scheduling.
+    frame_number: core::cell::Cell<u32>,
 
     // Reference to context (not owned — caller must keep alive)
     // We store raw device handle for recording commands; the context
@@ -487,6 +489,7 @@ impl GpuSimulation {
             descriptor_pool,
             num_particles: 0,
             num_phase_rules: num_phase_rules as u32,
+            frame_number: core::cell::Cell::new(0),
             device: ctx.device.clone(),
         })
     }
@@ -575,11 +578,12 @@ impl GpuSimulation {
         }
 
         // 3. P2G (particle dispatch)
+        let frame = self.frame_number.get();
         let p2g_pc = P2gPushConstants {
             grid_size,
             dt,
             num_particles,
-            _pad: 0,
+            frame_number: frame,
         };
         passes::dispatch(
             &self.device,
@@ -665,6 +669,10 @@ impl GpuSimulation {
             dt,
             num_particles,
             num_rules: self.num_phase_rules,
+            frame_number: frame,
+            _pad0: 0,
+            _pad1: 0,
+            _pad2: 0,
         };
         passes::dispatch(
             &self.device,
@@ -783,6 +791,9 @@ impl GpuSimulation {
             bytemuck::bytes_of(&occupancy_pc),
         );
         passes::barrier(cmd, &self.device);
+
+        // Increment frame counter for graduated sleep scheduling
+        self.frame_number.set(frame.wrapping_add(1));
     }
 
     /// Run chemical reactions only. Call once per frame after all substeps.

--- a/crates/shaders/src/compute/g2p.rs
+++ b/crates/shaders/src/compute/g2p.rs
@@ -23,6 +23,14 @@ pub struct G2pPushConstants {
     pub num_particles: u32,
     /// Number of valid phase transition rules.
     pub num_rules: u32,
+    /// Current simulation frame number (used with tick_period for graduated sleep).
+    pub frame_number: u32,
+    /// Padding to 32-byte alignment.
+    pub _pad0: u32,
+    /// Padding to 32-byte alignment.
+    pub _pad1: u32,
+    /// Padding to 32-byte alignment.
+    pub _pad2: u32,
 }
 
 /// PIC/FLIP blend ratio (0.0 = pure FLIP, 1.0 = pure PIC).
@@ -441,22 +449,42 @@ fn reset_deformation_gradient(particle: &mut Particle) {
     particle.f_col2 = Vec4::new(0.0, 0.0, 1.0, 0.0);
 }
 
-/// Check whether the brick containing a particle position is sleeping.
+/// Check whether a brick should be skipped this frame based on its tick period.
 ///
-/// Computes the brick index from position and looks up the sleep state buffer.
-/// Returns `true` if the brick is marked as sleeping (value != 0).
-/// Out-of-bounds positions return `false` (not sleeping) as a safe default.
-pub fn is_brick_sleeping(pos_x: f32, pos_y: f32, pos_z: f32, sleep_state: &[u32]) -> bool {
+/// - `tick_period == 0`: frozen, always skip.
+/// - `tick_period == 1`: active, never skip.
+/// - Otherwise: skip unless `frame_number % tick_period == 0`.
+///
+/// Split to keep branch count <= 3 per function (trap #15).
+pub fn check_skip(tick_period: u32, frame_number: u32) -> bool {
+    if tick_period == 0 {
+        return true;
+    }
+    if tick_period == 1 {
+        return false;
+    }
+    frame_number % tick_period != 0
+}
+
+/// Check whether the brick containing a particle position should be skipped.
+///
+/// Computes the brick index from position, reads the tick_period from the
+/// sleep_state buffer, and uses `check_skip` with the current frame number
+/// to decide whether to skip this brick's particles.
+///
+/// Out-of-bounds positions return `false` (do not skip) as a safe default.
+pub fn should_skip_brick(pos_x: f32, pos_y: f32, pos_z: f32, sleep_state: &[u32], frame_number: u32) -> bool {
     let brick_size: u32 = 8;
     let bricks_per_axis: u32 = 32; // 256 / 8
     let bx = (pos_x as u32) / brick_size;
     let by = (pos_y as u32) / brick_size;
     let bz = (pos_z as u32) / brick_size;
     if bx >= bricks_per_axis || by >= bricks_per_axis || bz >= bricks_per_axis {
-        return false; // out of bounds = not sleeping
+        return false; // out of bounds = do not skip
     }
     let brick_idx = bz * bricks_per_axis * bricks_per_axis + by * bricks_per_axis + bx;
-    sleep_state[brick_idx as usize] != 0
+    let tick_period = sleep_state[brick_idx as usize];
+    check_skip(tick_period, frame_number)
 }
 
 /// Compute shader entry point: Grid-to-Particle transfer.
@@ -483,9 +511,9 @@ pub fn g2p(
         return;
     }
 
-    // Copy position to locals (trap #21) and check sleep state before gathering
+    // Copy position to locals (trap #21) and check graduated sleep before gathering
     let pos_mass = particles[idx].pos_mass;
-    if is_brick_sleeping(pos_mass.x, pos_mass.y, pos_mass.z, sleep_state) {
+    if should_skip_brick(pos_mass.x, pos_mass.y, pos_mass.z, sleep_state, push.frame_number) {
         return;
     }
 

--- a/crates/shaders/src/compute/p2g.rs
+++ b/crates/shaders/src/compute/p2g.rs
@@ -29,8 +29,8 @@ pub struct P2gPushConstants {
     pub dt: f32,
     /// Total number of particles.
     pub num_particles: u32,
-    /// Padding to maintain alignment.
-    pub _pad: u32,
+    /// Current simulation frame number (used with tick_period for graduated sleep).
+    pub frame_number: u32,
 }
 
 /// Compute the stress contribution from the particle's constitutive model.
@@ -309,22 +309,42 @@ pub fn scatter_particle(
     }
 }
 
-/// Check whether the brick containing a particle position is sleeping.
+/// Check whether a brick should be skipped this frame based on its tick period.
 ///
-/// Computes the brick index from position and looks up the sleep state buffer.
-/// Returns `true` if the brick is marked as sleeping (value != 0).
-/// Out-of-bounds positions return `false` (not sleeping) as a safe default.
-pub fn is_brick_sleeping(pos_x: f32, pos_y: f32, pos_z: f32, sleep_state: &[u32]) -> bool {
+/// - `tick_period == 0`: frozen, always skip.
+/// - `tick_period == 1`: active, never skip.
+/// - Otherwise: skip unless `frame_number % tick_period == 0`.
+///
+/// Split to keep branch count <= 3 per function (trap #15).
+pub fn check_skip(tick_period: u32, frame_number: u32) -> bool {
+    if tick_period == 0 {
+        return true;
+    }
+    if tick_period == 1 {
+        return false;
+    }
+    frame_number % tick_period != 0
+}
+
+/// Check whether the brick containing a particle position should be skipped.
+///
+/// Computes the brick index from position, reads the tick_period from the
+/// sleep_state buffer, and uses `check_skip` with the current frame number
+/// to decide whether to skip this brick's particles.
+///
+/// Out-of-bounds positions return `false` (do not skip) as a safe default.
+pub fn should_skip_brick(pos_x: f32, pos_y: f32, pos_z: f32, sleep_state: &[u32], frame_number: u32) -> bool {
     let brick_size: u32 = 8;
     let bricks_per_axis: u32 = 32; // 256 / 8
     let bx = (pos_x as u32) / brick_size;
     let by = (pos_y as u32) / brick_size;
     let bz = (pos_z as u32) / brick_size;
     if bx >= bricks_per_axis || by >= bricks_per_axis || bz >= bricks_per_axis {
-        return false; // out of bounds = not sleeping
+        return false; // out of bounds = do not skip
     }
     let brick_idx = bz * bricks_per_axis * bricks_per_axis + by * bricks_per_axis + bx;
-    sleep_state[brick_idx as usize] != 0
+    let tick_period = sleep_state[brick_idx as usize];
+    check_skip(tick_period, frame_number)
 }
 
 /// Compute shader entry point: Particle-to-Grid transfer.
@@ -350,9 +370,9 @@ pub fn p2g(
         return;
     }
 
-    // Copy position to locals (trap #21) and check sleep state before scattering
+    // Copy position to locals (trap #21) and check graduated sleep before scattering
     let pos_mass = particles[idx].pos_mass;
-    if is_brick_sleeping(pos_mass.x, pos_mass.y, pos_mass.z, sleep_state) {
+    if should_skip_brick(pos_mass.x, pos_mass.y, pos_mass.z, sleep_state, push.frame_number) {
         return;
     }
 

--- a/crates/shaders/src/compute/update_sleep.rs
+++ b/crates/shaders/src/compute/update_sleep.rs
@@ -1,14 +1,24 @@
 //! Per-brick sleep state update compute shader.
 //!
 //! Runs per-brick (1D dispatch, 64 threads/workgroup). For each brick,
-//! reads the activity counter from the activity map. If the brick has been
-//! inactive for `sleep_threshold` consecutive frames, it is marked as sleeping.
-//! Active bricks reset their sleep counter immediately.
+//! reads the activity counter from the activity map. Based on how long
+//! the brick has been inactive, assigns a graduated tick period:
 //!
-//! Sleeping bricks are skipped by P2G and G2P to save compute bandwidth.
+//! - `1` = tick every frame (active / just went quiet)
+//! - `3` = every 3rd frame (cooling down)
+//! - `10` = every 10th frame (deeply idle)
+//! - `0` = frozen (past sleep threshold)
+//!
+//! P2G and G2P use `frame_number % tick_period` to decide whether to skip.
 
 use spirv_std::glam::UVec3;
 use spirv_std::spirv;
+
+/// Frames of inactivity before switching from tick_period=1 to tick_period=3.
+const COOLDOWN_FAST: u32 = 10;
+
+/// Frames of inactivity before switching from tick_period=3 to tick_period=10.
+const COOLDOWN_SLOW: u32 = 20;
 
 /// Push constants for the update_sleep shader.
 #[derive(Copy, Clone)]
@@ -16,7 +26,7 @@ use spirv_std::spirv;
 pub struct UpdateSleepPushConstants {
     /// Total number of bricks in the grid.
     pub total_bricks: u32,
-    /// Number of inactive frames before a brick is put to sleep.
+    /// Number of inactive frames before a brick is fully frozen (tick_period=0).
     pub sleep_threshold: u32,
     /// Padding for 16-byte alignment.
     pub _pad0: u32,
@@ -24,26 +34,49 @@ pub struct UpdateSleepPushConstants {
     pub _pad1: u32,
 }
 
+/// Determine tick period for a brick that has been inactive for `counter` frames
+/// and the counter is below `COOLDOWN_FAST`.
+///
+/// Split into separate helpers to avoid >3 if/else branches (trap #15).
+pub fn tick_period_from_counter(counter: u32, threshold: u32) -> u32 {
+    if counter < COOLDOWN_FAST {
+        return 1;
+    }
+    tick_period_slow(counter, threshold)
+}
+
+/// Determine tick period for a brick with counter >= COOLDOWN_FAST.
+///
+/// Split helper to avoid >3 branches in a single function (trap #15).
+pub fn tick_period_slow(counter: u32, threshold: u32) -> u32 {
+    if counter < COOLDOWN_SLOW {
+        return 3;
+    }
+    tick_period_frozen(counter, threshold)
+}
+
+/// Determine tick period for a brick with counter >= COOLDOWN_SLOW.
+///
+/// Returns 10 if below threshold, 0 (frozen) if at or above threshold.
+/// Split helper to avoid >3 branches in a single function (trap #15).
+pub fn tick_period_frozen(counter: u32, threshold: u32) -> u32 {
+    if counter < threshold { 10 } else { 0 }
+}
+
 /// Update sleep state for a single brick based on its activity counter.
 ///
-/// Returns `(new_counter, new_sleep_state)`:
-/// - If the brick was active (`activity > 0`): counter resets to 0, state = awake (0).
-/// - If inactive: counter increments. Once it reaches the threshold, state = sleeping (1).
+/// Returns `(new_counter, tick_period)`:
+/// - If the brick was active (`activity > 0`): counter resets to 0, tick_period = 1 (every frame).
+/// - If inactive: counter increments and tick_period is graduated based on inactivity duration.
 ///
 /// This helper satisfies trap #4a (entry points must call at least one helper).
 pub fn update_brick(activity: u32, counter: u32, threshold: u32) -> (u32, u32) {
     if activity > 0 {
-        // Brick had active particles this frame: reset counter, mark awake
-        (0, 0)
+        // Brick had active particles this frame: reset counter, full rate
+        (0, 1)
     } else {
         let new_counter = counter + 1;
-        if new_counter >= threshold {
-            // Brick has been inactive long enough: mark sleeping
-            (new_counter, 1)
-        } else {
-            // Still counting inactive frames, not sleeping yet
-            (new_counter, 0)
-        }
+        (new_counter, tick_period_from_counter(new_counter, threshold))
     }
 }
 


### PR DESCRIPTION
## Summary
- **update_sleep.rs**: `sleep_state` buffer now stores graduated `tick_period` (1/3/10/0) instead of binary 0/1, with cooldown thresholds at 10 and 20 frames before the full sleep threshold
- **p2g.rs / g2p.rs**: Replace `is_brick_sleeping()` with `should_skip_brick()` + `check_skip()` that use `frame_number % tick_period` to decide per-frame skip; push constants gain `frame_number` field
- **server push_constants + simulation**: Mirror the new push constant layouts, add `frame_number` counter that increments each physics step
- All multi-branch logic split into separate helper functions to avoid trap #15 (rust-gpu drops later if/else branches)

Closes #220, part of #208

## Test plan
- [ ] `cargo build` passes (verified)
- [ ] `cargo test -p server -- --test-threads=1` passes
- [ ] Visual check: idle bricks still update at reduced rate before freezing
- [ ] Verify no regression in active brick simulation

🤖 Generated with [Claude Code](https://claude.com/claude-code)