### PR TITLE
feat: wire up built optimization infrastructure

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -52,6 +52,7 @@ pub(crate) struct App {
     palette: Vec<MaterialSlot>,
     pending_explosion: Option<[f32; 3]>,
     material_db: Option<MaterialDatabase>,
+    last_react_time: Instant,
 }
 
 impl App {
@@ -141,6 +142,7 @@ impl App {
             palette: material_palette(),
             pending_explosion: None,
             material_db,
+            last_react_time: Instant::now(),
         }
     }
 
@@ -243,6 +245,16 @@ impl App {
             selected_index: self.selected_material as u32,
             material_count: self.palette.len().min(TOOLBAR_MAX_MATERIALS) as u32,
             colors,
+        }
+    }
+
+    /// Returns `true` roughly every 100ms to throttle reaction dispatch.
+    fn should_run_react(&mut self, now: Instant) -> bool {
+        if now.duration_since(self.last_react_time).as_millis() >= 100 {
+            self.last_react_time = now;
+            true
+        } else {
+            false
         }
     }
 
@@ -391,10 +403,13 @@ impl ApplicationHandler for App {
                 let target = self.player.camera.target();
                 let toolbar_pc = self.toolbar_push_constants();
                 let explosion = self.pending_explosion.take();
+                let run_react = self.should_run_react(now);
                 if let (Some(renderer), Some(ctx), Some(sim)) = (self.renderer.as_mut(), self.ctx.as_ref(), self.sim.as_ref()) {
                     if let Err(e) = ctx.execute_one_shot(|cmd| {
-                        for _ in 0..substeps { sim.step_physics(cmd); }
-                        sim.step_react(cmd);
+                        for _ in 0..substeps { sim.step_physics_with_time(cmd, now); }
+                        if run_react {
+                            sim.step_react(cmd);
+                        }
                         if let Some(center) = explosion {
                             sim.apply_explosion(cmd, center, EXPLOSION_RADIUS, EXPLOSION_STRENGTH);
                         }

--- a/crates/app/src/headless.rs
+++ b/crates/app/src/headless.rs
@@ -2,6 +2,8 @@
 //!
 //! Runs the simulation for a fixed number of frames and saves a screenshot.
 
+use std::time::Instant;
+
 use anyhow::Result;
 use gpu_core::VulkanContext;
 use server::GpuSimulation;
@@ -54,9 +56,18 @@ pub(crate) fn run_headless(args: &Args) -> Result<()> {
     }
     sim.init_particles(&ctx, &particles)?;
 
+    let mut last_react_time = Instant::now();
     for i in 0..args.frames {
+        let now = Instant::now();
+        let run_react = now.duration_since(last_react_time).as_millis() >= 100;
+        if run_react {
+            last_react_time = now;
+        }
         ctx.execute_one_shot(|cmd| {
-            for _ in 0..args.substeps { sim.step(cmd); }
+            for _ in 0..args.substeps { sim.step_physics_with_time(cmd, now); }
+            if run_react {
+                sim.step_react(cmd);
+            }
         })?;
         if i % 10 == 0 { tracing::info!("Frame {}/{}", i, args.frames); }
     }

--- a/crates/server/src/simulation.rs
+++ b/crates/server/src/simulation.rs
@@ -142,6 +142,8 @@ pub struct GpuSimulation {
     last_sleep_update_time: core::cell::Cell<Instant>,
     /// Last time `compute_occupancy` was dispatched.
     last_occupancy_time: core::cell::Cell<Instant>,
+    /// Last time `sort_particles` was dispatched.
+    last_sort_time: core::cell::Cell<Instant>,
 
     // Reference to context (not owned — caller must keep alive)
     // We store raw device handle for recording commands; the context
@@ -750,6 +752,7 @@ impl GpuSimulation {
             prev_target: core::cell::Cell::new([f32::NAN; 3]),
             last_sleep_update_time: core::cell::Cell::new(Instant::now()),
             last_occupancy_time: core::cell::Cell::new(Instant::now()),
+            last_sort_time: core::cell::Cell::new(Instant::now()),
             device: ctx.device.clone(),
         })
     }
@@ -822,6 +825,13 @@ impl GpuSimulation {
         }
 
         self.record_voxelize(cmd);
+
+        // Particle sorting (improves cache coherence): every 500ms
+        let sort_elapsed = now.duration_since(self.last_sort_time.get());
+        if sort_elapsed.as_millis() >= 500 {
+            self.sort_particles(cmd);
+            self.last_sort_time.set(now);
+        }
 
         // Brick occupancy (render optimization): every 200ms
         let occupancy_elapsed = now.duration_since(self.last_occupancy_time.get());


### PR DESCRIPTION
## Summary

- **App loop**: Switch from `step_physics()` to `step_physics_with_time()` which enables multi-rate scheduling (activity tracking + sleep every 100ms, brick occupancy every 200ms instead of every frame)
- **React throttling**: `step_react()` now called every ~100ms instead of every frame, reducing GPU work significantly
- **Particle sorting**: `sort_particles()` called every ~500ms inside `step_physics_with_time()` for improved cache coherence
- **Headless mode**: Same optimized path applied to `run_headless()`
- **Dirty-tile rendering**: Already wired in `render()` method -- confirmed `compute_dirty_tiles` dispatches before main render, and `finalize_render` copies current frame to prev buffer

## Test plan
- [x] `cargo build` -- compiles cleanly
- [x] `cargo run -p app -- --headless --frames 3` -- no crash, screenshot produced
- [ ] `cargo run -p app` -- windowed mode manual test

🤖 Generated with [Claude Code](https://claude.com/claude-code)