### PR TITLE
feat: wire sparse hash grid into physics dispatch chain

### DIFF
--- a/crates/app/src/scene.rs
+++ b/crates/app/src/scene.rs
@@ -330,7 +330,8 @@ pub(crate) fn mountain_height(x: f32, z: f32) -> f32 {
 /// Create the initial set of particles for the mountain range scene.
 ///
 /// Features multiple mountain peaks, valleys with water pools, a lava river,
-/// and a cave tunnel through one mountain. Targets 800K-1M particles.
+/// and a cave tunnel through one mountain. With 4M max particles, the terrain
+/// shell is thicker and water pools are deeper for a denser world.
 pub(crate) fn create_mountain_particles() -> Vec<Particle> {
     let mut particles = Vec::new();
     let gs = GRID_SIZE;
@@ -351,8 +352,8 @@ pub(crate) fn create_mountain_particles() -> Vec<Particle> {
         }
     }
 
-    // 2. Terrain shell — thick shell for mountains to look solid
-    let shell = 8_i32;
+    // 2. Terrain shell — thicker shell (16 layers) for dense mountains
+    let shell = 16_i32;
     let gs_f = gs as f32;
     let cx = gs_f * 0.5;
     let cz = gs_f * 0.5;
@@ -395,13 +396,13 @@ pub(crate) fn create_mountain_particles() -> Vec<Particle> {
         }
     }
 
-    // 3. Water pools in valleys — fill low areas between mountains
-    let water_level = (gs_f * 0.15) as i32; // valleys fill up to ~15% of grid height
-    // Only fill water in specific valley regions to control particle count
-    let valley_regions: [(f32, f32, f32); 3] = [
-        (cx + 10.0, cz + 10.0, 40.0),  // valley between peaks 1,2,3
-        (cx - 40.0, cz - 30.0, 25.0),  // small pool near peak1
-        (cx + 50.0, cz - 20.0, 20.0),  // pool near peak5
+    // 3. Water pools in valleys — deeper (3 layers, 8 PPC) for denser world
+    let water_level = (gs_f * 0.18) as i32; // valleys fill up to ~18% of grid height
+    let valley_regions: [(f32, f32, f32); 4] = [
+        (cx + 10.0, cz + 10.0, 45.0),  // valley between peaks 1,2,3 (bigger)
+        (cx - 40.0, cz - 30.0, 30.0),  // pool near peak1 (bigger)
+        (cx + 50.0, cz - 20.0, 25.0),  // pool near peak5 (bigger)
+        (cx - 10.0, cz - 45.0, 20.0),  // new pool near peak7
     ];
     for x in margin..upper {
         for z in margin..upper {
@@ -419,7 +420,7 @@ pub(crate) fn create_mountain_particles() -> Vec<Particle> {
 
             if terrain_h < water_level as f32 {
                 let top = water_level.min(upper as i32);
-                let bottom = (top - 1).max(terrain_h.ceil() as i32);
+                let bottom = (top - 3).max(terrain_h.ceil() as i32); // 3 layers deep
                 for y in bottom..top {
                     spawn_cell(&mut particles, fx - 0.5, y as f32, fz - 0.5,
                         0.125, MAT_WATER, PHASE_LIQUID);
@@ -428,15 +429,14 @@ pub(crate) fn create_mountain_particles() -> Vec<Particle> {
         }
     }
 
-    // 4. Lava river in a valley between peak4 and peak3
-    // River flows roughly from (cx-50, cz+40) toward (cx, cz+55)
+    // 4. Lava river in a valley between peak4 and peak3 — wider
     let lava_segments: [(f32, f32, f32, f32); 4] = [
         (cx - 50.0, cz + 40.0, cx - 35.0, cz + 45.0),
         (cx - 35.0, cz + 45.0, cx - 20.0, cz + 50.0),
         (cx - 20.0, cz + 50.0, cx - 5.0, cz + 53.0),
         (cx - 5.0, cz + 53.0, cx + 10.0, cz + 55.0),
     ];
-    let river_width = 4.0_f32;
+    let river_width = 6.0_f32; // wider river
     for x in margin..upper {
         for z in margin..upper {
             let fx = x as f32 + 0.5;
@@ -535,10 +535,10 @@ mod tests {
             particles.len(),
             shared::MAX_PARTICLES
         );
-        // Should be significantly more than island scene
+        // Dense scene should have >1M particles with thicker shells and deeper pools
         assert!(
-            particles.len() > 600_000,
-            "Mountain scene should have >600K particles, got {}",
+            particles.len() > 1_000_000,
+            "Mountain scene should have >1M particles, got {}",
             particles.len()
         );
     }

--- a/crates/server/src/simulation.rs
+++ b/crates/server/src/simulation.rs
@@ -187,17 +187,32 @@ impl GpuSimulation {
             "particle-buffer",
         )?;
 
-        // Grid buffer: must fit both GridCell view and flat f32 view.
-        // GridCell = 48 bytes = 12 * f32, so GRID_CELL_COUNT * sizeof(GridCell)
-        // equals GRID_CELL_COUNT * 12 * sizeof(f32). Same size, no issue.
+        // Grid buffer: used by the dense physics path.
+        // When sparse hash grid is active, we allocate a small placeholder
+        // since the dense passes won't run and this saves ~768MB at 256³.
+        // GridCell = 48 bytes = 12 * f32.
+        let use_sparse = true; // matches use_sparse_grid default
+        let grid_buf_cells = if use_sparse {
+            // Small placeholder — dense passes (clear_grid_sparse, mark_active,
+            // prepare_indirect, grid_update_sparse, P2G, G2P) won't run.
+            64 * 64 * 64_usize
+        } else {
+            GRID_CELL_COUNT as usize
+        };
         let grid_buf_size =
-            (GRID_CELL_COUNT as usize * mem::size_of::<GridCell>()) as vk::DeviceSize;
+            (grid_buf_cells * mem::size_of::<GridCell>()) as vk::DeviceSize;
         let grid_buffer = buffer::create_device_local_buffer(
             ctx,
             grid_buf_size,
             vk::BufferUsageFlags::STORAGE_BUFFER,
             "grid-buffer",
         )?;
+        tracing::info!(
+            "Grid buffer: {} cells ({:.1}MB) [sparse={}]",
+            grid_buf_cells,
+            grid_buf_size as f64 / (1024.0 * 1024.0),
+            use_sparse,
+        );
 
         let voxel_buf_size =
             (GRID_CELL_COUNT as usize * mem::size_of::<glam::UVec4>()) as vk::DeviceSize;
@@ -327,15 +342,27 @@ impl GpuSimulation {
         )?;
 
         // -- Sparse dispatch buffers --
+        // When hash grid is active, mark_buffer and active_cells are unused (dense path only).
+        // Allocate small placeholders to save memory.
+        let sparse_dispatch_cells = if use_sparse {
+            64_usize // minimal placeholder
+        } else {
+            GRID_CELL_COUNT as usize
+        };
+        let sparse_active_cells = if use_sparse {
+            64_usize
+        } else {
+            MAX_ACTIVE_CELLS as usize
+        };
         let mark_buffer = buffer::create_device_local_buffer(
             ctx,
-            (GRID_CELL_COUNT as usize * 4) as vk::DeviceSize,
+            (sparse_dispatch_cells * 4) as vk::DeviceSize,
             vk::BufferUsageFlags::STORAGE_BUFFER | vk::BufferUsageFlags::TRANSFER_DST,
             "mark-buffer",
         )?;
         let active_cells_buffer = buffer::create_device_local_buffer(
             ctx,
-            (MAX_ACTIVE_CELLS as usize * 4) as vk::DeviceSize,
+            (sparse_active_cells * 4) as vk::DeviceSize,
             vk::BufferUsageFlags::STORAGE_BUFFER,
             "active-cells-buffer",
         )?;
@@ -742,7 +769,7 @@ impl GpuSimulation {
             p2g_hash_pass,
             g2p_hash_pass,
             grid_update_hash_pass,
-            use_sparse_grid: false,
+            use_sparse_grid: true,
             shader_module,
             descriptor_pool,
             num_particles: 0,
@@ -847,11 +874,23 @@ impl GpuSimulation {
         self.frame_number.set(self.frame_number.get().wrapping_add(1));
     }
 
-    /// Record core physics dispatches: sparse clear, P2G, mark_active,
-    /// prepare_indirect, grid_update_sparse, G2P.
+    /// Record core physics dispatches, choosing between sparse hash grid and
+    /// dense flat grid paths based on `use_sparse_grid`.
     ///
     /// These MUST run every substep for correct simulation.
     fn record_core_physics(&self, cmd: vk::CommandBuffer) {
+        if self.use_sparse_grid {
+            self.record_core_physics_sparse(cmd);
+        } else {
+            self.record_core_physics_dense(cmd);
+        }
+    }
+
+    /// Dense flat-grid physics path: clear_grid_sparse (indirect on active list),
+    /// mark_active, prepare_indirect, grid_update_sparse (indirect), dense P2G/G2P.
+    ///
+    /// This is the original dispatch chain using the flat `grid_buffer`.
+    fn record_core_physics_dense(&self, cmd: vk::CommandBuffer) {
         let num_particles = self.num_particles;
         let grid_size = GRID_SIZE;
         let dt = shared::DT;
@@ -859,8 +898,6 @@ impl GpuSimulation {
         let particle_wg = (num_particles + 63) / 64;
 
         // 1. Clear grid (sparse) — clears only cells that were active last frame.
-        // Uses indirect dispatch from previous frame's active cell list.
-        // On the first frame, indirect buffer is (0,0,0) so this is a no-op.
         unsafe {
             self.device.cmd_bind_pipeline(
                 cmd,
@@ -885,16 +922,12 @@ impl GpuSimulation {
         passes::barrier(cmd, &self.device);
 
         // 2. Reset active_count to 0 AND clear mark_buffer for this frame.
-        // mark_buffer must be zeroed every frame — otherwise mark_active finds
-        // cells already marked from the previous frame, skips adding them to
-        // active_cells, and grid_update_sparse processes 0 cells (#221).
         unsafe {
             self.device
                 .cmd_fill_buffer(cmd, self.active_count_buffer.buffer, 0, 4, 0);
             self.device
                 .cmd_fill_buffer(cmd, self.mark_buffer.buffer, 0, vk::WHOLE_SIZE, 0);
         }
-        // Barrier: TRANSFER_WRITE → SHADER_READ | SHADER_WRITE
         {
             let memory_barrier = vk::MemoryBarrier::default()
                 .src_access_mask(vk::AccessFlags::TRANSFER_WRITE)
@@ -1013,6 +1046,110 @@ impl GpuSimulation {
             &self.device,
             cmd,
             &self.g2p_pass,
+            particle_wg,
+            1,
+            1,
+            bytemuck::bytes_of(&g2p_pc),
+        );
+        passes::barrier(cmd, &self.device);
+    }
+
+    /// Sparse hash-grid physics path: clear_hash_grid, p2g_sparse, grid_update_hash,
+    /// g2p_sparse.
+    ///
+    /// Uses a hash table instead of a flat 3D grid buffer. Only occupied cells are
+    /// allocated in the hash table, so memory usage is proportional to particle count
+    /// rather than grid volume. This enables much larger grids (512³+) without
+    /// allocating terabytes of flat buffer.
+    ///
+    /// Dispatch order:
+    /// 1. `clear_hash_grid` — reset all keys to EMPTY sentinel, zero all values
+    /// 2. `p2g_sparse` — scatter particle data into hash grid via atomic insert
+    /// 3. `grid_update_hash` — update physics on all occupied hash grid slots
+    /// 4. `g2p_sparse` — gather grid data back to particles via hash grid lookup
+    fn record_core_physics_sparse(&self, cmd: vk::CommandBuffer) {
+        let num_particles = self.num_particles;
+        let grid_size = GRID_SIZE;
+        let dt = shared::DT;
+        let gravity = shared::GRAVITY;
+        let particle_wg = (num_particles + 63) / 64;
+        let hash_capacity = HASH_GRID_DEFAULT_CAPACITY;
+        let hash_wg = (hash_capacity + 63) / 64;
+        let frame = self.frame_number.get();
+
+        // 1. Clear hash grid — reset keys to EMPTY, zero values
+        let clear_pc = ClearHashGridPushConstants {
+            hash_capacity,
+            _pad0: 0,
+            _pad1: 0,
+            _pad2: 0,
+        };
+        passes::dispatch(
+            &self.device,
+            cmd,
+            &self.clear_hash_grid_pass,
+            hash_wg,
+            1,
+            1,
+            bytemuck::bytes_of(&clear_pc),
+        );
+        passes::barrier(cmd, &self.device);
+
+        // 2. P2G sparse (particle dispatch) — scatter into hash grid
+        let p2g_pc = P2gSparsePushConstants {
+            grid_size,
+            dt,
+            num_particles,
+            frame_number: frame,
+            hash_capacity,
+            _pad0: 0,
+            _pad1: 0,
+            _pad2: 0,
+        };
+        passes::dispatch(
+            &self.device,
+            cmd,
+            &self.p2g_hash_pass,
+            particle_wg,
+            1,
+            1,
+            bytemuck::bytes_of(&p2g_pc),
+        );
+        passes::barrier(cmd, &self.device);
+
+        // 3. Grid update hash — physics on occupied hash grid slots only
+        let grid_pc = GridUpdateHashPushConstants {
+            grid_size,
+            dt,
+            gravity,
+            hash_capacity,
+        };
+        passes::dispatch(
+            &self.device,
+            cmd,
+            &self.grid_update_hash_pass,
+            hash_wg,
+            1,
+            1,
+            bytemuck::bytes_of(&grid_pc),
+        );
+        passes::barrier(cmd, &self.device);
+
+        // 4. G2P sparse (particle dispatch) — gather from hash grid
+        let g2p_pc = G2pSparsePushConstants {
+            grid_size,
+            dt,
+            num_particles,
+            num_rules: self.num_phase_rules,
+            frame_number: frame,
+            hash_capacity,
+            _pad0: 0,
+            _pad1: 0,
+        };
+        passes::dispatch(
+            &self.device,
+            cmd,
+            &self.g2p_hash_pass,
             particle_wg,
             1,
             1,

--- a/crates/shaders/src/types.rs
+++ b/crates/shaders/src/types.rs
@@ -64,7 +64,7 @@ pub struct GridCell {
 pub const GRID_SIZE: u32 = 256;
 
 /// Default hash grid capacity (synced with shared::constants).
-pub const HASH_GRID_DEFAULT_CAPACITY: u32 = 1 << 20;
+pub const HASH_GRID_DEFAULT_CAPACITY: u32 = 1 << 21;
 
 /// Empty sentinel for hash grid keys (synced with shared::constants).
 pub const HASH_GRID_EMPTY_KEY: u32 = 0xFFFF_FFFF;

--- a/crates/shared/src/constants.rs
+++ b/crates/shared/src/constants.rs
@@ -32,7 +32,7 @@ pub const RENDER_WIDTH: u32 = 1280;
 pub const RENDER_HEIGHT: u32 = 720;
 
 /// Maximum number of particles for MVP.
-pub const MAX_PARTICLES: u32 = 2_000_000;
+pub const MAX_PARTICLES: u32 = 4_000_000;
 
 /// Physics tick rate (Hz).
 pub const PHYSICS_HZ: u32 = 60;
@@ -64,7 +64,7 @@ pub const DIRTY_TILE_COUNT: u32 = DIRTY_TILES_X * DIRTY_TILES_Y;
 /// Default hash grid capacity (number of slots).
 /// Should be ~2x the expected max active cells for low collision rate.
 /// Must be a power of 2 for fast modulo via bitwise AND.
-pub const HASH_GRID_DEFAULT_CAPACITY: u32 = 1 << 20; // 1M slots = ~52MB
+pub const HASH_GRID_DEFAULT_CAPACITY: u32 = 1 << 21; // 2M slots = ~104MB
 
 /// Empty sentinel for hash grid keys.
 /// Represents an unoccupied slot in the hash grid.
@@ -119,6 +119,7 @@ mod tests {
     fn hash_grid_capacity_is_power_of_two() {
         assert!(HASH_GRID_DEFAULT_CAPACITY.is_power_of_two());
         assert!(HASH_GRID_DEFAULT_CAPACITY > 0);
+        assert_eq!(HASH_GRID_DEFAULT_CAPACITY, 1 << 21); // 2M slots
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Sparse physics path wired in**: `record_core_physics()` now branches on `use_sparse_grid` flag. When true (now the default), it dispatches `clear_hash_grid` -> `p2g_sparse` -> `grid_update_hash` -> `g2p_sparse` instead of the dense flat-grid passes (clear_grid_sparse, mark_active, prepare_indirect, grid_update_sparse, P2G, G2P).
- **Memory savings**: When sparse is active, grid_buffer (768MB at 256^3) and mark_buffer (64MB) are allocated as small placeholders. Hash grid uses ~104MB for 2M slots instead.
- **MAX_PARTICLES raised to 4M** with HASH_GRID_DEFAULT_CAPACITY doubled to 2M slots (synced in shaders).
- **Denser mountain terrain**: Shell thickness 8->16 layers, deeper water pools (3 layers), wider lava river, 4 valley regions. Scene targets 1-2M particles.

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo test -p shared` passes (constants, hash grid capacity test updated)
- [x] `cargo test -p app` passes (mountain scene >1M particles, under 4M limit)
- [ ] `cargo run -p app` launches without crash (needs GPU)
- [ ] Visual check: sparse path produces correct physics (particles fall, water flows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)