### PR TITLE
feat(shaders,server): counting sort for per-brick particle dispatch

### DIFF
--- a/crates/server/src/push_constants.rs
+++ b/crates/server/src/push_constants.rs
@@ -185,6 +185,62 @@ pub struct UpdateSleepPushConstants {
     pub _pad1: u32,
 }
 
+/// Push constants for the count_per_brick shader.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Pod, bytemuck::Zeroable)]
+pub struct CountPerBrickPushConstants {
+    /// Total number of active particles.
+    pub num_particles: u32,
+    /// Grid dimension (cells per axis).
+    pub grid_size: u32,
+    /// Brick size (voxels per brick axis, e.g. 8).
+    pub brick_size: u32,
+    /// Padding to 16-byte alignment.
+    pub _pad: u32,
+}
+
+/// Push constants for the prefix_sum shader.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Pod, bytemuck::Zeroable)]
+pub struct PrefixSumPushConstants {
+    /// Total number of bricks.
+    pub total_bricks: u32,
+    /// Padding to 16-byte alignment.
+    pub _pad0: u32,
+    /// Padding to 16-byte alignment.
+    pub _pad1: u32,
+    /// Padding to 16-byte alignment.
+    pub _pad2: u32,
+}
+
+/// Push constants for the scatter_particles shader.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Pod, bytemuck::Zeroable)]
+pub struct ScatterParticlesPushConstants {
+    /// Total number of active particles.
+    pub num_particles: u32,
+    /// Grid dimension (cells per axis).
+    pub grid_size: u32,
+    /// Brick size (voxels per brick axis, e.g. 8).
+    pub brick_size: u32,
+    /// Padding to 16-byte alignment.
+    pub _pad: u32,
+}
+
+/// Push constants for the compact_active_bricks shader.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Pod, bytemuck::Zeroable)]
+pub struct CompactActiveBricksPushConstants {
+    /// Total number of bricks.
+    pub total_bricks: u32,
+    /// Padding to 16-byte alignment.
+    pub _pad0: u32,
+    /// Padding to 16-byte alignment.
+    pub _pad1: u32,
+    /// Padding to 16-byte alignment.
+    pub _pad2: u32,
+}
+
 /// Maximum number of material slots in the toolbar.
 pub const TOOLBAR_MAX_MATERIALS: usize = 8;
 

--- a/crates/server/src/simulation.rs
+++ b/crates/server/src/simulation.rs
@@ -47,6 +47,14 @@ pub struct GpuSimulation {
     // Brick occupancy (render optimization)
     brick_occupancy_buffer: GpuBuffer,
 
+    // Counting sort buffers (particle-by-brick sorting)
+    brick_count_buffer: GpuBuffer,
+    brick_offset_buffer: GpuBuffer,
+    write_offset_buffer: GpuBuffer,
+    sorted_particle_buffer: GpuBuffer,
+    active_brick_list_buffer: GpuBuffer,
+    active_brick_count_buffer: GpuBuffer,
+
     // Sparse dispatch buffers
     mark_buffer: GpuBuffer,
     active_cells_buffer: GpuBuffer,
@@ -73,6 +81,12 @@ pub struct GpuSimulation {
 
     // Brick sleep pass
     update_sleep_pass: ComputePass,
+
+    // Counting sort passes
+    count_per_brick_pass: ComputePass,
+    prefix_sum_pass: ComputePass,
+    scatter_particles_pass: ComputePass,
+    compact_active_bricks_pass: ComputePass,
 
     // Sparse compute passes
     mark_active_pass: ComputePass,
@@ -259,14 +273,58 @@ impl GpuSimulation {
         let indirect_dispatch_buffer =
             buffer::create_indirect_buffer(ctx, "indirect-dispatch-buffer")?;
 
+        // -- Counting sort buffers --
+        // brick_count: u32 per brick
+        let brick_count_buffer = buffer::create_device_local_buffer(
+            ctx,
+            (TOTAL_BRICKS as usize * 4) as vk::DeviceSize,
+            vk::BufferUsageFlags::STORAGE_BUFFER | vk::BufferUsageFlags::TRANSFER_DST,
+            "brick-count-buffer",
+        )?;
+        // brick_offset: u32 per brick + 1 (for total count at end)
+        let brick_offset_buffer = buffer::create_device_local_buffer(
+            ctx,
+            ((TOTAL_BRICKS as usize + 1) * 4) as vk::DeviceSize,
+            vk::BufferUsageFlags::STORAGE_BUFFER | vk::BufferUsageFlags::TRANSFER_SRC,
+            "brick-offset-buffer",
+        )?;
+        // write_offset: copy of brick_offset, modified by scatter atomics
+        let write_offset_buffer = buffer::create_device_local_buffer(
+            ctx,
+            ((TOTAL_BRICKS as usize + 1) * 4) as vk::DeviceSize,
+            vk::BufferUsageFlags::STORAGE_BUFFER | vk::BufferUsageFlags::TRANSFER_DST,
+            "write-offset-buffer",
+        )?;
+        // sorted_particle_buffer: same size as particle buffer
+        let sorted_particle_buffer = buffer::create_device_local_buffer(
+            ctx,
+            particle_buf_size,
+            vk::BufferUsageFlags::STORAGE_BUFFER,
+            "sorted-particle-buffer",
+        )?;
+        // active_brick_list: u32 per brick (worst case: all bricks active)
+        let active_brick_list_buffer = buffer::create_device_local_buffer(
+            ctx,
+            (TOTAL_BRICKS as usize * 4) as vk::DeviceSize,
+            vk::BufferUsageFlags::STORAGE_BUFFER,
+            "active-brick-list-buffer",
+        )?;
+        // active_brick_count: single u32 atomic counter
+        let active_brick_count_buffer = buffer::create_device_local_buffer(
+            ctx,
+            16 as vk::DeviceSize,
+            vk::BufferUsageFlags::STORAGE_BUFFER | vk::BufferUsageFlags::TRANSFER_DST,
+            "active-brick-count-buffer",
+        )?;
+
         // -- Descriptor pool --
-        // 18 passes, max 5 bindings each = up to 90 storage buffer descriptors
+        // 22 passes, max 5 bindings each = up to 110 storage buffer descriptors
         let pool_sizes = [vk::DescriptorPoolSize {
             ty: vk::DescriptorType::STORAGE_BUFFER,
-            descriptor_count: 90,
+            descriptor_count: 110,
         }];
         let descriptor_pool =
-            pipeline::create_descriptor_pool(ctx, &pool_sizes, 18, "sim-descriptor-pool")?;
+            pipeline::create_descriptor_pool(ctx, &pool_sizes, 22, "sim-descriptor-pool")?;
 
         // -- Create each compute pass --
         // Entry point names are fully qualified module paths in rust-gpu SPIR-V.
@@ -451,6 +509,51 @@ impl GpuSimulation {
             "grid-update-sparse",
         )?;
 
+        // -- Counting sort passes --
+        // count_per_brick: particles(r), brick_count(rw)
+        let count_per_brick_pass = passes::create_pass(
+            ctx,
+            shader_module,
+            c"compute::count_per_brick::count_per_brick",
+            &[&particle_buffer, &brick_count_buffer],
+            mem::size_of::<CountPerBrickPushConstants>() as u32,
+            descriptor_pool,
+            "count-per-brick",
+        )?;
+
+        // prefix_sum: brick_count(r), brick_offset(w)
+        let prefix_sum_pass = passes::create_pass(
+            ctx,
+            shader_module,
+            c"compute::prefix_sum::prefix_sum",
+            &[&brick_count_buffer, &brick_offset_buffer],
+            mem::size_of::<PrefixSumPushConstants>() as u32,
+            descriptor_pool,
+            "prefix-sum",
+        )?;
+
+        // scatter_particles: particles(r), write_offset(rw), sorted_particles(w)
+        let scatter_particles_pass = passes::create_pass(
+            ctx,
+            shader_module,
+            c"compute::scatter_particles::scatter_particles",
+            &[&particle_buffer, &write_offset_buffer, &sorted_particle_buffer],
+            mem::size_of::<ScatterParticlesPushConstants>() as u32,
+            descriptor_pool,
+            "scatter-particles",
+        )?;
+
+        // compact_active_bricks: brick_count(r), sleep_state(r), active_brick_list(w), active_brick_count(rw)
+        let compact_active_bricks_pass = passes::create_pass(
+            ctx,
+            shader_module,
+            c"compute::compact_active_bricks::compact_active_bricks",
+            &[&brick_count_buffer, &sleep_state_buffer, &active_brick_list_buffer, &active_brick_count_buffer],
+            mem::size_of::<CompactActiveBricksPushConstants>() as u32,
+            descriptor_pool,
+            "compact-active-bricks",
+        )?;
+
         tracing::info!("GpuSimulation created successfully");
 
         Ok(Self {
@@ -464,6 +567,12 @@ impl GpuSimulation {
             sleep_counter_buffer,
             sleep_state_buffer,
             brick_occupancy_buffer,
+            brick_count_buffer,
+            brick_offset_buffer,
+            write_offset_buffer,
+            sorted_particle_buffer,
+            active_brick_list_buffer,
+            active_brick_count_buffer,
             mark_buffer,
             active_cells_buffer,
             active_count_buffer,
@@ -481,6 +590,10 @@ impl GpuSimulation {
             compute_activity_pass,
             compute_occupancy_pass,
             update_sleep_pass,
+            count_per_brick_pass,
+            prefix_sum_pass,
+            scatter_particles_pass,
+            compact_active_bricks_pass,
             mark_active_pass,
             prepare_indirect_pass,
             clear_grid_sparse_pass,
@@ -825,6 +938,192 @@ impl GpuSimulation {
         self.step_react(cmd);
     }
 
+    /// Record the counting sort dispatch chain into the given command buffer.
+    ///
+    /// Sorts particles by brick_id so that all particles in the same brick are
+    /// contiguous in the sorted_particle_buffer. Also builds a compact list of
+    /// active (non-sleeping, non-empty) bricks.
+    ///
+    /// The command buffer must already be in the recording state.
+    /// This method does NOT integrate with step_physics yet -- call it separately
+    /// for testing. Integration with the main dispatch chain comes later.
+    ///
+    /// Dispatch order:
+    /// 1. `vkCmdFillBuffer` -- clear brick_count to 0
+    /// 2. Barrier (TRANSFER -> COMPUTE)
+    /// 3. `count_per_brick` -- count particles per brick
+    /// 4. Barrier
+    /// 5. `prefix_sum` -- exclusive prefix sum over brick_count
+    /// 6. Barrier
+    /// 7. `vkCmdCopyBuffer` -- copy brick_offset to write_offset
+    /// 8. Barrier (TRANSFER -> COMPUTE)
+    /// 9. `scatter_particles` -- scatter to sorted positions
+    /// 10. Barrier
+    /// 11. `vkCmdFillBuffer` -- clear active_brick_count to 0
+    /// 12. Barrier (TRANSFER -> COMPUTE)
+    /// 13. `compact_active_bricks` -- build active brick list
+    /// 14. Barrier
+    pub fn sort_particles(&self, cmd: vk::CommandBuffer) {
+        let num_particles = self.num_particles;
+        let grid_size = GRID_SIZE;
+        let particle_wg = (num_particles + 63) / 64;
+        let brick_wg = (TOTAL_BRICKS + 63) / 64;
+
+        // 1. Clear brick_count to 0
+        unsafe {
+            self.device
+                .cmd_fill_buffer(cmd, self.brick_count_buffer.buffer, 0, vk::WHOLE_SIZE, 0);
+        }
+
+        // 2. Barrier: TRANSFER_WRITE -> SHADER_READ | SHADER_WRITE
+        {
+            let memory_barrier = vk::MemoryBarrier::default()
+                .src_access_mask(vk::AccessFlags::TRANSFER_WRITE)
+                .dst_access_mask(vk::AccessFlags::SHADER_READ | vk::AccessFlags::SHADER_WRITE);
+            unsafe {
+                self.device.cmd_pipeline_barrier(
+                    cmd,
+                    vk::PipelineStageFlags::TRANSFER,
+                    vk::PipelineStageFlags::COMPUTE_SHADER,
+                    vk::DependencyFlags::empty(),
+                    &[memory_barrier],
+                    &[],
+                    &[],
+                );
+            }
+        }
+
+        // 3. count_per_brick
+        let count_pc = CountPerBrickPushConstants {
+            num_particles,
+            grid_size,
+            brick_size: shared::BRICK_SIZE,
+            _pad: 0,
+        };
+        passes::dispatch(
+            &self.device,
+            cmd,
+            &self.count_per_brick_pass,
+            particle_wg,
+            1,
+            1,
+            bytemuck::bytes_of(&count_pc),
+        );
+        passes::barrier(cmd, &self.device);
+
+        // 5. prefix_sum (single workgroup)
+        let prefix_pc = PrefixSumPushConstants {
+            total_bricks: TOTAL_BRICKS,
+            _pad0: 0,
+            _pad1: 0,
+            _pad2: 0,
+        };
+        passes::dispatch(
+            &self.device,
+            cmd,
+            &self.prefix_sum_pass,
+            1,
+            1,
+            1,
+            bytemuck::bytes_of(&prefix_pc),
+        );
+        passes::barrier(cmd, &self.device);
+
+        // 7. Copy brick_offset -> write_offset (scatter needs a mutable copy)
+        {
+            let copy_size = ((TOTAL_BRICKS as usize + 1) * 4) as vk::DeviceSize;
+            let region = vk::BufferCopy {
+                src_offset: 0,
+                dst_offset: 0,
+                size: copy_size,
+            };
+            unsafe {
+                self.device.cmd_copy_buffer(
+                    cmd,
+                    self.brick_offset_buffer.buffer,
+                    self.write_offset_buffer.buffer,
+                    &[region],
+                );
+            }
+        }
+        // 8. Barrier: TRANSFER -> COMPUTE
+        {
+            let memory_barrier = vk::MemoryBarrier::default()
+                .src_access_mask(vk::AccessFlags::TRANSFER_WRITE)
+                .dst_access_mask(vk::AccessFlags::SHADER_READ | vk::AccessFlags::SHADER_WRITE);
+            unsafe {
+                self.device.cmd_pipeline_barrier(
+                    cmd,
+                    vk::PipelineStageFlags::TRANSFER,
+                    vk::PipelineStageFlags::COMPUTE_SHADER,
+                    vk::DependencyFlags::empty(),
+                    &[memory_barrier],
+                    &[],
+                    &[],
+                );
+            }
+        }
+
+        // 9. scatter_particles
+        let scatter_pc = ScatterParticlesPushConstants {
+            num_particles,
+            grid_size,
+            brick_size: shared::BRICK_SIZE,
+            _pad: 0,
+        };
+        passes::dispatch(
+            &self.device,
+            cmd,
+            &self.scatter_particles_pass,
+            particle_wg,
+            1,
+            1,
+            bytemuck::bytes_of(&scatter_pc),
+        );
+        passes::barrier(cmd, &self.device);
+
+        // 11. Clear active_brick_count to 0
+        unsafe {
+            self.device
+                .cmd_fill_buffer(cmd, self.active_brick_count_buffer.buffer, 0, 4, 0);
+        }
+        // 12. Barrier: TRANSFER -> COMPUTE
+        {
+            let memory_barrier = vk::MemoryBarrier::default()
+                .src_access_mask(vk::AccessFlags::TRANSFER_WRITE)
+                .dst_access_mask(vk::AccessFlags::SHADER_READ | vk::AccessFlags::SHADER_WRITE);
+            unsafe {
+                self.device.cmd_pipeline_barrier(
+                    cmd,
+                    vk::PipelineStageFlags::TRANSFER,
+                    vk::PipelineStageFlags::COMPUTE_SHADER,
+                    vk::DependencyFlags::empty(),
+                    &[memory_barrier],
+                    &[],
+                    &[],
+                );
+            }
+        }
+
+        // 13. compact_active_bricks
+        let compact_pc = CompactActiveBricksPushConstants {
+            total_bricks: TOTAL_BRICKS,
+            _pad0: 0,
+            _pad1: 0,
+            _pad2: 0,
+        };
+        passes::dispatch(
+            &self.device,
+            cmd,
+            &self.compact_active_bricks_pass,
+            brick_wg,
+            1,
+            1,
+            bytemuck::bytes_of(&compact_pc),
+        );
+        passes::barrier(cmd, &self.device);
+    }
+
     /// Append new particles to the existing simulation.
     ///
     /// Reads back current particles from the GPU, appends the new ones,
@@ -991,6 +1290,10 @@ impl GpuSimulation {
             &self.compute_activity_pass,
             &self.compute_occupancy_pass,
             &self.update_sleep_pass,
+            &self.count_per_brick_pass,
+            &self.prefix_sum_pass,
+            &self.scatter_particles_pass,
+            &self.compact_active_bricks_pass,
             &self.mark_active_pass,
             &self.prepare_indirect_pass,
             &self.clear_grid_sparse_pass,
@@ -1122,6 +1425,54 @@ impl GpuSimulation {
                 size: 0,
             },
         );
+        let brick_count_buf = std::mem::replace(
+            &mut self.brick_count_buffer,
+            GpuBuffer {
+                buffer: vk::Buffer::null(),
+                allocation: None,
+                size: 0,
+            },
+        );
+        let brick_offset_buf = std::mem::replace(
+            &mut self.brick_offset_buffer,
+            GpuBuffer {
+                buffer: vk::Buffer::null(),
+                allocation: None,
+                size: 0,
+            },
+        );
+        let write_offset_buf = std::mem::replace(
+            &mut self.write_offset_buffer,
+            GpuBuffer {
+                buffer: vk::Buffer::null(),
+                allocation: None,
+                size: 0,
+            },
+        );
+        let sorted_particle_buf = std::mem::replace(
+            &mut self.sorted_particle_buffer,
+            GpuBuffer {
+                buffer: vk::Buffer::null(),
+                allocation: None,
+                size: 0,
+            },
+        );
+        let active_brick_list_buf = std::mem::replace(
+            &mut self.active_brick_list_buffer,
+            GpuBuffer {
+                buffer: vk::Buffer::null(),
+                allocation: None,
+                size: 0,
+            },
+        );
+        let active_brick_count_buf = std::mem::replace(
+            &mut self.active_brick_count_buffer,
+            GpuBuffer {
+                buffer: vk::Buffer::null(),
+                allocation: None,
+                size: 0,
+            },
+        );
         buffer::destroy_buffer(ctx, particle_buf);
         buffer::destroy_buffer(ctx, grid_buf);
         buffer::destroy_buffer(ctx, voxel_buf);
@@ -1132,6 +1483,12 @@ impl GpuSimulation {
         buffer::destroy_buffer(ctx, sleep_counter_buf);
         buffer::destroy_buffer(ctx, sleep_state_buf);
         buffer::destroy_buffer(ctx, brick_occupancy_buf);
+        buffer::destroy_buffer(ctx, brick_count_buf);
+        buffer::destroy_buffer(ctx, brick_offset_buf);
+        buffer::destroy_buffer(ctx, write_offset_buf);
+        buffer::destroy_buffer(ctx, sorted_particle_buf);
+        buffer::destroy_buffer(ctx, active_brick_list_buf);
+        buffer::destroy_buffer(ctx, active_brick_count_buf);
         buffer::destroy_buffer(ctx, mark_buf);
         buffer::destroy_buffer(ctx, active_cells_buf);
         buffer::destroy_buffer(ctx, active_count_buf);

--- a/crates/shaders/src/compute/compact_active_bricks.rs
+++ b/crates/shaders/src/compute/compact_active_bricks.rs
@@ -1,0 +1,104 @@
+//! Compact active bricks compute shader.
+//!
+//! Runs per-brick (1D dispatch, 64 threads/workgroup). For each brick,
+//! checks if it has particles (brick_count > 0) and is not sleeping
+//! (sleep_state != 0). If both conditions are met, appends the brick_id
+//! to the active_brick_list using an atomic counter.
+//!
+//! This is the fourth step of the counting sort pipeline:
+//! count_per_brick -> prefix_sum -> scatter_particles -> compact_active_bricks
+
+use spirv_std::glam::UVec3;
+use spirv_std::spirv;
+
+/// Push constants for the compact_active_bricks shader.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct CompactActiveBricksPushConstants {
+    /// Total number of bricks.
+    pub total_bricks: u32,
+    /// Padding for 16-byte alignment.
+    pub _pad0: u32,
+    /// Padding for 16-byte alignment.
+    pub _pad1: u32,
+    /// Padding for 16-byte alignment.
+    pub _pad2: u32,
+}
+
+/// Atomically add a value to a u32 in a buffer, returning the old value.
+///
+/// Uses `spirv_std::arch::atomic_i_add` on SPIR-V targets.
+/// Falls back to non-atomic increment on CPU (for testing).
+///
+/// # Safety
+/// Caller must ensure `buffer[index]` is valid and properly aligned for atomic access.
+#[inline]
+pub unsafe fn atomic_add_u32(buffer: &mut [u32], index: usize, value: u32) -> u32 {
+    #[cfg(target_arch = "spirv")]
+    {
+        unsafe { spirv_std::arch::atomic_i_add::<u32, 1u32, 0x0u32>(&mut buffer[index], value) }
+    }
+    #[cfg(not(target_arch = "spirv"))]
+    {
+        let old = buffer[index];
+        buffer[index] = old + value;
+        old
+    }
+}
+
+/// Check if a brick should be added to the active list and append it if so.
+///
+/// A brick is active if it has particles (count > 0) and is not fully asleep
+/// (sleep_state != 0). Sleep_state of 0 means frozen; any non-zero value means
+/// the brick has a tick period and should be processed.
+///
+/// Extracted as a helper to satisfy trap #4a (entry points must call a helper).
+pub fn try_compact_brick(
+    brick_id: u32,
+    total_bricks: u32,
+    brick_count: &[u32],
+    sleep_state: &[u32],
+    active_brick_list: &mut [u32],
+    active_brick_count: &mut [u32],
+) {
+    if brick_id >= total_bricks {
+        return;
+    }
+
+    let count = brick_count[brick_id as usize];
+    let sleep = sleep_state[brick_id as usize];
+
+    // Include brick if it has particles and is not frozen (sleep_state == 0 means frozen)
+    if count > 0 && sleep != 0 {
+        let slot = unsafe { atomic_add_u32(active_brick_count, 0, 1) };
+        active_brick_list[slot as usize] = brick_id;
+    }
+}
+
+/// Compute shader entry point: compact active bricks into a list.
+///
+/// Descriptor set 0, binding 0: storage buffer of `u32` (brick_count, read).
+/// Descriptor set 0, binding 1: storage buffer of `u32` (sleep_state, read).
+/// Descriptor set 0, binding 2: storage buffer of `u32` (active_brick_list, write).
+/// Descriptor set 0, binding 3: storage buffer of `u32` (active_brick_count, read-write).
+/// Push constants: `CompactActiveBricksPushConstants`.
+/// Dispatch with `(ceil(total_bricks / 64), 1, 1)` workgroups.
+#[spirv(compute(threads(64)))]
+pub fn compact_active_bricks(
+    #[spirv(global_invocation_id)] id: UVec3,
+    #[spirv(push_constant)] push: &CompactActiveBricksPushConstants,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] brick_count: &[u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] sleep_state: &[u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] active_brick_list: &mut [u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] active_brick_count: &mut [u32],
+) {
+    let brick_id = id.x;
+    try_compact_brick(
+        brick_id,
+        push.total_bricks,
+        brick_count,
+        sleep_state,
+        active_brick_list,
+        active_brick_count,
+    );
+}

--- a/crates/shaders/src/compute/count_per_brick.rs
+++ b/crates/shaders/src/compute/count_per_brick.rs
@@ -1,0 +1,101 @@
+//! Count particles per brick compute shader.
+//!
+//! Runs per-particle (1D dispatch, 64 threads/workgroup). For each particle,
+//! computes the brick_id from its position and atomically increments the
+//! corresponding entry in the brick_count buffer.
+//!
+//! This is the first step of the counting sort pipeline:
+//! count_per_brick -> prefix_sum -> scatter_particles -> compact_active_bricks
+
+use crate::types::Particle;
+use spirv_std::glam::UVec3;
+use spirv_std::spirv;
+
+/// Push constants for the count_per_brick shader.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct CountPerBrickPushConstants {
+    /// Total number of particles.
+    pub num_particles: u32,
+    /// Grid dimension (cells per axis).
+    pub grid_size: u32,
+    /// Brick size (voxels per brick axis, e.g. 8).
+    pub brick_size: u32,
+    /// Padding for 16-byte alignment.
+    pub _pad: u32,
+}
+
+/// Atomically add a value to a u32 in a buffer, returning the old value.
+///
+/// Uses `spirv_std::arch::atomic_i_add` on SPIR-V targets.
+/// Falls back to non-atomic increment on CPU (for testing).
+///
+/// # Safety
+/// Caller must ensure `buffer[index]` is valid and properly aligned for atomic access.
+#[inline]
+pub unsafe fn atomic_add_u32(buffer: &mut [u32], index: usize, value: u32) -> u32 {
+    #[cfg(target_arch = "spirv")]
+    {
+        unsafe { spirv_std::arch::atomic_i_add::<u32, 1u32, 0x0u32>(&mut buffer[index], value) }
+    }
+    #[cfg(not(target_arch = "spirv"))]
+    {
+        let old = buffer[index];
+        buffer[index] = old + value;
+        old
+    }
+}
+
+/// Compute the brick index for a particle at the given position.
+///
+/// Returns the flat ZYX brick index, or `u32::MAX` if out of bounds.
+/// Extracted as a helper to satisfy trap #4a (entry points must call a helper).
+pub fn compute_brick_index(pos_x: f32, pos_y: f32, pos_z: f32, grid_size: u32, brick_size: u32) -> u32 {
+    let bx = (pos_x as u32) / brick_size;
+    let by = (pos_y as u32) / brick_size;
+    let bz = (pos_z as u32) / brick_size;
+    let bricks_per_axis = grid_size / brick_size;
+
+    if bx >= bricks_per_axis || by >= bricks_per_axis || bz >= bricks_per_axis {
+        return u32::MAX;
+    }
+
+    // ZYX order matching grid indexing convention
+    bz * bricks_per_axis * bricks_per_axis + by * bricks_per_axis + bx
+}
+
+/// Compute shader entry point: count particles per brick.
+///
+/// Descriptor set 0, binding 0: storage buffer of `Particle` (read).
+/// Descriptor set 0, binding 1: storage buffer of `u32` (brick_count, read-write).
+/// Push constants: `CountPerBrickPushConstants`.
+/// Dispatch with `(ceil(num_particles / 64), 1, 1)` workgroups.
+#[spirv(compute(threads(64)))]
+pub fn count_per_brick(
+    #[spirv(global_invocation_id)] id: UVec3,
+    #[spirv(push_constant)] push: &CountPerBrickPushConstants,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] particles: &[Particle],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] brick_count: &mut [u32],
+) {
+    let idx = id.x;
+    if idx >= push.num_particles {
+        return;
+    }
+
+    // Copy to locals to avoid buffer references in loops (trap #21)
+    let pos_mass = particles[idx as usize].pos_mass;
+
+    let brick_id = compute_brick_index(
+        pos_mass.x,
+        pos_mass.y,
+        pos_mass.z,
+        push.grid_size,
+        push.brick_size,
+    );
+
+    if brick_id != u32::MAX {
+        unsafe {
+            atomic_add_u32(brick_count, brick_id as usize, 1);
+        }
+    }
+}

--- a/crates/shaders/src/compute/mod.rs
+++ b/crates/shaders/src/compute/mod.rs
@@ -11,17 +11,21 @@
 
 pub mod clear_grid;
 pub mod clear_grid_sparse;
+pub mod compact_active_bricks;
 pub mod compute_activity;
 pub mod compute_occupancy;
+pub mod count_per_brick;
 pub mod explosion;
 pub mod g2p;
 pub mod grid_update;
 pub mod grid_update_sparse;
 pub mod mark_active;
 pub mod p2g;
+pub mod prefix_sum;
 pub mod prepare_indirect;
 pub mod react;
 pub mod render;
+pub mod scatter_particles;
 pub mod toolbar_overlay;
 pub mod update_sleep;
 pub mod voxelize;

--- a/crates/shaders/src/compute/prefix_sum.rs
+++ b/crates/shaders/src/compute/prefix_sum.rs
@@ -1,0 +1,204 @@
+//! Exclusive prefix sum compute shader.
+//!
+//! Computes an exclusive prefix sum over the brick_count buffer to produce
+//! brick_offset. This is the second step of the counting sort pipeline:
+//! count_per_brick -> prefix_sum -> scatter_particles -> compact_active_bricks
+//!
+//! For 32K bricks (TOTAL_BRICKS = 32768), we use a single workgroup with
+//! 256 threads, each handling 128 elements. The scan is done in shared memory
+//! using a work-efficient Blelloch scan (up-sweep + down-sweep).
+//!
+//! brick_offset[i] = sum of brick_count[0..i] (exclusive)
+//! brick_offset[TOTAL_BRICKS] = total particle count (for validation)
+
+use spirv_std::glam::UVec3;
+use spirv_std::spirv;
+
+/// Push constants for the prefix_sum shader.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct PrefixSumPushConstants {
+    /// Total number of bricks.
+    pub total_bricks: u32,
+    /// Padding for 16-byte alignment.
+    pub _pad0: u32,
+    /// Padding for 16-byte alignment.
+    pub _pad1: u32,
+    /// Padding for 16-byte alignment.
+    pub _pad2: u32,
+}
+
+/// Number of threads per workgroup for the prefix sum.
+const WORKGROUP_SIZE: u32 = 256;
+
+/// Maximum number of elements the prefix sum can handle.
+/// Must be >= TOTAL_BRICKS. 256 threads * 128 elements each = 32768.
+const MAX_ELEMENTS: u32 = 32768;
+
+/// Perform the sequential scan of a chunk assigned to this thread.
+///
+/// Each thread sums its chunk of the brick_count buffer into shared memory.
+/// Extracted as a helper to satisfy trap #4a (entry points must call a helper).
+pub fn load_and_sum_chunk(
+    local_id: u32,
+    total_bricks: u32,
+    brick_count: &[u32],
+    chunk_size: u32,
+) -> u32 {
+    let start = local_id * chunk_size;
+    let mut sum = 0u32;
+    let mut i = 0u32;
+    while i < chunk_size {
+        let idx = start + i;
+        if idx < total_bricks {
+            sum += brick_count[idx as usize];
+        }
+        i += 1;
+    }
+    sum
+}
+
+/// Write the prefix sum results back to the brick_offset buffer.
+///
+/// Each thread writes the offsets for its chunk of elements.
+/// The exclusive offset for each element is computed from the thread's
+/// base offset (from the shared memory scan) plus a running sum within the chunk.
+pub fn write_offsets(
+    local_id: u32,
+    total_bricks: u32,
+    brick_count: &[u32],
+    brick_offset: &mut [u32],
+    base_offset: u32,
+    chunk_size: u32,
+) {
+    let start = local_id * chunk_size;
+    let mut running = base_offset;
+    let mut i = 0u32;
+    while i < chunk_size {
+        let idx = start + i;
+        if idx < total_bricks {
+            brick_offset[idx as usize] = running;
+            running += brick_count[idx as usize];
+        }
+        i += 1;
+    }
+    // Last thread writes the total count at brick_offset[total_bricks]
+    if local_id == WORKGROUP_SIZE - 1 {
+        brick_offset[total_bricks as usize] = running;
+    }
+}
+
+/// Compute shader entry point: exclusive prefix sum over brick_count.
+///
+/// Uses a two-phase approach:
+/// 1. Each thread sums its chunk of brick_count into shared memory
+/// 2. Hillis-Steele inclusive scan in shared memory (O(n log n) work, simple)
+/// 3. Each thread writes back per-element exclusive offsets
+///
+/// Descriptor set 0, binding 0: storage buffer of `u32` (brick_count, read).
+/// Descriptor set 0, binding 1: storage buffer of `u32` (brick_offset, write, length = total_bricks + 1).
+/// Push constants: `PrefixSumPushConstants`.
+/// Dispatch with `(1, 1, 1)` — single workgroup.
+#[spirv(compute(threads(256)))]
+pub fn prefix_sum(
+    #[spirv(global_invocation_id)] _id: UVec3,
+    #[spirv(local_invocation_id)] local_id: UVec3,
+    #[spirv(push_constant)] push: &PrefixSumPushConstants,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] brick_count: &[u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] brick_offset: &mut [u32],
+    #[spirv(workgroup)] shared: &mut [u32; 512],
+) {
+    let lid = local_id.x;
+    let total_bricks = push.total_bricks;
+    let chunk_size = (total_bricks + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE;
+
+    // Phase 1: each thread sums its chunk
+    let my_sum = load_and_sum_chunk(lid, total_bricks, brick_count, chunk_size);
+
+    // Store in shared memory for scan
+    // We use double-buffering: shared[0..256] and shared[256..512]
+    shared[lid as usize] = my_sum;
+
+    // Phase 2: Hillis-Steele inclusive prefix sum in shared memory
+    // After this, shared[lid] = sum of all thread sums from thread 0..=lid
+    unsafe { spirv_std::arch::workgroup_memory_barrier_with_group_sync(); }
+
+    // Hillis-Steele: log2(256) = 8 iterations
+    // Unrolled to avoid dynamic loop variable issues with shared memory
+    // Each step: shared[i] += shared[i - stride] if i >= stride
+    let mut stride = 1u32;
+    let mut read_bank = 0u32;
+    let mut write_bank = 256u32;
+
+    // We need 8 iterations for 256 elements. Unrolling to avoid >3 branches per fn.
+    stride = do_scan_step(lid, shared, stride, read_bank, write_bank);
+    read_bank = 256 - read_bank;
+    write_bank = 256 - write_bank;
+
+    stride = do_scan_step(lid, shared, stride, read_bank, write_bank);
+    read_bank = 256 - read_bank;
+    write_bank = 256 - write_bank;
+
+    stride = do_scan_step(lid, shared, stride, read_bank, write_bank);
+    read_bank = 256 - read_bank;
+    write_bank = 256 - write_bank;
+
+    stride = do_scan_step(lid, shared, stride, read_bank, write_bank);
+    read_bank = 256 - read_bank;
+    write_bank = 256 - write_bank;
+
+    stride = do_scan_step(lid, shared, stride, read_bank, write_bank);
+    read_bank = 256 - read_bank;
+    write_bank = 256 - write_bank;
+
+    stride = do_scan_step(lid, shared, stride, read_bank, write_bank);
+    read_bank = 256 - read_bank;
+    write_bank = 256 - write_bank;
+
+    stride = do_scan_step(lid, shared, stride, read_bank, write_bank);
+    read_bank = 256 - read_bank;
+    write_bank = 256 - write_bank;
+
+    let _ = do_scan_step(lid, shared, stride, read_bank, write_bank);
+    read_bank = 256 - read_bank;
+    // After 8 iterations, the inclusive scan result is in the read_bank
+
+    unsafe { spirv_std::arch::workgroup_memory_barrier_with_group_sync(); }
+
+    // Convert inclusive scan to exclusive: base_offset = inclusive[lid - 1], or 0 for lid==0
+    let inclusive_sum = shared[(read_bank + lid) as usize];
+    let base_offset = if lid == 0 { 0 } else { shared[(read_bank + lid - 1) as usize] };
+
+    // Phase 3: write per-element offsets back to brick_offset
+    write_offsets(lid, total_bricks, brick_count, brick_offset, base_offset, chunk_size);
+
+    // Ensure the last thread also has the correct total — it's already handled
+    // in write_offsets for the last thread. But we need to also handle the case
+    // where total_bricks is not evenly divisible. The last thread's running sum
+    // after its chunk is the total count. This is written by write_offsets.
+    let _ = inclusive_sum; // suppress unused warning
+}
+
+/// One step of the Hillis-Steele scan with double-buffered shared memory.
+///
+/// Reads from `shared[read_bank + lid]`, writes to `shared[write_bank + lid]`.
+/// Returns `stride * 2` for the next iteration.
+pub fn do_scan_step(
+    lid: u32,
+    shared: &mut [u32; 512],
+    stride: u32,
+    read_bank: u32,
+    write_bank: u32,
+) -> u32 {
+    unsafe { spirv_std::arch::workgroup_memory_barrier_with_group_sync(); }
+
+    let val = shared[(read_bank + lid) as usize];
+    let sum = if lid >= stride {
+        val + shared[(read_bank + lid - stride) as usize]
+    } else {
+        val
+    };
+    shared[(write_bank + lid) as usize] = sum;
+
+    stride * 2
+}

--- a/crates/shaders/src/compute/scatter_particles.rs
+++ b/crates/shaders/src/compute/scatter_particles.rs
@@ -1,0 +1,124 @@
+//! Scatter particles to sorted positions compute shader.
+//!
+//! Runs per-particle (1D dispatch, 64 threads/workgroup). For each particle,
+//! computes its brick_id, atomically increments the write offset for that brick,
+//! and copies the particle to the sorted position.
+//!
+//! This is the third step of the counting sort pipeline:
+//! count_per_brick -> prefix_sum -> scatter_particles -> compact_active_bricks
+//!
+//! Uses a separate write_offset buffer (copy of brick_offset) because atomicAdd
+//! modifies the values. The original brick_offset is preserved for later use.
+
+use crate::types::Particle;
+use spirv_std::glam::{UVec4, Vec4, UVec3};
+use spirv_std::spirv;
+
+/// Push constants for the scatter_particles shader.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct ScatterParticlesPushConstants {
+    /// Total number of particles.
+    pub num_particles: u32,
+    /// Grid dimension (cells per axis).
+    pub grid_size: u32,
+    /// Brick size (voxels per brick axis, e.g. 8).
+    pub brick_size: u32,
+    /// Padding for 16-byte alignment.
+    pub _pad: u32,
+}
+
+/// Atomically add a value to a u32 in a buffer, returning the old value.
+///
+/// Uses `spirv_std::arch::atomic_i_add` on SPIR-V targets.
+/// Falls back to non-atomic increment on CPU (for testing).
+///
+/// # Safety
+/// Caller must ensure `buffer[index]` is valid and properly aligned for atomic access.
+#[inline]
+pub unsafe fn atomic_add_u32(buffer: &mut [u32], index: usize, value: u32) -> u32 {
+    #[cfg(target_arch = "spirv")]
+    {
+        unsafe { spirv_std::arch::atomic_i_add::<u32, 1u32, 0x0u32>(&mut buffer[index], value) }
+    }
+    #[cfg(not(target_arch = "spirv"))]
+    {
+        let old = buffer[index];
+        buffer[index] = old + value;
+        old
+    }
+}
+
+/// Copy a particle from the source buffer to the destination buffer at the given index.
+///
+/// Copies all 9 Vec4/UVec4 fields individually to avoid taking references
+/// to buffer elements inside loops (trap #21). Extracted as a helper to
+/// satisfy trap #4a (entry points must call a helper).
+pub fn copy_particle_to_sorted(
+    src_idx: usize,
+    dst_idx: usize,
+    particles: &[Particle],
+    sorted: &mut [Particle],
+) {
+    let pos_mass = particles[src_idx].pos_mass;
+    let vel_temp = particles[src_idx].vel_temp;
+    let f_col0 = particles[src_idx].f_col0;
+    let f_col1 = particles[src_idx].f_col1;
+    let f_col2 = particles[src_idx].f_col2;
+    let c_col0 = particles[src_idx].c_col0;
+    let c_col1 = particles[src_idx].c_col1;
+    let c_col2 = particles[src_idx].c_col2;
+    let ids = particles[src_idx].ids;
+
+    sorted[dst_idx].pos_mass = pos_mass;
+    sorted[dst_idx].vel_temp = vel_temp;
+    sorted[dst_idx].f_col0 = f_col0;
+    sorted[dst_idx].f_col1 = f_col1;
+    sorted[dst_idx].f_col2 = f_col2;
+    sorted[dst_idx].c_col0 = c_col0;
+    sorted[dst_idx].c_col1 = c_col1;
+    sorted[dst_idx].c_col2 = c_col2;
+    sorted[dst_idx].ids = ids;
+}
+
+/// Compute shader entry point: scatter particles to sorted positions.
+///
+/// Descriptor set 0, binding 0: storage buffer of `Particle` (read, source particles).
+/// Descriptor set 0, binding 1: storage buffer of `u32` (write_offset, read-write, atomics).
+/// Descriptor set 0, binding 2: storage buffer of `Particle` (write, sorted particles).
+/// Push constants: `ScatterParticlesPushConstants`.
+/// Dispatch with `(ceil(num_particles / 64), 1, 1)` workgroups.
+#[spirv(compute(threads(64)))]
+pub fn scatter_particles(
+    #[spirv(global_invocation_id)] id: UVec3,
+    #[spirv(push_constant)] push: &ScatterParticlesPushConstants,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] particles: &[Particle],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] write_offset: &mut [u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] sorted: &mut [Particle],
+) {
+    let idx = id.x;
+    if idx >= push.num_particles {
+        return;
+    }
+
+    // Copy position to locals (trap #21)
+    let pos_mass = particles[idx as usize].pos_mass;
+
+    let brick_id = crate::compute::count_per_brick::compute_brick_index(
+        pos_mass.x,
+        pos_mass.y,
+        pos_mass.z,
+        push.grid_size,
+        push.brick_size,
+    );
+
+    if brick_id == u32::MAX {
+        return;
+    }
+
+    // Atomically get the next write position for this brick
+    let sorted_idx = unsafe { atomic_add_u32(write_offset, brick_id as usize, 1) };
+
+    // Copy particle to sorted position
+    copy_particle_to_sorted(idx as usize, sorted_idx as usize, particles, sorted);
+}


### PR DESCRIPTION
## Summary

- Add 4 new compute shaders implementing a counting sort pipeline that sorts particles by brick_id, making all particles in the same brick contiguous in memory
- Add server-side buffers (brick_count, brick_offset, write_offset, sorted_particles, active_brick_list, active_brick_count) and compute passes for the sort pipeline
- Add `sort_particles()` method that records the full dispatch chain: clear -> count_per_brick -> prefix_sum -> copy offsets -> scatter_particles -> compact_active_bricks

### Shader details
- **count_per_brick**: per-particle, atomicAdd to brick_count buffer
- **prefix_sum**: single-workgroup Hillis-Steele exclusive scan (256 threads, 128 elements each, shared memory double-buffered)
- **scatter_particles**: per-particle, atomic offset claim + particle copy to sorted buffer
- **compact_active_bricks**: per-brick, filters by count > 0 && sleep_state != 0

### Not included (intentional)
- `sort_particles()` is NOT called from `step_physics()` yet -- integration comes in a follow-up after testing

## Test plan
- [x] `cargo build -p server` passes (shaders compile to SPIR-V successfully)
- [ ] GPU integration test: sort N particles, readback sorted buffer, verify brick contiguity
- [ ] GPU integration test: verify active_brick_count matches expected count
- [ ] Performance benchmark: sort 2M particles, verify < 1ms total

🤖 Generated with [Claude Code](https://claude.com/claude-code)