### PR TITLE
feat(app): add mountain range scene with --big flag

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -23,7 +23,8 @@ use winit::{
 };
 
 use crate::scene::{
-    MaterialSlot, create_island_particles, generate_heightmap, material_palette, spawn_cell,
+    MaterialSlot, create_island_particles, create_mountain_particles,
+    generate_heightmap, generate_mountain_heightmap, material_palette, spawn_cell,
 };
 
 /// Distance (in grid units) from the camera eye at which particles are
@@ -61,22 +62,25 @@ impl App {
     /// Otherwise falls back to the default procedural island scene.
     /// If `model_path` is provided, the `.vox` model is loaded and its
     /// particles are added to the scene at `model_pos` (default 32,20,32).
-    pub(crate) fn new(substeps: u32, scene_path: Option<&str>, model_path: Option<&str>, model_pos: Option<(f32, f32, f32)>) -> Self {
-        let (mut particles, scene_camera) = if let Some(path) = scene_path {
+    pub(crate) fn new(substeps: u32, scene_path: Option<&str>, big: bool, model_path: Option<&str>, model_pos: Option<(f32, f32, f32)>) -> Self {
+        let (mut particles, scene_camera, use_mountain) = if let Some(path) = scene_path {
             match content::load_scene(path) {
                 Ok(scene) => {
                     tracing::info!("Loaded scene '{}' from {}", scene.name, path);
                     let cam = scene.camera.clone();
                     let p = scene.spawn_particles();
-                    (p, cam)
+                    (p, cam, false)
                 }
                 Err(e) => {
                     tracing::warn!("Failed to load scene '{}': {}, using default", path, e);
-                    (create_island_particles(), None)
+                    (create_island_particles(), None, false)
                 }
             }
+        } else if big {
+            tracing::info!("Using mountain range scene (--big)");
+            (create_mountain_particles(), None, true)
         } else {
-            (create_island_particles(), None)
+            (create_island_particles(), None, false)
         };
         if let Some(path) = model_path {
             let pos = model_pos.unwrap_or((32.0, 20.0, 32.0));
@@ -122,9 +126,13 @@ impl App {
             )
         };
         let mut player = PlayerController::new(camera);
-        // Only generate heightmap for default island scene (RON scenes don't have procedural terrain)
+        // Only generate heightmap for procedural scenes (RON scenes don't have procedural terrain)
         if scene_camera.is_none() {
-            let heightmap = generate_heightmap();
+            let heightmap = if use_mountain {
+                generate_mountain_heightmap()
+            } else {
+                generate_heightmap()
+            };
             if let Err(e) = player.set_heightmap(heightmap, GRID_SIZE) {
                 tracing::warn!("Failed to set heightmap: {}", e);
             }

--- a/crates/app/src/headless.rs
+++ b/crates/app/src/headless.rs
@@ -35,6 +35,9 @@ pub(crate) fn run_headless(args: &Args) -> Result<()> {
         let cam = scene.camera.clone();
         let p = scene.spawn_particles();
         (p, cam)
+    } else if args.big {
+        tracing::info!("Using mountain range scene (--big)");
+        (crate::scene::create_mountain_particles(), None)
     } else {
         (create_island_particles(), None)
     };

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -25,6 +25,8 @@ struct Args {
     substeps: u32,
     /// Path to a RON scene file. If `None`, the default island scene is used.
     scene: Option<String>,
+    /// If true, use the mountain range scene instead of the island.
+    big: bool,
     /// Path to a `.vox` (MagicaVoxel) model to load into the scene.
     model: Option<String>,
     /// World-space offset (x,y,z) at which to place the loaded model.
@@ -58,6 +60,7 @@ fn parse_args() -> Args {
         .iter()
         .position(|a| a == "--model")
         .and_then(|i| args.get(i + 1).cloned());
+    let big = args.contains(&"--big".to_string());
     let model_pos = args
         .iter()
         .position(|a| a == "--model-pos")
@@ -74,7 +77,7 @@ fn parse_args() -> Args {
                 None
             }
         });
-    Args { headless, frames, output, substeps, scene, model, model_pos }
+    Args { headless, frames, output, substeps, scene, big, model, model_pos }
 }
 
 fn main() -> Result<()> {
@@ -88,7 +91,7 @@ fn main() -> Result<()> {
     if args.headless { return headless::run_headless(&args); }
 
     let event_loop = EventLoop::new()?;
-    let mut application = app::App::new(args.substeps, args.scene.as_deref(), args.model.as_deref(), args.model_pos);
+    let mut application = app::App::new(args.substeps, args.scene.as_deref(), args.big, args.model.as_deref(), args.model_pos);
     event_loop.run_app(&mut application)?;
     tracing::info!("VOX Engine shut down");
     Ok(())

--- a/crates/app/src/scene.rs
+++ b/crates/app/src/scene.rs
@@ -245,14 +245,260 @@ pub(crate) fn create_island_particles() -> Vec<Particle> {
 
 /// Generate the CPU-side heightmap for player ground collision.
 pub(crate) fn generate_heightmap() -> Vec<f32> {
+    generate_heightmap_with(island_height)
+}
+
+/// Generate the CPU-side heightmap for the mountain range scene.
+pub(crate) fn generate_mountain_heightmap() -> Vec<f32> {
+    generate_heightmap_with(mountain_height)
+}
+
+/// Generate a heightmap using the given height function.
+fn generate_heightmap_with(height_fn: fn(f32, f32) -> f32) -> Vec<f32> {
     let size = GRID_SIZE;
     let mut heightmap = vec![0.0f32; (size * size) as usize];
     for z in 0..size {
         for x in 0..size {
-            heightmap[(z * size + x) as usize] = island_height(x as f32 + 0.5, z as f32 + 0.5);
+            heightmap[(z * size + x) as usize] = height_fn(x as f32 + 0.5, z as f32 + 0.5);
         }
     }
     heightmap
+}
+
+/// Compute a Gaussian peak contribution at (x, z) centered at (px, pz).
+fn gaussian_peak(x: f32, z: f32, px: f32, pz: f32, radius: f32, height: f32) -> f32 {
+    let dx = x - px;
+    let dz = z - pz;
+    let dist_sq = dx * dx + dz * dz;
+    height * (-dist_sq / (2.0 * radius * radius)).exp()
+}
+
+/// Compute terrain height for the mountain range scene at (x, z).
+///
+/// Features multiple peaks of varied heights, rolling hills, and valleys.
+/// Coordinates scale with GRID_SIZE.
+pub(crate) fn mountain_height(x: f32, z: f32) -> f32 {
+    let gs = GRID_SIZE as f32;
+    let cx = gs * 0.5;
+    let cz = gs * 0.5;
+
+    let base = MARGIN as f32;
+
+    // Boundary falloff — keep particles away from grid edges
+    let edge_margin = gs * 0.04;
+    let fx = if x < edge_margin {
+        x / edge_margin
+    } else if x > gs - edge_margin {
+        (gs - x) / edge_margin
+    } else {
+        1.0
+    };
+    let fz = if z < edge_margin {
+        z / edge_margin
+    } else if z > gs - edge_margin {
+        (gs - z) / edge_margin
+    } else {
+        1.0
+    };
+    let edge_falloff = (fx * fz).max(0.0).min(1.0);
+
+    // Multiple mountain peaks at different positions — wider and taller
+    let peak1 = gaussian_peak(x, z, cx - 25.0, cz - 15.0, 50.0, gs * 0.60);
+    let peak2 = gaussian_peak(x, z, cx + 40.0, cz + 30.0, 45.0, gs * 0.52);
+    let peak3 = gaussian_peak(x, z, cx, cz + 50.0, 55.0, gs * 0.72);
+    let peak4 = gaussian_peak(x, z, cx - 45.0, cz + 35.0, 40.0, gs * 0.45);
+    let peak5 = gaussian_peak(x, z, cx + 15.0, cz - 40.0, 50.0, gs * 0.55);
+    let peak6 = gaussian_peak(x, z, cx + 55.0, cz - 15.0, 35.0, gs * 0.40);
+    let peak7 = gaussian_peak(x, z, cx - 15.0, cz - 50.0, 40.0, gs * 0.42);
+
+    // Multi-octave rolling hills for base terrain — higher base
+    let n1 = (x * 0.04).sin() * (z * 0.05).cos() * gs * 0.05;
+    let n2 = (x * 0.09 + 1.7).sin() * (z * 0.08 + 2.3).cos() * gs * 0.03;
+    let n3 = (x * 0.21 + 0.5).cos() * (z * 0.19 + 1.1).sin() * gs * 0.015;
+    let n4 = (x * 0.37 + 3.1).sin() * (z * 0.41 + 0.7).cos() * gs * 0.008;
+    let hills = n1 + n2 + n3 + n4;
+
+    let peaks = peak1 + peak2 + peak3 + peak4 + peak5 + peak6 + peak7;
+    let terrain = hills + peaks;
+
+    // Clamp height to leave room at top of grid
+    let max_height = gs * 0.88;
+    let h = base + (gs * 0.06 + terrain.max(0.0)) * edge_falloff;
+    h.min(max_height)
+}
+
+/// Create the initial set of particles for the mountain range scene.
+///
+/// Features multiple mountain peaks, valleys with water pools, a lava river,
+/// and a cave tunnel through one mountain. Targets 800K-1M particles.
+pub(crate) fn create_mountain_particles() -> Vec<Particle> {
+    let mut particles = Vec::new();
+    let gs = GRID_SIZE;
+    let margin = MARGIN;
+    let upper = gs - margin;
+
+    // 1. Thin floor
+    for x in margin..upper {
+        for z in margin..upper {
+            let fx = x as f32 + 0.5;
+            let fz = z as f32 + 0.5;
+            for y in (margin as i32)..(margin as i32 + FLOOR_THICKNESS).min(upper as i32) {
+                particles.push(Particle::new(
+                    Vec3::new(fx, y as f32 + 0.5, fz),
+                    1.0, MAT_STONE, PHASE_SOLID,
+                ));
+            }
+        }
+    }
+
+    // 2. Terrain shell — thick shell for mountains to look solid
+    let shell = 8_i32;
+    let gs_f = gs as f32;
+    let cx = gs_f * 0.5;
+    let cz = gs_f * 0.5;
+    for x in margin..upper {
+        for z in margin..upper {
+            let fx = x as f32 + 0.5;
+            let fz = z as f32 + 0.5;
+            let height = mountain_height(fx, fz);
+            let max_y = (height.ceil() as i32).min(upper as i32);
+            let min_y = (max_y - shell).max(margin as i32 + FLOOR_THICKNESS);
+
+            // Cave tunnel through peak3 (the tallest mountain at cx, cz+55)
+            let cave_cx = cx;
+            let cave_cz = cz + 55.0;
+            let cave_dx = fx - cave_cx;
+            let cave_dz = fz - cave_cz;
+            // Tunnel runs along X axis, cylindrical hole
+            let cave_radius = 6.0;
+            let cave_y_center = MARGIN as f32 + gs_f * 0.15;
+            let is_in_cave = cave_dz.abs() < cave_radius
+                && cave_dx.abs() < gs_f * 0.15;
+            let cave_dist_sq = cave_dz * cave_dz;
+
+            for y in min_y..max_y {
+                let fy = y as f32 + 0.5;
+
+                // Carve cave tunnel
+                if is_in_cave {
+                    let dy = fy - cave_y_center;
+                    if cave_dist_sq + dy * dy < cave_radius * cave_radius {
+                        continue; // skip this voxel — it's inside the cave
+                    }
+                }
+
+                particles.push(Particle::new(
+                    Vec3::new(fx, fy, fz),
+                    1.0, MAT_STONE, PHASE_SOLID,
+                ));
+            }
+        }
+    }
+
+    // 3. Water pools in valleys — fill low areas between mountains
+    let water_level = (gs_f * 0.15) as i32; // valleys fill up to ~15% of grid height
+    // Only fill water in specific valley regions to control particle count
+    let valley_regions: [(f32, f32, f32); 3] = [
+        (cx + 10.0, cz + 10.0, 40.0),  // valley between peaks 1,2,3
+        (cx - 40.0, cz - 30.0, 25.0),  // small pool near peak1
+        (cx + 50.0, cz - 20.0, 20.0),  // pool near peak5
+    ];
+    for x in margin..upper {
+        for z in margin..upper {
+            let fx = x as f32 + 0.5;
+            let fz = z as f32 + 0.5;
+            let terrain_h = mountain_height(fx, fz);
+
+            // Only place water if in a valley region
+            let in_valley = valley_regions.iter().any(|(vx, vz, vr)| {
+                let dx = fx - vx;
+                let dz = fz - vz;
+                dx * dx + dz * dz < vr * vr
+            });
+            if !in_valley { continue; }
+
+            if terrain_h < water_level as f32 {
+                let top = water_level.min(upper as i32);
+                let bottom = (top - 1).max(terrain_h.ceil() as i32);
+                for y in bottom..top {
+                    spawn_cell(&mut particles, fx - 0.5, y as f32, fz - 0.5,
+                        0.125, MAT_WATER, PHASE_LIQUID);
+                }
+            }
+        }
+    }
+
+    // 4. Lava river in a valley between peak4 and peak3
+    // River flows roughly from (cx-50, cz+40) toward (cx, cz+55)
+    let lava_segments: [(f32, f32, f32, f32); 4] = [
+        (cx - 50.0, cz + 40.0, cx - 35.0, cz + 45.0),
+        (cx - 35.0, cz + 45.0, cx - 20.0, cz + 50.0),
+        (cx - 20.0, cz + 50.0, cx - 5.0, cz + 53.0),
+        (cx - 5.0, cz + 53.0, cx + 10.0, cz + 55.0),
+    ];
+    let river_width = 4.0_f32;
+    for x in margin..upper {
+        for z in margin..upper {
+            let fx = x as f32 + 0.5;
+            let fz = z as f32 + 0.5;
+
+            // Check distance to any river segment
+            let near_river = lava_segments.iter().any(|&(x1, z1, x2, z2)| {
+                point_segment_dist_sq(fx, fz, x1, z1, x2, z2) < river_width * river_width
+            });
+            if !near_river { continue; }
+
+            let terrain_h = mountain_height(fx, fz);
+            // Lava sits on top of terrain, 1 layer
+            let lava_y = terrain_h.ceil() as i32;
+            if lava_y >= upper as i32 { continue; }
+
+            spawn_cell(&mut particles, fx - 0.5, lava_y as f32, fz - 0.5,
+                0.125, MAT_LAVA, PHASE_LIQUID);
+            // Set temperature on the 8 lava particles just spawned
+            let start = particles.len() - 8;
+            for p in &mut particles[start..] {
+                p.vel_temp = glam::Vec4::new(0.0, 0.0, 0.0, 2000.0);
+            }
+        }
+    }
+
+    // Log material counts
+    let stone_count = particles.iter().filter(|p| p.material_id() == MAT_STONE).count();
+    let water_count = particles.iter().filter(|p| p.material_id() == MAT_WATER).count();
+    let lava_count = particles.iter().filter(|p| p.material_id() == MAT_LAVA).count();
+    tracing::info!(
+        "Mountain scene: {} stone + {} water + {} lava = {} total",
+        stone_count, water_count, lava_count, particles.len(),
+    );
+
+    assert!(
+        particles.len() < shared::MAX_PARTICLES as usize,
+        "Mountain scene has {} particles, max is {}",
+        particles.len(),
+        shared::MAX_PARTICLES
+    );
+
+    particles
+}
+
+/// Squared distance from point (px, pz) to line segment (x1,z1)-(x2,z2).
+fn point_segment_dist_sq(px: f32, pz: f32, x1: f32, z1: f32, x2: f32, z2: f32) -> f32 {
+    let dx = x2 - x1;
+    let dz = z2 - z1;
+    let len_sq = dx * dx + dz * dz;
+    if len_sq < 1e-6 {
+        let ex = px - x1;
+        let ez = pz - z1;
+        return ex * ex + ez * ez;
+    }
+    let t = ((px - x1) * dx + (pz - z1) * dz) / len_sq;
+    let t = t.max(0.0).min(1.0);
+    let proj_x = x1 + t * dx;
+    let proj_z = z1 + t * dz;
+    let ex = px - proj_x;
+    let ez = pz - proj_z;
+    ex * ex + ez * ez
 }
 
 #[cfg(test)]
@@ -278,5 +524,46 @@ mod tests {
             assert!(h.is_finite(), "NaN in heightmap");
             assert!(*h >= 0.0 && *h < GRID_SIZE as f32, "Height {} out of bounds", h);
         }
+    }
+
+    #[test]
+    fn mountain_particles_under_limit() {
+        let particles = create_mountain_particles();
+        assert!(
+            particles.len() < shared::MAX_PARTICLES as usize,
+            "Mountain scene has {} particles, max is {}",
+            particles.len(),
+            shared::MAX_PARTICLES
+        );
+        // Should be significantly more than island scene
+        assert!(
+            particles.len() > 600_000,
+            "Mountain scene should have >600K particles, got {}",
+            particles.len()
+        );
+    }
+
+    #[test]
+    fn mountain_heightmap_values_valid() {
+        let hm = generate_mountain_heightmap();
+        assert_eq!(hm.len(), (GRID_SIZE * GRID_SIZE) as usize);
+        for h in &hm {
+            assert!(h.is_finite(), "NaN in mountain heightmap");
+            assert!(*h >= 0.0 && *h < GRID_SIZE as f32, "Height {} out of bounds", h);
+        }
+    }
+
+    #[test]
+    fn mountain_has_varied_terrain() {
+        let hm = generate_mountain_heightmap();
+        let min_h = hm.iter().cloned().fold(f32::MAX, f32::min);
+        let max_h = hm.iter().cloned().fold(f32::MIN, f32::max);
+        let range = max_h - min_h;
+        // Should have significant height variation (at least 30% of grid)
+        assert!(
+            range > GRID_SIZE as f32 * 0.3,
+            "Height range {:.1} is too small (min={:.1}, max={:.1})",
+            range, min_h, max_h
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Add `mountain_range_scene()` to `crates/app/src/scene.rs` with 7 Gaussian peaks (50-200 units tall), rolling hills, 3 water pools in valleys, a lava river between mountains, and a cave tunnel through the tallest peak
- Add `--big` CLI flag to switch from default island to mountain scene in both windowed and headless modes
- Scene generates 600K-1M particles in 256 grid (under MAX_PARTICLES=2M limit), targeting stress-test of sleep optimization with large static terrain
- 3 new tests: particle count bounds, heightmap validity, terrain height variation

## Usage
```bash
cargo run -p app -- --big                          # Windowed mountain scene
cargo run -p app -- --big --headless --frames 10   # Headless screenshot
```

## Test plan
- [x] `cargo build` compiles successfully
- [x] `cargo test -p app` -- all 5 tests pass (2 existing + 3 new)
- [ ] `cargo run -p app -- --big` launches and renders the terrain
- [ ] Verify sleep optimization handles large static terrain efficiently

🤖 Generated with [Claude Code](https://claude.com/claude-code)