### PR TITLE
fix(shaders): remove sleep skip from sparse physics + voxelize

### DIFF
--- a/crates/shaders/src/compute/g2p_sparse.rs
+++ b/crates/shaders/src/compute/g2p_sparse.rs
@@ -276,11 +276,10 @@ pub fn g2p_sparse(
         return;
     }
 
-    // Copy position to locals (trap #21) and check graduated sleep
-    let pos_mass = particles[idx].pos_mass;
-    if g2p::should_skip_brick(pos_mass.x, pos_mass.y, pos_mass.z, sleep_state, push.frame_number) {
-        return;
-    }
+    // NOTE: In sparse mode, the hash grid itself is the sparsity optimization.
+    // Sleep-based brick skipping is NOT used here — see p2g_sparse.rs for details.
+    // The sleep_state binding is kept to avoid descriptor set layout changes.
+    let _sleep_state = sleep_state;
 
     gather_particle_sparse(
         &mut particles[idx],

--- a/crates/shaders/src/compute/p2g_sparse.rs
+++ b/crates/shaders/src/compute/p2g_sparse.rs
@@ -206,11 +206,13 @@ pub fn p2g_sparse(
         return;
     }
 
-    // Copy position to locals (trap #21) and check graduated sleep
-    let pos_mass = particles[idx].pos_mass;
-    if p2g::should_skip_brick(pos_mass.x, pos_mass.y, pos_mass.z, sleep_state, push.frame_number) {
-        return;
-    }
+    // NOTE: In sparse mode, the hash grid itself is the sparsity optimization.
+    // Sleep-based brick skipping is NOT used here because record_core_physics_sparse()
+    // skips mark_active/compute_activity passes, so sleep_state is never updated.
+    // Using should_skip_brick() here causes a deadlock: all bricks sleep -> P2G skips
+    // all particles -> grid empty -> G2P reads nothing -> particles freeze.
+    // The sleep_state binding is kept to avoid descriptor set layout changes.
+    let _sleep_state = sleep_state;
 
     scatter_particle_sparse(
         &particles[idx],

--- a/crates/shaders/src/compute/voxelize.rs
+++ b/crates/shaders/src/compute/voxelize.rs
@@ -27,7 +27,6 @@ use crate::types::Particle;
 use spirv_std::glam::{UVec3, UVec4};
 use spirv_std::spirv;
 
-use super::p2g::should_skip_brick;
 
 /// Number of u32 values per voxel cell.
 const U32S_PER_VOXEL: u32 = 4;
@@ -230,10 +229,10 @@ pub fn clear_voxels(
     if id.x >= grid_size || id.y >= grid_size || id.z >= grid_size {
         return;
     }
-    // Skip clearing voxels in frozen bricks — their data is still valid
-    if is_frozen_brick(id.x, id.y, id.z, sleep_state) {
-        return;
-    }
+    // NOTE: Do NOT skip clearing based on sleep state. When a brick wakes up,
+    // stale voxel data from the previous frame causes visible rectangular artifacts
+    // at brick boundaries. The clear pass is cheap — always clear all cells.
+    let _sleep_state = sleep_state;
     let cell_idx = (id.z * grid_size * grid_size + id.y * grid_size + id.x) as usize;
     let base = cell_idx * U32S_PER_VOXEL as usize;
     clear_voxel_cell(voxels, base);
@@ -261,10 +260,8 @@ pub fn voxelize(
     if id.x >= push.num_particles {
         return;
     }
-    // Copy position to locals (trap #21) and check sleep state before writing
-    let pos_mass = particles[idx].pos_mass;
-    if should_skip_brick(pos_mass.x, pos_mass.y, pos_mass.z, sleep_state, push.frame_number) {
-        return;
-    }
+    // NOTE: Do NOT skip voxelization based on sleep state. Skipping causes
+    // stale voxel data and visible brick boundary artifacts. Voxelize is cheap.
+    let _sleep_state = sleep_state;
     write_voxel(&particles[idx], voxels, push.grid_size);
 }


### PR DESCRIPTION
## Summary

- **Bug 1 (physics frozen):** Removed `should_skip_brick()` calls from `p2g_sparse` and `g2p_sparse` entry points. In sparse mode, `record_core_physics_sparse()` skips `mark_active`/`compute_activity` passes, so `sleep_state` is never updated — all bricks appear sleeping, causing a deadlock where P2G/G2P skip all particles and physics freezes completely.
- **Bug 2 (brick boundary artifacts):** Removed sleep-based skip from `clear_voxels` and `voxelize` entry points. When a brick sleeps, its voxels go stale; when it wakes, there's a 1-frame lag with stale data visible as rectangular 8x8x8 patches on surfaces.
- Buffer bindings for `sleep_state` are preserved (assigned to `_sleep_state`) to avoid descriptor set layout changes.

## Test plan

- [x] `cargo build` passes
- [x] `cargo run -p app -- --headless --frames 10 --big` completes without crash (1.1M particles)
- [ ] Visual verification: water flows, explosions produce flying debris (not just holes)
- [ ] No rectangular artifacts visible at brick boundaries on mountain surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)