### PR TITLE
feat(server,shaders): chunk streaming GPU support

### DIFF
--- a/crates/server/src/readback.rs
+++ b/crates/server/src/readback.rs
@@ -83,4 +83,25 @@ impl GpuSimulation {
     pub fn any_active_buffer(&self) -> &GpuBuffer {
         &self.any_active_buffer
     }
+
+    /// Read the out-of-bounds flag from the GPU.
+    ///
+    /// Returns `true` if any particle was clamped back into the domain during
+    /// the last `step_physics()`. The CPU can use this to trigger chunk
+    /// streaming when particles approach the simulation boundary.
+    ///
+    /// This is a synchronous readback operation; call after `step_physics()`
+    /// completes and the GPU is idle.
+    pub fn readback_oob_flag(&self, ctx: &VulkanContext) -> Result<bool> {
+        let data = buffer::readback::<u32>(ctx, &self.oob_flag_buffer, 1)?;
+        Ok(data[0] != 0)
+    }
+
+    /// Returns a reference to the out-of-bounds flag buffer.
+    ///
+    /// Contains a single `u32`: 0 = all particles within margin, non-zero = at
+    /// least one particle hit the domain boundary during G2P.
+    pub fn oob_flag_buffer(&self) -> &GpuBuffer {
+        &self.oob_flag_buffer
+    }
 }

--- a/crates/server/src/simulation.rs
+++ b/crates/server/src/simulation.rs
@@ -54,6 +54,9 @@ pub struct GpuSimulation {
     // Any-active flag (1 u32, set by update_sleep if any brick is active)
     pub(crate) any_active_buffer: GpuBuffer,
 
+    // Out-of-bounds flag (1 u32, set by G2P if any particle escapes domain)
+    pub(crate) oob_flag_buffer: GpuBuffer,
+
     // Counting sort buffers (particle-by-brick sorting)
     brick_count_buffer: GpuBuffer,
     brick_offset_buffer: GpuBuffer,
@@ -341,6 +344,16 @@ impl GpuSimulation {
             "any-active-buffer",
         )?;
 
+        // -- OOB flag buffer (1 u32, set by G2P if any particle escapes domain) --
+        let oob_flag_buffer = buffer::create_device_local_buffer(
+            ctx,
+            16 as vk::DeviceSize, // min 16 for alignment
+            vk::BufferUsageFlags::STORAGE_BUFFER
+                | vk::BufferUsageFlags::TRANSFER_DST
+                | vk::BufferUsageFlags::TRANSFER_SRC,
+            "oob-flag-buffer",
+        )?;
+
         // -- Sparse dispatch buffers --
         // When hash grid is active, mark_buffer and active_cells are unused (dense path only).
         // Allocate small placeholders to save memory.
@@ -446,7 +459,7 @@ impl GpuSimulation {
         // All passes combined: dirty tiles + hash grid + counting sort + super bricks
         let pool_sizes = [vk::DescriptorPoolSize {
             ty: vk::DescriptorType::STORAGE_BUFFER,
-            descriptor_count: 180,
+            descriptor_count: 184,
         }];
         let descriptor_pool =
             pipeline::create_descriptor_pool(ctx, &pool_sizes, 30, "sim-descriptor-pool")?;
@@ -487,7 +500,7 @@ impl GpuSimulation {
             ctx,
             shader_module,
             c"compute::g2p::g2p",
-            &[&particle_buffer, &grid_buffer, &voxel_buffer, &reaction_buffer, &sleep_state_buffer],
+            &[&particle_buffer, &grid_buffer, &voxel_buffer, &reaction_buffer, &sleep_state_buffer, &oob_flag_buffer],
             mem::size_of::<G2pPushConstants>() as u32,
             descriptor_pool,
             "g2p",
@@ -672,7 +685,7 @@ impl GpuSimulation {
         let g2p_hash_pass = passes::create_pass(
             ctx, shader_module,
             c"compute::g2p_sparse::g2p_sparse",
-            &[&particle_buffer, &hash_grid_keys_buffer, &hash_grid_values_buffer, &voxel_buffer, &reaction_buffer, &sleep_state_buffer],
+            &[&particle_buffer, &hash_grid_keys_buffer, &hash_grid_values_buffer, &voxel_buffer, &reaction_buffer, &sleep_state_buffer, &oob_flag_buffer],
             mem::size_of::<G2pSparsePushConstants>() as u32,
             descriptor_pool, "g2p-hash",
         )?;
@@ -729,6 +742,7 @@ impl GpuSimulation {
             brick_occupancy_buffer,
             super_brick_occupancy_buffer,
             any_active_buffer,
+            oob_flag_buffer,
             brick_count_buffer,
             brick_offset_buffer,
             write_offset_buffer,
@@ -794,6 +808,21 @@ impl GpuSimulation {
         self.num_particles = particles.len() as u32;
         buffer::upload(ctx, particles, &self.particle_buffer)?;
         tracing::info!("Uploaded {} particles to GPU", self.num_particles);
+        Ok(())
+    }
+
+    /// Upload a new set of particles, replacing the current set.
+    ///
+    /// Unlike [`init_particles`](Self::init_particles), this preserves sleep state
+    /// for bricks that haven't changed occupancy. Sleep state will naturally
+    /// adapt via the activity tracking system.
+    pub fn reload_particles(&mut self, ctx: &VulkanContext, particles: &[Particle]) -> Result<()> {
+        if particles.len() > MAX_PARTICLES as usize {
+            return Err(ServerError::TooManyParticles(particles.len()));
+        }
+        self.num_particles = particles.len() as u32;
+        buffer::upload(ctx, particles, &self.particle_buffer)?;
+        tracing::info!("Reloaded {} particles to GPU", self.num_particles);
         Ok(())
     }
 
@@ -879,6 +908,28 @@ impl GpuSimulation {
     ///
     /// These MUST run every substep for correct simulation.
     fn record_core_physics(&self, cmd: vk::CommandBuffer) {
+        // Clear OOB flag before physics (G2P will set it if any particle escapes)
+        unsafe {
+            self.device
+                .cmd_fill_buffer(cmd, self.oob_flag_buffer.buffer, 0, 4, 0);
+        }
+        {
+            let memory_barrier = vk::MemoryBarrier::default()
+                .src_access_mask(vk::AccessFlags::TRANSFER_WRITE)
+                .dst_access_mask(vk::AccessFlags::SHADER_READ | vk::AccessFlags::SHADER_WRITE);
+            unsafe {
+                self.device.cmd_pipeline_barrier(
+                    cmd,
+                    vk::PipelineStageFlags::TRANSFER,
+                    vk::PipelineStageFlags::COMPUTE_SHADER,
+                    vk::DependencyFlags::empty(),
+                    &[memory_barrier],
+                    &[],
+                    &[],
+                );
+            }
+        }
+
         if self.use_sparse_grid {
             self.record_core_physics_sparse(cmd);
         } else {
@@ -1976,6 +2027,10 @@ impl GpuSimulation {
             &mut self.any_active_buffer,
             GpuBuffer { buffer: vk::Buffer::null(), allocation: None, size: 0 },
         );
+        let oob_flag_buf = std::mem::replace(
+            &mut self.oob_flag_buffer,
+            GpuBuffer { buffer: vk::Buffer::null(), allocation: None, size: 0 },
+        );
         let prev_render_output_buf = std::mem::replace(
             &mut self.prev_render_output_buffer,
             GpuBuffer {
@@ -2072,6 +2127,7 @@ impl GpuSimulation {
         buffer::destroy_buffer(ctx, brick_occupancy_buf);
         buffer::destroy_buffer(ctx, super_brick_occupancy_buf);
         buffer::destroy_buffer(ctx, any_active_buf);
+        buffer::destroy_buffer(ctx, oob_flag_buf);
         buffer::destroy_buffer(ctx, prev_render_output_buf);
         buffer::destroy_buffer(ctx, dirty_tile_buf);
         buffer::destroy_buffer(ctx, brick_count_buf);

--- a/crates/shaders/src/compute/g2p.rs
+++ b/crates/shaders/src/compute/g2p.rs
@@ -487,6 +487,21 @@ pub fn should_skip_brick(pos_x: f32, pos_y: f32, pos_z: f32, sleep_state: &[u32]
     check_skip(tick_period, frame_number)
 }
 
+/// Check if a position is near the domain boundary and flag it.
+///
+/// Sets `oob_flag[0]` to 1 via atomic max if the particle position is within
+/// `margin` of the grid edge. This allows the CPU to detect when particles
+/// are being clamped and trigger chunk streaming.
+fn check_and_flag_oob(pos: Vec3, grid_size: u32, oob_flag: &mut [u32]) {
+    let margin = 2.0_f32;
+    let upper = grid_size as f32 - margin;
+    if pos.x < margin || pos.x > upper || pos.y < margin || pos.y > upper || pos.z < margin || pos.z > upper {
+        unsafe {
+            spirv_std::arch::atomic_u_max::<u32, 1u32, 0x0u32>(&mut oob_flag[0], 1);
+        }
+    }
+}
+
 /// Compute shader entry point: Grid-to-Particle transfer.
 ///
 /// Descriptor set 0, binding 0: storage buffer of `Particle` (read-write).
@@ -494,6 +509,7 @@ pub fn should_skip_brick(pos_x: f32, pos_y: f32, pos_z: f32, sleep_state: &[u32]
 /// Descriptor set 0, binding 2: storage buffer of `u32` (voxel grid, 4 per cell, read).
 /// Descriptor set 0, binding 3: storage buffer of `PhaseTransitionRule` (read).
 /// Descriptor set 0, binding 4: storage buffer of `u32` (sleep_state per brick, read).
+/// Descriptor set 0, binding 5: storage buffer of `u32` (oob_flag, write).
 /// Push constants: `G2pPushConstants`.
 /// Dispatch with `(ceil(num_particles / 64), 1, 1)` workgroups.
 #[spirv(compute(threads(64)))]
@@ -505,6 +521,7 @@ pub fn g2p(
     #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] voxels: &[u32],
     #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] reactions: &[PhaseTransitionRule],
     #[spirv(storage_buffer, descriptor_set = 0, binding = 4)] sleep_state: &[u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 5)] oob_flag: &mut [u32],
 ) {
     let idx = id.x as usize;
     if id.x >= push.num_particles {
@@ -526,4 +543,8 @@ pub fn g2p(
         push.dt,
         push.num_rules,
     );
+
+    // Check OOB after position update
+    let new_pos = particles[idx].pos_mass.truncate();
+    check_and_flag_oob(new_pos, push.grid_size, oob_flag);
 }

--- a/crates/shaders/src/compute/g2p_sparse.rs
+++ b/crates/shaders/src/compute/g2p_sparse.rs
@@ -251,6 +251,21 @@ fn apply_radiative_cooling_sparse(temp: f32) -> f32 {
     temp + cooling_rate * (ambient_temp - temp)
 }
 
+/// Check if a position is near the domain boundary and flag it.
+///
+/// Sets `oob_flag[0]` to 1 via atomic max if the particle position is within
+/// `margin` of the grid edge. This allows the CPU to detect when particles
+/// are being clamped and trigger chunk streaming.
+fn check_and_flag_oob_sparse(pos: Vec3, grid_size: u32, oob_flag: &mut [u32]) {
+    let margin = 2.0_f32;
+    let upper = grid_size as f32 - margin;
+    if pos.x < margin || pos.x > upper || pos.y < margin || pos.y > upper || pos.z < margin || pos.z > upper {
+        unsafe {
+            spirv_std::arch::atomic_u_max::<u32, 1u32, 0x0u32>(&mut oob_flag[0], 1);
+        }
+    }
+}
+
 /// Compute shader entry point: sparse Grid-to-Particle transfer.
 ///
 /// Descriptor set 0, binding 0: storage buffer of `Particle` (read-write).
@@ -259,6 +274,7 @@ fn apply_radiative_cooling_sparse(temp: f32) -> f32 {
 /// Descriptor set 0, binding 3: storage buffer of `u32` (voxels, read).
 /// Descriptor set 0, binding 4: storage buffer of `PhaseTransitionRule` (read).
 /// Descriptor set 0, binding 5: storage buffer of `u32` (sleep_state, read).
+/// Descriptor set 0, binding 6: storage buffer of `u32` (oob_flag, write).
 /// Push constants: `G2pSparsePushConstants`.
 #[spirv(compute(threads(64)))]
 pub fn g2p_sparse(
@@ -270,6 +286,7 @@ pub fn g2p_sparse(
     #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] voxels: &[u32],
     #[spirv(storage_buffer, descriptor_set = 0, binding = 4)] reactions: &[PhaseTransitionRule],
     #[spirv(storage_buffer, descriptor_set = 0, binding = 5)] sleep_state: &[u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 6)] oob_flag: &mut [u32],
 ) {
     let idx = id.x as usize;
     if id.x >= push.num_particles {
@@ -292,4 +309,8 @@ pub fn g2p_sparse(
         push.hash_capacity,
         push.num_rules,
     );
+
+    // Check OOB after position update
+    let new_pos = particles[idx].pos_mass.truncate();
+    check_and_flag_oob_sparse(new_pos, push.grid_size, oob_flag);
 }


### PR DESCRIPTION
## Summary
- Add `GpuSimulation::reload_particles()` method that re-uploads particles without resetting brick sleep state, enabling incremental chunk streaming
- Add `oob_flag_buffer` (single u32) written by both dense and sparse G2P shaders via `atomic_u_max` when any particle hits the domain boundary margin
- Add `readback_oob_flag()` for CPU-side detection of boundary escapes to trigger chunk loading
- Clear OOB flag each frame in `record_core_physics` before dispatch
- Properly destroy the new buffer in `GpuSimulation::destroy()`

## Test plan
- [ ] Verify `cargo build` passes (confirmed)
- [ ] Run `cargo test -p server -- --test-threads=1` to check GPU tests still pass
- [ ] Manual test: spawn particles near grid edge, verify OOB flag reads true
- [ ] Verify reload_particles preserves sleep state (bricks that haven't changed stay asleep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)