### PR TITLE
feat: add far-field voxel rendering

### DIFF
--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -20,9 +20,10 @@ pub mod simulation;
 
 pub use push_constants::{
     ComputeActivityPushConstants, DirtyTilesPushConstants, ExplosionPushConstants,
-    G2pPushConstants, GridUpdatePushConstants, GridUpdateSparsePushConstants,
-    MarkActivePushConstants, P2gPushConstants, ReactPushConstants, RenderPushConstants,
-    ToolbarPushConstants, VoxelizePushConstants, TOOLBAR_MAX_MATERIALS,
+    FarFieldPushConstants, G2pPushConstants, GridUpdatePushConstants,
+    GridUpdateSparsePushConstants, MarkActivePushConstants, P2gPushConstants,
+    ReactPushConstants, RenderPushConstants, ToolbarPushConstants, VoxelizePushConstants,
+    TOOLBAR_MAX_MATERIALS,
 };
 pub use simulation::GpuSimulation;
 
@@ -90,6 +91,8 @@ mod tests {
         assert_eq!(mem::size_of::<ToolbarPushConstants>(), 144);
         // DirtyTilesPushConstants: 4 u32s (16 bytes) + 2 Vec4s (32 bytes) = 48 bytes
         assert_eq!(mem::size_of::<DirtyTilesPushConstants>(), 48);
+        // FarFieldPushConstants: 4 u32s (16 bytes) + 3 Vec4s (48 bytes) = 64 bytes
+        assert_eq!(mem::size_of::<FarFieldPushConstants>(), 64);
     }
 
     #[test]

--- a/crates/server/src/push_constants.rs
+++ b/crates/server/src/push_constants.rs
@@ -331,6 +331,26 @@ pub struct DirtyTilesPushConstants {
     pub target: glam::Vec4,
 }
 
+/// Push constants for the far-field render shader.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Pod, bytemuck::Zeroable)]
+pub struct FarFieldPushConstants {
+    /// Render target width in pixels.
+    pub width: u32,
+    /// Render target height in pixels.
+    pub height: u32,
+    /// Number of valid entries in the chunk table.
+    pub chunk_count: u32,
+    /// Grid dimension of the sim domain (cells per axis).
+    pub grid_size: u32,
+    /// Camera eye position (xyz) + padding (w).
+    pub eye: glam::Vec4,
+    /// Camera target position (xyz) + padding (w).
+    pub target: glam::Vec4,
+    /// World-space origin of the sim domain (xyz) + padding (w).
+    pub sim_origin: glam::Vec4,
+}
+
 /// Maximum number of material slots in the toolbar.
 pub const TOOLBAR_MAX_MATERIALS: usize = 8;
 

--- a/crates/server/src/simulation.rs
+++ b/crates/server/src/simulation.rs
@@ -3,6 +3,8 @@
 use std::mem;
 use std::time::Instant;
 
+use bytemuck::Zeroable;
+
 use ash::vk;
 use gpu_core::{
     VulkanContext,
@@ -10,9 +12,9 @@ use gpu_core::{
     pipeline,
 };
 use shared::{
-    DIRTY_TILE_COUNT, GRID_CELL_COUNT, GRID_SIZE, GridCell, HASH_GRID_DEFAULT_CAPACITY,
-    MAX_ACTIVE_CELLS, MAX_PARTICLES,
-    Particle, RENDER_HEIGHT, RENDER_WIDTH, SLEEP_THRESHOLD, TOTAL_BRICKS,
+    ChunkTableEntry, DIRTY_TILE_COUNT, FAR_FIELD_VOXEL_BUFFER_SIZE, GRID_CELL_COUNT,
+    GRID_SIZE, GridCell, HASH_GRID_DEFAULT_CAPACITY, MAX_ACTIVE_CELLS, MAX_FAR_CHUNKS,
+    MAX_PARTICLES, Particle, RENDER_HEIGHT, RENDER_WIDTH, SLEEP_THRESHOLD, TOTAL_BRICKS,
     TOTAL_SUPER_BRICKS,
     material::{self, MATERIAL_COUNT, MaterialParams},
     reaction::{self, MAX_PHASE_RULES, PhaseTransitionRule},
@@ -50,6 +52,10 @@ pub struct GpuSimulation {
     // Brick occupancy (render optimization)
     brick_occupancy_buffer: GpuBuffer,
     super_brick_occupancy_buffer: GpuBuffer,
+
+    // Far-field rendering buffers
+    far_field_voxel_buffer: GpuBuffer,
+    far_field_chunk_table: GpuBuffer,
 
     // Any-active flag (1 u32, set by update_sleep if any brick is active)
     pub(crate) any_active_buffer: GpuBuffer,
@@ -89,6 +95,9 @@ pub struct GpuSimulation {
 
     // Brick occupancy pass (render optimization)
     compute_occupancy_pass: ComputePass,
+
+    // Far-field render pass
+    render_far_field_pass: ComputePass,
 
     // Dirty-tile pass
     compute_dirty_tiles_pass: ComputePass,
@@ -130,6 +139,10 @@ pub struct GpuSimulation {
     // State
     pub(crate) num_particles: u32,
     num_phase_rules: u32,
+    /// Number of far-field chunks currently uploaded to the GPU.
+    far_field_chunk_count: u32,
+    /// World-space origin of the simulation domain (grid [0,0,0] in world coords).
+    sim_origin: [f32; 3],
     /// Monotonically increasing frame counter for graduated sleep scheduling.
     frame_number: core::cell::Cell<u32>,
     /// Previous frame camera eye (for dirty-tile camera-moved detection).
@@ -331,6 +344,33 @@ impl GpuSimulation {
             "super-brick-occupancy-buffer",
         )?;
 
+        // -- Far-field rendering buffers --
+        // Voxel buffer: u8 per voxel packed as u32s → total bytes / 4
+        let far_field_voxel_buf_size =
+            (FAR_FIELD_VOXEL_BUFFER_SIZE as usize) as vk::DeviceSize;
+        let far_field_voxel_buffer = buffer::create_device_local_buffer(
+            ctx,
+            far_field_voxel_buf_size,
+            vk::BufferUsageFlags::STORAGE_BUFFER | vk::BufferUsageFlags::TRANSFER_DST,
+            "far-field-voxel-buffer",
+        )?;
+        tracing::info!(
+            "Far-field voxel buffer: {:.1}MB ({} chunks * {}³ voxels)",
+            far_field_voxel_buf_size as f64 / (1024.0 * 1024.0),
+            MAX_FAR_CHUNKS,
+            64,
+        );
+
+        // Chunk table: ChunkTableEntry (32 bytes) * MAX_FAR_CHUNKS
+        let far_field_table_size =
+            (MAX_FAR_CHUNKS as usize * mem::size_of::<ChunkTableEntry>()) as vk::DeviceSize;
+        let far_field_chunk_table = buffer::create_device_local_buffer(
+            ctx,
+            far_field_table_size,
+            vk::BufferUsageFlags::STORAGE_BUFFER | vk::BufferUsageFlags::TRANSFER_DST,
+            "far-field-chunk-table",
+        )?;
+
         // -- Any-active flag buffer (1 u32, set by update_sleep via atomicMax) --
         let any_active_buffer = buffer::create_device_local_buffer(
             ctx,
@@ -443,13 +483,13 @@ impl GpuSimulation {
         )?;
 
         // -- Descriptor pool --
-        // All passes combined: dirty tiles + hash grid + counting sort + super bricks
+        // All passes combined: dirty tiles + hash grid + counting sort + super bricks + far-field
         let pool_sizes = [vk::DescriptorPoolSize {
             ty: vk::DescriptorType::STORAGE_BUFFER,
-            descriptor_count: 180,
+            descriptor_count: 184,
         }];
         let descriptor_pool =
-            pipeline::create_descriptor_pool(ctx, &pool_sizes, 30, "sim-descriptor-pool")?;
+            pipeline::create_descriptor_pool(ctx, &pool_sizes, 31, "sim-descriptor-pool")?;
 
         // -- Create each compute pass --
         // Entry point names are fully qualified module paths in rust-gpu SPIR-V.
@@ -583,6 +623,23 @@ impl GpuSimulation {
             mem::size_of::<ComputeOccupancyPushConstants>() as u32,
             descriptor_pool,
             "compute-occupancy",
+        )?;
+
+        // -- Far-field render pass --
+        // render_far_field: render_output(rw), far_field_voxels(r), far_field_table(r), materials(r)
+        let render_far_field_pass = passes::create_pass(
+            ctx,
+            shader_module,
+            c"compute::render_far_field::render_far_field",
+            &[
+                &render_output_buffer,
+                &far_field_voxel_buffer,
+                &far_field_chunk_table,
+                &material_buffer,
+            ],
+            mem::size_of::<FarFieldPushConstants>() as u32,
+            descriptor_pool,
+            "render-far-field",
         )?;
 
         // -- Dirty-tile pass --
@@ -728,6 +785,8 @@ impl GpuSimulation {
             sleep_state_buffer,
             brick_occupancy_buffer,
             super_brick_occupancy_buffer,
+            far_field_voxel_buffer,
+            far_field_chunk_table,
             any_active_buffer,
             brick_count_buffer,
             brick_offset_buffer,
@@ -753,6 +812,7 @@ impl GpuSimulation {
             explosion_pass,
             compute_activity_pass,
             compute_occupancy_pass,
+            render_far_field_pass,
             compute_dirty_tiles_pass,
             update_sleep_pass,
             count_per_brick_pass,
@@ -774,6 +834,8 @@ impl GpuSimulation {
             descriptor_pool,
             num_particles: 0,
             num_phase_rules: num_phase_rules as u32,
+            far_field_chunk_count: 0,
+            sim_origin: [0.0; 3],
             frame_number: core::cell::Cell::new(0),
             prev_eye: core::cell::Cell::new([f32::NAN; 3]),
             prev_target: core::cell::Cell::new([f32::NAN; 3]),
@@ -1728,6 +1790,121 @@ impl GpuSimulation {
         dx > eps || dy > eps || dz > eps
     }
 
+    /// Set the world-space origin of the simulation domain.
+    ///
+    /// This defines where grid voxel [0,0,0] sits in world coordinates.
+    /// Used by the far-field render pass to convert between grid-local and world space.
+    pub fn set_sim_origin(&mut self, origin: [f32; 3]) {
+        self.sim_origin = origin;
+    }
+
+    /// Upload far-field voxel data for a set of chunks.
+    ///
+    /// Each chunk provides its world-space origin and a 64^3 u8 material palette.
+    /// The `data` slice for each chunk must be exactly `FAR_FIELD_VOXELS_PER_CHUNK` bytes.
+    /// Chunks are appended sequentially starting from offset 0.
+    ///
+    /// All voxel data is concatenated into a single upload to avoid per-chunk
+    /// staging buffer overhead.
+    ///
+    /// Returns the number of chunks actually uploaded (may be less than provided
+    /// if `MAX_FAR_CHUNKS` is exceeded).
+    pub fn update_far_field(
+        &mut self,
+        ctx: &VulkanContext,
+        chunks: &[(ChunkTableEntry, &[u8])],
+    ) -> Result<u32> {
+        let max = MAX_FAR_CHUNKS as usize;
+        let count = chunks.len().min(max);
+
+        // Build table entries with sequential offsets
+        let mut table = vec![ChunkTableEntry::zeroed(); max];
+        let voxels_per_chunk = shared::FAR_FIELD_VOXELS_PER_CHUNK as usize;
+
+        // Concatenate all voxel data into a single buffer for one upload
+        let mut all_voxels = vec![0u8; count * voxels_per_chunk];
+
+        for (i, (entry, data)) in chunks.iter().take(count).enumerate() {
+            table[i] = ChunkTableEntry {
+                origin: entry.origin,
+                voxel_offset: (i * voxels_per_chunk) as u32,
+                _pad: [0; 3],
+            };
+            // Ensure w=1 for valid entries
+            table[i].origin[3] = 1.0;
+
+            // Copy voxel data into concatenated buffer
+            let dst_start = i * voxels_per_chunk;
+            let copy_len = data.len().min(voxels_per_chunk);
+            all_voxels[dst_start..dst_start + copy_len].copy_from_slice(&data[..copy_len]);
+        }
+
+        // Upload chunk table
+        buffer::upload(ctx, &table, &self.far_field_chunk_table)?;
+
+        // Upload all voxel data in a single transfer
+        if count > 0 {
+            buffer::upload(ctx, &all_voxels, &self.far_field_voxel_buffer)?;
+        }
+
+        self.far_field_chunk_count = count as u32;
+        tracing::info!(
+            "Uploaded {} far-field chunks ({:.1}MB voxel data)",
+            count,
+            (count * voxels_per_chunk) as f64 / (1024.0 * 1024.0),
+        );
+
+        Ok(count as u32)
+    }
+
+    /// Record a far-field render dispatch into the given command buffer.
+    ///
+    /// Runs after the main render pass. For each pixel showing sky, casts rays
+    /// into far-field chunks and writes hit colors.
+    /// The command buffer must be in recording state.
+    pub fn render_far_field(
+        &self,
+        cmd: vk::CommandBuffer,
+        width: u32,
+        height: u32,
+        eye: [f32; 3],
+        target: [f32; 3],
+    ) {
+        if self.far_field_chunk_count == 0 {
+            return;
+        }
+
+        passes::barrier(cmd, &self.device);
+
+        let push = FarFieldPushConstants {
+            width,
+            height,
+            chunk_count: self.far_field_chunk_count,
+            grid_size: GRID_SIZE,
+            eye: glam::Vec4::new(eye[0], eye[1], eye[2], 0.0),
+            target: glam::Vec4::new(target[0], target[1], target[2], 0.0),
+            sim_origin: glam::Vec4::new(
+                self.sim_origin[0],
+                self.sim_origin[1],
+                self.sim_origin[2],
+                0.0,
+            ),
+        };
+
+        let wg_x = (width + 7) / 8;
+        let wg_y = (height + 7) / 8;
+
+        passes::dispatch(
+            &self.device,
+            cmd,
+            &self.render_far_field_pass,
+            wg_x,
+            wg_y,
+            1,
+            bytemuck::bytes_of(&push),
+        );
+    }
+
     /// Record a toolbar overlay dispatch into the given command buffer.
     ///
     /// Draws a material selection toolbar on top of the render output buffer.
@@ -1859,6 +2036,7 @@ impl GpuSimulation {
             &self.explosion_pass,
             &self.compute_activity_pass,
             &self.compute_occupancy_pass,
+            &self.render_far_field_pass,
             &self.compute_dirty_tiles_pass,
             &self.update_sleep_pass,
             &self.count_per_brick_pass,
@@ -1972,6 +2150,14 @@ impl GpuSimulation {
             &mut self.super_brick_occupancy_buffer,
             GpuBuffer { buffer: vk::Buffer::null(), allocation: None, size: 0 },
         );
+        let far_field_voxel_buf = std::mem::replace(
+            &mut self.far_field_voxel_buffer,
+            GpuBuffer { buffer: vk::Buffer::null(), allocation: None, size: 0 },
+        );
+        let far_field_table_buf = std::mem::replace(
+            &mut self.far_field_chunk_table,
+            GpuBuffer { buffer: vk::Buffer::null(), allocation: None, size: 0 },
+        );
         let any_active_buf = std::mem::replace(
             &mut self.any_active_buffer,
             GpuBuffer { buffer: vk::Buffer::null(), allocation: None, size: 0 },
@@ -2071,6 +2257,8 @@ impl GpuSimulation {
         buffer::destroy_buffer(ctx, sleep_state_buf);
         buffer::destroy_buffer(ctx, brick_occupancy_buf);
         buffer::destroy_buffer(ctx, super_brick_occupancy_buf);
+        buffer::destroy_buffer(ctx, far_field_voxel_buf);
+        buffer::destroy_buffer(ctx, far_field_table_buf);
         buffer::destroy_buffer(ctx, any_active_buf);
         buffer::destroy_buffer(ctx, prev_render_output_buf);
         buffer::destroy_buffer(ctx, dirty_tile_buf);

--- a/crates/shaders/src/compute/mod.rs
+++ b/crates/shaders/src/compute/mod.rs
@@ -31,6 +31,7 @@ pub mod prefix_sum;
 pub mod prepare_indirect;
 pub mod react;
 pub mod render;
+pub mod render_far_field;
 pub mod scatter_particles;
 pub mod toolbar_overlay;
 pub mod update_sleep;

--- a/crates/shaders/src/compute/render_far_field.rs
+++ b/crates/shaders/src/compute/render_far_field.rs
@@ -1,0 +1,377 @@
+//! Far-field render compute shader: fills in sky pixels with far-field chunk data.
+//!
+//! Runs as a second pass AFTER the near-field render. For each pixel that was
+//! left as sky (alpha channel marker), casts a ray into far-field chunks and
+//! writes the hit color. This avoids touching the performance-critical DDA loop
+//! in the main render shader.
+
+use crate::compute::render::math::{compute_ray, pack_bgra};
+use crate::compute::render::sky::compute_sky_color;
+use crate::types::{ChunkTableEntry, FAR_CHUNK_SIZE, MaterialParams};
+use spirv_std::glam::{UVec3, Vec3, Vec4};
+#[cfg(target_arch = "spirv")]
+use spirv_std::num_traits::Float;
+use spirv_std::spirv;
+
+/// Push constants for the far-field render shader.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct FarFieldPushConstants {
+    /// Render target width in pixels.
+    pub width: u32,
+    /// Render target height in pixels.
+    pub height: u32,
+    /// Number of valid entries in the chunk table.
+    pub chunk_count: u32,
+    /// Grid dimension of the sim domain (cells per axis).
+    pub grid_size: u32,
+    /// Camera eye position (xyz) + padding (w).
+    pub eye: Vec4,
+    /// Camera target position (xyz) + padding (w).
+    pub target: Vec4,
+    /// World-space origin of the sim domain (xyz) + padding (w).
+    /// Grid voxel [0,0,0] maps to this world position.
+    pub sim_origin: Vec4,
+}
+
+/// Compute simple shading for a far-field voxel hit.
+///
+/// Uses the material color from the table with a basic directional light + ambient.
+/// Separated into a helper to satisfy trap #4a (entry points must call helpers).
+fn shade_far_field_hit(material_id: u32, normal: Vec3, materials: &[MaterialParams]) -> Vec3 {
+    let base_color = if (material_id as usize) < materials.len() {
+        let c = materials[material_id as usize].color;
+        Vec3::new(c.x, c.y, c.z)
+    } else {
+        Vec3::new(0.5, 0.5, 0.5)
+    };
+
+    // Simple directional light (sun from upper-right)
+    let sun_dir = Vec3::new(0.4, 0.7, 0.3);
+    let sun_len_sq = sun_dir.x * sun_dir.x + sun_dir.y * sun_dir.y + sun_dir.z * sun_dir.z;
+    let inv_sun_len = 1.0 / sun_len_sq.sqrt();
+    let sun_norm = Vec3::new(sun_dir.x * inv_sun_len, sun_dir.y * inv_sun_len, sun_dir.z * inv_sun_len);
+
+    let ndotl = normal.x * sun_norm.x + normal.y * sun_norm.y + normal.z * sun_norm.z;
+    let ndotl = if ndotl > 0.0 { ndotl } else { 0.0 };
+
+    let ambient = 0.35;
+    let diffuse = 0.65 * ndotl;
+    let factor = ambient + diffuse;
+
+    Vec3::new(
+        (base_color.x * factor).min(1.0),
+        (base_color.y * factor).min(1.0),
+        (base_color.z * factor).min(1.0),
+    )
+}
+
+/// Read a u8 material ID from the packed u32 voxel buffer.
+///
+/// The far-field voxel buffer stores u8 values packed 4 per u32.
+/// Returns the material ID at the given voxel offset.
+fn read_voxel_u8(far_voxels: &[u32], voxel_offset: u32) -> u32 {
+    let word_idx = (voxel_offset / 4) as usize;
+    let byte_idx = voxel_offset % 4;
+    let word = far_voxels[word_idx];
+    (word >> (byte_idx * 8)) & 0xFF
+}
+
+/// DDA ray march through a single far-field chunk.
+///
+/// Returns (hit, material_id, normal) where hit is true if a non-empty voxel was found.
+/// The normal is the face normal of the last DDA step axis.
+fn march_chunk(
+    ray_origin: Vec3,
+    ray_dir: Vec3,
+    chunk_origin: Vec3,
+    voxel_base_offset: u32,
+    far_voxels: &[u32],
+) -> (bool, u32, Vec3) {
+    let chunk_size = FAR_CHUNK_SIZE as f32;
+
+    // Ray-AABB intersection with the chunk
+    let inv_dir_x = if ray_dir.x.abs() > 1e-8 { 1.0 / ray_dir.x } else { 1e20 };
+    let inv_dir_y = if ray_dir.y.abs() > 1e-8 { 1.0 / ray_dir.y } else { 1e20 };
+    let inv_dir_z = if ray_dir.z.abs() > 1e-8 { 1.0 / ray_dir.z } else { 1e20 };
+
+    let t1x = (chunk_origin.x - ray_origin.x) * inv_dir_x;
+    let t2x = (chunk_origin.x + chunk_size - ray_origin.x) * inv_dir_x;
+    let t1y = (chunk_origin.y - ray_origin.y) * inv_dir_y;
+    let t2y = (chunk_origin.y + chunk_size - ray_origin.y) * inv_dir_y;
+    let t1z = (chunk_origin.z - ray_origin.z) * inv_dir_z;
+    let t2z = (chunk_origin.z + chunk_size - ray_origin.z) * inv_dir_z;
+
+    let tmin_x = if t1x < t2x { t1x } else { t2x };
+    let tmax_x = if t1x > t2x { t1x } else { t2x };
+    let tmin_y = if t1y < t2y { t1y } else { t2y };
+    let tmax_y = if t1y > t2y { t1y } else { t2y };
+    let tmin_z = if t1z < t2z { t1z } else { t2z };
+    let tmax_z = if t1z > t2z { t1z } else { t2z };
+
+    let mut t_enter = tmin_x;
+    if tmin_y > t_enter { t_enter = tmin_y; }
+    if tmin_z > t_enter { t_enter = tmin_z; }
+
+    let mut t_exit = tmax_x;
+    if tmax_y < t_exit { t_exit = tmax_y; }
+    if tmax_z < t_exit { t_exit = tmax_z; }
+
+    if t_enter > t_exit || t_exit < 0.0 {
+        return (false, 0, Vec3::new(0.0, 1.0, 0.0));
+    }
+    if t_enter < 0.0 { t_enter = 0.0; }
+
+    // Entry point into chunk local coords
+    let entry = Vec3::new(
+        ray_origin.x + ray_dir.x * (t_enter + 0.001) - chunk_origin.x,
+        ray_origin.y + ray_dir.y * (t_enter + 0.001) - chunk_origin.y,
+        ray_origin.z + ray_dir.z * (t_enter + 0.001) - chunk_origin.z,
+    );
+
+    let cs = FAR_CHUNK_SIZE as i32;
+    let mut vx = entry.x as i32;
+    let mut vy = entry.y as i32;
+    let mut vz = entry.z as i32;
+
+    // Clamp
+    if vx < 0 { vx = 0; }
+    if vy < 0 { vy = 0; }
+    if vz < 0 { vz = 0; }
+    if vx >= cs { vx = cs - 1; }
+    if vy >= cs { vy = cs - 1; }
+    if vz >= cs { vz = cs - 1; }
+
+    let step_x: i32 = if ray_dir.x >= 0.0 { 1 } else { -1 };
+    let step_y: i32 = if ray_dir.y >= 0.0 { 1 } else { -1 };
+    let step_z: i32 = if ray_dir.z >= 0.0 { 1 } else { -1 };
+
+    let t_delta_x = if ray_dir.x.abs() > 1e-8 { (1.0 / ray_dir.x).abs() } else { 1e20 };
+    let t_delta_y = if ray_dir.y.abs() > 1e-8 { (1.0 / ray_dir.y).abs() } else { 1e20 };
+    let t_delta_z = if ray_dir.z.abs() > 1e-8 { (1.0 / ray_dir.z).abs() } else { 1e20 };
+
+    let next_x = if step_x > 0 { (vx + 1) as f32 } else { vx as f32 };
+    let next_y = if step_y > 0 { (vy + 1) as f32 } else { vy as f32 };
+    let next_z = if step_z > 0 { (vz + 1) as f32 } else { vz as f32 };
+
+    let mut t_max_x = if ray_dir.x.abs() > 1e-8 { (next_x - entry.x) / ray_dir.x } else { 1e20 };
+    let mut t_max_y = if ray_dir.y.abs() > 1e-8 { (next_y - entry.y) / ray_dir.y } else { 1e20 };
+    let mut t_max_z = if ray_dir.z.abs() > 1e-8 { (next_z - entry.z) / ray_dir.z } else { 1e20 };
+
+    // Max steps = 3 * 64 = 192
+    let max_steps = FAR_CHUNK_SIZE * 3;
+    let mut last_axis: u32 = 0;
+    let mut i: u32 = 0;
+
+    while i < max_steps {
+        if vx < 0 || vx >= cs || vy < 0 || vy >= cs || vz < 0 || vz >= cs {
+            break;
+        }
+
+        let local_offset = (vz as u32) * FAR_CHUNK_SIZE * FAR_CHUNK_SIZE
+            + (vy as u32) * FAR_CHUNK_SIZE
+            + (vx as u32);
+        let mat_id = read_voxel_u8(far_voxels, voxel_base_offset + local_offset);
+
+        if mat_id != 0 {
+            let normal = compute_hit_normal(last_axis, step_x, step_y, step_z);
+            return (true, mat_id, normal);
+        }
+
+        // DDA step
+        if t_max_x < t_max_y {
+            if t_max_x < t_max_z {
+                vx += step_x;
+                t_max_x += t_delta_x;
+                last_axis = 0;
+            } else {
+                vz += step_z;
+                t_max_z += t_delta_z;
+                last_axis = 2;
+            }
+        } else if t_max_y < t_max_z {
+            vy += step_y;
+            t_max_y += t_delta_y;
+            last_axis = 1;
+        } else {
+            vz += step_z;
+            t_max_z += t_delta_z;
+            last_axis = 2;
+        }
+
+        i += 1;
+    }
+
+    (false, 0, Vec3::new(0.0, 1.0, 0.0))
+}
+
+/// Compute hit normal from DDA last axis and step direction.
+///
+/// Separated to keep branch count low per function (trap #15).
+fn compute_hit_normal(last_axis: u32, step_x: i32, step_y: i32, step_z: i32) -> Vec3 {
+    if last_axis == 0 {
+        Vec3::new(-(step_x as f32), 0.0, 0.0)
+    } else if last_axis == 1 {
+        Vec3::new(0.0, -(step_y as f32), 0.0)
+    } else {
+        Vec3::new(0.0, 0.0, -(step_z as f32))
+    }
+}
+
+/// Per-pixel far-field rendering logic.
+///
+/// Checks if the pixel is sky, then casts a ray through far-field chunks.
+/// Helper for the entry point (trap #4a).
+fn render_far_field_pixel(
+    px: u32,
+    py: u32,
+    push: &FarFieldPushConstants,
+    render_output: &mut [u32],
+    far_field_voxels: &[u32],
+    far_field_table: &[ChunkTableEntry],
+    materials: &[MaterialParams],
+) {
+    let width = push.width;
+    let height = push.height;
+
+    if px >= width || py >= height {
+        return;
+    }
+
+    let pixel_idx = (py * width + px) as usize;
+    let existing = render_output[pixel_idx];
+
+    // Check if pixel is sky: alpha byte (bits 24-31) marks fully opaque (0xFF)
+    // for near-field hits. If the pixel was written by near-field render, skip it.
+    // Near-field render writes alpha=0xFF (255). Sky pixels also get 0xFF from pack_bgra.
+    // We use a special marker: if the existing color matches the sky color exactly,
+    // it's a sky pixel. But that's fragile. Instead, we use a simpler approach:
+    // the near-field render writes the sky color (dark navy 0x2812120C with pack_bgra).
+    // We'll check if the pixel's RGB matches the sky gradient range.
+    //
+    // Simpler approach: always try far-field for ALL pixels. If we get a hit closer
+    // than the sim domain, we won't know. But since far-field is behind the sim domain,
+    // we only run this for pixels that got sky color from the main render.
+    //
+    // The most robust approach: check if the pixel's low bits match the sky pack pattern.
+    // Near-field sky: pack_bgra(18, 18, 40, 255) = 0xFF284012 (approx).
+    // Let's just check if the pixel matches sky color exactly OR if alpha==0.
+    //
+    // Actually, the simplest: compare to the sky gradient. The near-field render writes
+    // specific sky colors via compute_sky_color + pack_bgra. These are deterministic
+    // per-pixel from the ray direction. If the existing pixel equals what sky would produce,
+    // it's sky. But that requires re-computing sky. Too expensive.
+    //
+    // Best approach: use a flag. The simplest flag is alpha < 255 for sky.
+    // But current render always writes alpha=255. We'd need to change the near-field
+    // render to write alpha=0 for sky pixels. That's a small change.
+    //
+    // For now, use the simplest possible heuristic: re-compute what the sky color
+    // would be for this pixel and compare. If it matches, this is a sky pixel.
+    // This works because sky colors are deterministic per ray direction.
+
+    // Check if chunk_count is 0 - nothing to render
+    if push.chunk_count == 0 {
+        return;
+    }
+
+    let eye = Vec3::new(push.eye.x, push.eye.y, push.eye.z);
+    let target = Vec3::new(push.target.x, push.target.y, push.target.z);
+    let ray_dir = compute_ray(px, py, width, height, eye, target);
+
+    // Re-compute expected sky color for this pixel
+    let sky = compute_sky_color(ray_dir);
+    let sky_r = ((sky.x * 255.0) as u32).min(255);
+    let sky_g = ((sky.y * 255.0) as u32).min(255);
+    let sky_b = ((sky.z * 255.0) as u32).min(255);
+    let expected_sky = pack_bgra(sky_r, sky_g, sky_b, 255);
+
+    // If existing pixel doesn't match sky, it was hit by near-field - skip
+    if existing != expected_sky {
+        return;
+    }
+
+    // This pixel is sky. Try to find a far-field chunk hit.
+    // World-space ray: eye is in sim-domain coords, convert to world coords.
+    let sim_origin = Vec3::new(push.sim_origin.x, push.sim_origin.y, push.sim_origin.z);
+    let world_eye = Vec3::new(
+        eye.x + sim_origin.x,
+        eye.y + sim_origin.y,
+        eye.z + sim_origin.z,
+    );
+
+    // Find nearest chunk hit
+    let mut best_t = 1e20_f32;
+    let mut best_color = sky;
+    let mut found_hit = false;
+
+    let count = push.chunk_count;
+    // Linear scan over chunk table (fine for <128 chunks, avoids >3 branches)
+    let mut ci: u32 = 0;
+    while ci < count {
+        let entry_origin = far_field_table[ci as usize].origin;
+        let entry_offset = far_field_table[ci as usize].offset_pad.x;
+
+        // Skip invalid entries
+        if entry_origin.w < 0.5 {
+            ci += 1;
+            continue;
+        }
+
+        let chunk_origin = Vec3::new(entry_origin.x, entry_origin.y, entry_origin.z);
+
+        let (hit, mat_id, normal) = march_chunk(
+            world_eye, ray_dir, chunk_origin, entry_offset, far_field_voxels,
+        );
+
+        if hit {
+            // Compute approximate t for sorting (distance from eye to chunk origin)
+            let dx = chunk_origin.x + 32.0 - world_eye.x;
+            let dy = chunk_origin.y + 32.0 - world_eye.y;
+            let dz = chunk_origin.z + 32.0 - world_eye.z;
+            let dist_sq = dx * dx + dy * dy + dz * dz;
+            if dist_sq < best_t {
+                best_t = dist_sq;
+                best_color = shade_far_field_hit(mat_id, normal, materials);
+                found_hit = true;
+            }
+        }
+
+        ci += 1;
+    }
+
+    if found_hit {
+        let r = ((best_color.x * 255.0) as u32).min(255);
+        let g = ((best_color.y * 255.0) as u32).min(255);
+        let b = ((best_color.z * 255.0) as u32).min(255);
+        render_output[pixel_idx] = pack_bgra(r, g, b, 255);
+    }
+}
+
+/// Compute shader entry point: render far-field chunks behind the near-field.
+///
+/// Dispatched with `(ceil(width/8), ceil(height/8), 1)` workgroups.
+/// Runs after the main render pass. For each pixel that shows sky, casts a ray
+/// into far-field chunks and writes the hit color.
+///
+/// Descriptor set 0:
+/// - binding 0: render_output (u32, read/write)
+/// - binding 1: far_field_voxels (u32, packed u8s, read)
+/// - binding 2: far_field_table (ChunkTableEntry, read)
+/// - binding 3: materials (MaterialParams, read)
+///
+/// Push constants: `FarFieldPushConstants`.
+#[spirv(compute(threads(8, 8, 1)))]
+pub fn render_far_field(
+    #[spirv(global_invocation_id)] id: UVec3,
+    #[spirv(push_constant)] push: &FarFieldPushConstants,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] render_output: &mut [u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] far_field_voxels: &[u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] far_field_table: &[ChunkTableEntry],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] materials: &[MaterialParams],
+) {
+    render_far_field_pixel(
+        id.x, id.y, push,
+        render_output, far_field_voxels, far_field_table, materials,
+    );
+}

--- a/crates/shaders/src/types.rs
+++ b/crates/shaders/src/types.rs
@@ -12,6 +12,34 @@
 
 use spirv_std::glam::{UVec4, Vec4};
 
+// ---------------------------------------------------------------------------
+// Far-field rendering constants (synced with shared::far_field)
+// ---------------------------------------------------------------------------
+
+/// Maximum number of far-field chunks in the atlas.
+pub const MAX_FAR_CHUNKS: u32 = 128;
+
+/// Voxels per far-field chunk axis (64).
+pub const FAR_CHUNK_SIZE: u32 = 64;
+
+/// Total voxels per chunk (64^3 = 262144).
+pub const FAR_FIELD_VOXELS_PER_CHUNK: u32 = FAR_CHUNK_SIZE * FAR_CHUNK_SIZE * FAR_CHUNK_SIZE;
+
+/// Entry in the far-field chunk table mapping a chunk to its voxel data.
+///
+/// 32 bytes, 16-byte aligned. Mirrors `shared::far_field::ChunkTableEntry`.
+/// CPU side: origin=[f32;4], voxel_offset=u32, _pad=[u32;3].
+/// GPU side: origin=Vec4, offset_pad=UVec4 where x=voxel_offset.
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct ChunkTableEntry {
+    /// World-space origin of this chunk (chunk_coord * FAR_CHUNK_SIZE).
+    /// `w` = 1.0 if this entry is valid, 0.0 otherwise.
+    pub origin: Vec4,
+    /// x = voxel_offset (in voxels, not bytes), yzw = padding.
+    pub offset_pad: UVec4,
+}
+
 /// A single MPM particle. 144 bytes, 16-byte aligned.
 ///
 /// Fields pack multiple values into Vec4 components:

--- a/crates/shared/src/far_field.rs
+++ b/crates/shared/src/far_field.rs
@@ -1,0 +1,65 @@
+//! Far-field voxel rendering types.
+//!
+//! Types for rendering chunks beyond the active simulation zone using
+//! pre-baked voxel data. Each chunk is a 64x64x64 block of u8 material palette
+//! indices stored in a compact buffer on the GPU.
+
+use bytemuck::{Pod, Zeroable};
+
+/// Maximum number of far-field chunks in the atlas.
+pub const MAX_FAR_CHUNKS: u32 = 128;
+
+/// Voxels per chunk axis (64).
+pub const FAR_CHUNK_SIZE: u32 = 64;
+
+/// Total voxels per chunk (64^3 = 262144).
+pub const FAR_FIELD_VOXELS_PER_CHUNK: u32 = FAR_CHUNK_SIZE * FAR_CHUNK_SIZE * FAR_CHUNK_SIZE;
+
+/// Total bytes of voxel data in the far-field atlas.
+///
+/// Each voxel is a single u8 material palette index.
+/// 128 chunks * 262144 voxels/chunk = 33554432 bytes (32 MB).
+pub const FAR_FIELD_VOXEL_BUFFER_SIZE: u32 = MAX_FAR_CHUNKS * FAR_FIELD_VOXELS_PER_CHUNK;
+
+/// Entry in the far-field chunk table mapping a chunk to its voxel data.
+///
+/// 32 bytes, 16-byte aligned. Stored in a GPU storage buffer.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Pod, Zeroable)]
+pub struct ChunkTableEntry {
+    /// World-space origin of this chunk (chunk_coord * FAR_CHUNK_SIZE).
+    /// `w` = 1.0 if this entry is valid, 0.0 otherwise.
+    pub origin: [f32; 4],
+    /// Offset into the far_field_voxel_buffer in voxels (not bytes).
+    pub voxel_offset: u32,
+    /// Padding to 32 bytes (16-byte aligned).
+    pub _pad: [u32; 3],
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem;
+
+    #[test]
+    fn chunk_table_entry_size_and_alignment() {
+        assert_eq!(mem::size_of::<ChunkTableEntry>(), 32);
+        assert_eq!(mem::align_of::<ChunkTableEntry>(), 4);
+    }
+
+    #[test]
+    fn far_field_constants() {
+        assert_eq!(FAR_FIELD_VOXELS_PER_CHUNK, 262144);
+        assert_eq!(MAX_FAR_CHUNKS, 128);
+        // 128 * 262144 = 33554432 bytes = 32 MB
+        assert_eq!(FAR_FIELD_VOXEL_BUFFER_SIZE, 33_554_432);
+    }
+
+    #[test]
+    fn chunk_table_entry_is_pod() {
+        // Verify bytemuck traits work
+        let entry = ChunkTableEntry::zeroed();
+        let bytes: &[u8] = bytemuck::bytes_of(&entry);
+        assert_eq!(bytes.len(), 32);
+    }
+}

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod config;
 pub mod constants;
+pub mod far_field;
 pub mod indirect;
 pub mod material;
 pub mod particle;
@@ -20,6 +21,7 @@ pub mod svd;
 
 pub use config::*;
 pub use constants::*;
+pub use far_field::*;
 pub use indirect::IndirectDispatchArgs;
 pub use material::*;
 pub use particle::*;


### PR DESCRIPTION
## Summary

- Add `ChunkTableEntry` type and far-field constants to `shared` crate (MAX_FAR_CHUNKS=128, 64^3 chunks, 32MB voxel atlas)
- Add `render_far_field` compute shader as a second pass that fills sky pixels with far-field chunk data via DDA ray marching
- Add GPU buffer allocation (voxel atlas + chunk table), `update_far_field()` upload API, and `render_far_field()` dispatch method to `GpuSimulation`
- Mirror `ChunkTableEntry` in shader types for GPU-side access

The far-field pass runs AFTER the near-field render and only processes pixels that show sky (detected by comparing to the deterministic sky gradient), keeping the performance-critical DDA loop untouched.

## Test plan

- [x] `cargo build` — full workspace compiles
- [x] `cargo test -p shared` — new `ChunkTableEntry` size/alignment tests pass
- [x] `cargo test -p shared -p sim-cpu -p protocol -p content` — all CPU tests pass
- [x] Shader SPIR-V compilation succeeds (verified via `cargo build -p server` with forced shader rebuild)
- [ ] GPU integration: call `update_far_field()` with test chunk data, verify pixels render
- [ ] Visual: place a stone chunk adjacent to sim domain, confirm it appears in render

🤖 Generated with [Claude Code](https://claude.com/claude-code)