### PR TITLE
feat(app): wire WorldManager into game loop for chunk streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "winit",
+ "world",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ gpu-core = { path = "crates/gpu-core" }
 server = { path = "crates/server" }
 client = { path = "crates/client" }
 content = { path = "crates/content" }
+world = { path = "crates/world" }
 
 [profile.dev.build-override]
 opt-level = 3

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -16,3 +16,4 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 anyhow = { workspace = true }
 image = { workspace = true }
+world = { workspace = true }

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -27,6 +27,8 @@ use crate::scene::{
     generate_heightmap, generate_mountain_heightmap, material_palette, spawn_cell,
 };
 
+use world::{ChunkCoord, WorldManager};
+
 /// Distance (in grid units) from the camera eye at which particles are
 /// spawned, removed, or explosions are centered.
 const SPAWN_DISTANCE: f32 = 15.0;
@@ -69,35 +71,100 @@ pub(crate) struct App {
     fps_timer: Instant,
     /// Most recently computed FPS value.
     current_fps: f32,
+    /// World manager for chunk streaming (used when `--world` flag is set or as default).
+    world: Option<WorldManager>,
+    /// Current chunk coordinate the camera is in.
+    current_chunk: ChunkCoord,
 }
 
 impl App {
     /// Create a new `App` with the given number of physics substeps per frame.
     ///
     /// If `scene_path` is `Some`, loads a RON scene definition from that file.
+    /// If `use_world` is `true`, the world manager generates terrain procedurally.
     /// Otherwise falls back to the default procedural island scene.
     /// If `model_path` is provided, the `.vox` model is loaded and its
     /// particles are added to the scene at `model_pos` (default 32,20,32).
-    pub(crate) fn new(substeps: u32, scene_path: Option<&str>, big: bool, model_path: Option<&str>, model_pos: Option<(f32, f32, f32)>) -> Self {
-        let (mut particles, scene_camera, use_mountain) = if let Some(path) = scene_path {
+    pub(crate) fn new(
+        substeps: u32,
+        scene_path: Option<&str>,
+        big: bool,
+        model_path: Option<&str>,
+        model_pos: Option<(f32, f32, f32)>,
+        use_world: bool,
+    ) -> Self {
+        // Try loading materials from RON file, fall back to hardcoded defaults
+        let material_db = match content::load_material_database("assets/materials.ron") {
+            Ok(db) => {
+                tracing::info!("Loaded material database from assets/materials.ron");
+                Some(db)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to load assets/materials.ron, using hardcoded defaults: {}",
+                    e
+                );
+                None
+            }
+        };
+
+        // Determine scene source: WorldManager, RON scene, or built-in procedural.
+        let (particles, scene_camera, use_mountain, world_mgr, start_chunk) = if use_world {
+            tracing::info!("Using WorldManager for chunk-streamed terrain");
+            let seed = 12345u64;
+            let cache_dir = std::path::PathBuf::from("world_cache");
+            std::fs::create_dir_all(&cache_dir).ok();
+            match WorldManager::new(seed, cache_dir) {
+                Ok(mut world_mgr) => {
+                    // Start at world origin chunk
+                    let start_chunk = ChunkCoord::new(0, 0, 0);
+                    if let Err(e) = world_mgr.update_center(start_chunk) {
+                        tracing::error!("Failed to initialize world center: {}", e);
+                    }
+                    let mut particles = world_mgr.pack_particles_for_gpu();
+                    // Offset particles so all positions are within [0, GRID_SIZE).
+                    // pack_particles_for_gpu places center chunk at origin, so chunks
+                    // at negative offsets produce negative coordinates. Shift by
+                    // sim_radius * CHUNK_SIZE in X and Z to make everything positive.
+                    let offset_xz =
+                        world_mgr.sim_radius() as f32 * shared::constants::CHUNK_SIZE as f32;
+                    for p in &mut particles {
+                        let pos = p.position();
+                        p.set_position(Vec3::new(pos.x + offset_xz, pos.y, pos.z + offset_xz));
+                    }
+                    tracing::info!(
+                        "World: {} chunks loaded, {} particles",
+                        world_mgr.active_chunk_count(),
+                        particles.len(),
+                    );
+                    (particles, None, false, Some(world_mgr), start_chunk)
+                }
+                Err(e) => {
+                    tracing::error!("Failed to create WorldManager: {}, falling back to island", e);
+                    (create_island_particles(), None, false, None, ChunkCoord::new(0, 0, 0))
+                }
+            }
+        } else if let Some(path) = scene_path {
             match content::load_scene(path) {
                 Ok(scene) => {
                     tracing::info!("Loaded scene '{}' from {}", scene.name, path);
                     let cam = scene.camera.clone();
                     let p = scene.spawn_particles();
-                    (p, cam, false)
+                    (p, cam, false, None, ChunkCoord::new(0, 0, 0))
                 }
                 Err(e) => {
                     tracing::warn!("Failed to load scene '{}': {}, using default", path, e);
-                    (create_island_particles(), None, false)
+                    (create_island_particles(), None, false, None, ChunkCoord::new(0, 0, 0))
                 }
             }
         } else if big {
             tracing::info!("Using mountain range scene (--big)");
-            (create_mountain_particles(), None, true)
+            (create_mountain_particles(), None, true, None, ChunkCoord::new(0, 0, 0))
         } else {
-            (create_island_particles(), None, false)
+            (create_island_particles(), None, false, None, ChunkCoord::new(0, 0, 0))
         };
+
+        let mut particles = particles;
         if let Some(path) = model_path {
             let pos = model_pos.unwrap_or((32.0, 20.0, 32.0));
             let offset = Vec3::new(pos.0, pos.1, pos.2);
@@ -114,25 +181,17 @@ impl App {
         }
         tracing::info!("Created {} initial particles", particles.len());
 
-        // Try loading materials from RON file, fall back to hardcoded defaults
-        let material_db = match content::load_material_database("assets/materials.ron") {
-            Ok(db) => {
-                tracing::info!("Loaded material database from assets/materials.ron");
-                Some(db)
-            }
-            Err(e) => {
-                tracing::warn!(
-                    "Failed to load assets/materials.ron, using hardcoded defaults: {}",
-                    e
-                );
-                None
-            }
-        };
-
         let camera = if let Some(ref cam) = scene_camera {
             Camera::look_at(
                 Vec3::new(cam.eye.0, cam.eye.1, cam.eye.2),
                 Vec3::new(cam.target.0, cam.target.1, cam.target.2),
+            )
+        } else if world_mgr.is_some() {
+            // For world mode: start camera in the center of the active grid, looking forward
+            let gs = GRID_SIZE as f32;
+            Camera::look_at(
+                Vec3::new(gs * 0.5, gs * 0.7, gs * 0.5),
+                Vec3::new(gs * 0.5, gs * 0.3, gs * 0.5 + 1.0),
             )
         } else {
             let gs = GRID_SIZE as f32;
@@ -143,7 +202,7 @@ impl App {
         };
         let mut player = PlayerController::new(camera);
         // Only generate heightmap for procedural scenes (RON scenes don't have procedural terrain)
-        if scene_camera.is_none() {
+        if scene_camera.is_none() && world_mgr.is_none() {
             let heightmap = if use_mountain {
                 generate_mountain_heightmap()
             } else {
@@ -173,6 +232,8 @@ impl App {
             fps_frame_count: 0,
             fps_timer: Instant::now(),
             current_fps: 0.0,
+            world: world_mgr,
+            current_chunk: start_chunk,
         }
     }
 
@@ -487,6 +548,87 @@ impl ApplicationHandler for App {
                         match renderer.draw_frame_with_buffer(ctx, sim.render_output_buffer(), RENDER_WIDTH, RENDER_HEIGHT) {
                             Ok(_) => {}
                             Err(e) => tracing::error!("Frame error: {}", e),
+                        }
+                    }
+                }
+
+                // --- Chunk streaming: check if camera crossed a chunk boundary ---
+                if let Some(ref mut world) = self.world {
+                    let cam_eye = self.player.camera.eye();
+                    // Convert grid-space eye back to world-space for chunk lookup.
+                    // Grid-space has an offset of sim_radius * CHUNK_SIZE in X/Z.
+                    let offset_xz =
+                        world.sim_radius() as f32 * shared::constants::CHUNK_SIZE as f32;
+                    let world_x = cam_eye.x - offset_xz;
+                    let world_z = cam_eye.z - offset_xz;
+                    let cam_chunk = world::chunk::chunk_coord_for_position(world_x, world_z);
+
+                    if cam_chunk != self.current_chunk {
+                        tracing::info!(
+                            "Chunk boundary crossed: {:?} -> {:?}",
+                            self.current_chunk,
+                            cam_chunk,
+                        );
+
+                        // Read back current particles so we can save them to chunks
+                        if let (Some(sim), Some(ctx)) =
+                            (self.sim.as_ref(), self.ctx.as_ref())
+                        {
+                            match sim.readback_particles(ctx) {
+                                Ok(mut gpu_particles) => {
+                                    // Remove the grid offset before unpacking
+                                    for p in &mut gpu_particles {
+                                        let pos = p.position();
+                                        p.set_position(Vec3::new(
+                                            pos.x - offset_xz,
+                                            pos.y,
+                                            pos.z - offset_xz,
+                                        ));
+                                    }
+                                    world.unpack_particles_from_gpu(&gpu_particles);
+                                }
+                                Err(e) => {
+                                    tracing::error!("Failed to readback particles for chunk save: {}", e);
+                                }
+                            }
+                        }
+
+                        // Update center: evict old chunks, load new ones
+                        if let Err(e) = world.update_center(cam_chunk) {
+                            tracing::error!("Failed to update world center: {}", e);
+                        }
+                        self.current_chunk = cam_chunk;
+
+                        // Pack new particle set with grid offset and upload
+                        let mut new_particles = world.pack_particles_for_gpu();
+                        for p in &mut new_particles {
+                            let pos = p.position();
+                            p.set_position(Vec3::new(
+                                pos.x + offset_xz,
+                                pos.y,
+                                pos.z + offset_xz,
+                            ));
+                        }
+                        if let (Some(sim), Some(ctx)) =
+                            (self.sim.as_mut(), self.ctx.as_ref())
+                        {
+                            if let Err(e) = sim.reload_particles(ctx, &new_particles) {
+                                tracing::error!("Failed to reload particles: {}", e);
+                            } else {
+                                tracing::info!(
+                                    "Reloaded {} particles after chunk shift",
+                                    new_particles.len(),
+                                );
+                            }
+                        }
+                    }
+                }
+
+                // --- OOB particle detection ---
+                if self.world.is_some() {
+                    if let (Some(sim), Some(ctx)) = (self.sim.as_ref(), self.ctx.as_ref()) {
+                        if sim.readback_oob_flag(ctx).unwrap_or(false) {
+                            tracing::warn!("Particles out of bounds detected");
                         }
                     }
                 }

--- a/crates/app/src/headless.rs
+++ b/crates/app/src/headless.rs
@@ -5,9 +5,11 @@
 use std::time::Instant;
 
 use anyhow::Result;
+use glam::Vec3;
 use gpu_core::VulkanContext;
 use server::GpuSimulation;
 use shared::{GRID_SIZE, RENDER_HEIGHT, RENDER_WIDTH};
+use world::{ChunkCoord, WorldManager};
 
 use crate::scene::create_island_particles;
 use crate::Args;
@@ -31,7 +33,31 @@ pub(crate) fn run_headless(args: &Args) -> Result<()> {
             GpuSimulation::new(&ctx)?
         }
     };
-    let (mut particles, scene_camera) = if let Some(scene_path) = &args.scene {
+    let (mut particles, scene_camera) = if args.world {
+        tracing::info!("Headless: using WorldManager for chunk-streamed terrain");
+        let seed = 12345u64;
+        let cache_dir = std::path::PathBuf::from("world_cache");
+        std::fs::create_dir_all(&cache_dir)?;
+        let mut world_mgr = WorldManager::new(seed, cache_dir)
+            .map_err(|e| anyhow::anyhow!("WorldManager init failed: {}", e))?;
+        let start_chunk = ChunkCoord::new(0, 0, 0);
+        world_mgr
+            .update_center(start_chunk)
+            .map_err(|e| anyhow::anyhow!("World update_center failed: {}", e))?;
+        let mut packed = world_mgr.pack_particles_for_gpu();
+        let offset_xz =
+            world_mgr.sim_radius() as f32 * shared::constants::CHUNK_SIZE as f32;
+        for p in &mut packed {
+            let pos = p.position();
+            p.set_position(Vec3::new(pos.x + offset_xz, pos.y, pos.z + offset_xz));
+        }
+        tracing::info!(
+            "World: {} chunks, {} particles",
+            world_mgr.active_chunk_count(),
+            packed.len(),
+        );
+        (packed, None)
+    } else if let Some(scene_path) = &args.scene {
         let scene = content::load_scene(scene_path)?;
         tracing::info!("Loaded scene '{}' from {}", scene.name, scene_path);
         let cam = scene.camera.clone();

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -31,6 +31,8 @@ struct Args {
     model: Option<String>,
     /// World-space offset (x,y,z) at which to place the loaded model.
     model_pos: Option<(f32, f32, f32)>,
+    /// If true, use WorldManager for chunk-streamed procedural terrain.
+    world: bool,
 }
 
 fn parse_args() -> Args {
@@ -61,6 +63,7 @@ fn parse_args() -> Args {
         .position(|a| a == "--model")
         .and_then(|i| args.get(i + 1).cloned());
     let big = args.contains(&"--big".to_string());
+    let world = args.contains(&"--world".to_string());
     let model_pos = args
         .iter()
         .position(|a| a == "--model-pos")
@@ -77,7 +80,7 @@ fn parse_args() -> Args {
                 None
             }
         });
-    Args { headless, frames, output, substeps, scene, big, model, model_pos }
+    Args { headless, frames, output, substeps, scene, big, model, model_pos, world }
 }
 
 fn main() -> Result<()> {
@@ -91,7 +94,7 @@ fn main() -> Result<()> {
     if args.headless { return headless::run_headless(&args); }
 
     let event_loop = EventLoop::new()?;
-    let mut application = app::App::new(args.substeps, args.scene.as_deref(), args.big, args.model.as_deref(), args.model_pos);
+    let mut application = app::App::new(args.substeps, args.scene.as_deref(), args.big, args.model.as_deref(), args.model_pos, args.world);
     event_loop.run_app(&mut application)?;
     tracing::info!("VOX Engine shut down");
     Ok(())


### PR DESCRIPTION
## Summary

- Add `--world` CLI flag to enable chunk-streamed procedural terrain via `WorldManager`
- On init: create `WorldManager`, generate initial chunks around origin, pack particles with grid offset, upload to GPU
- Each frame: detect chunk boundary crossings from camera position, readback particles, unpack to old chunks, update center, pack new particles, reload to GPU via `reload_particles()`
- Check OOB flag after physics each frame (logged as warning for now)
- Both windowed (`App`) and headless modes support `--world`
- Old scenes (island, mountain, RON) remain as fallback when `--world` is not set
- Camera starts at grid center looking forward in world mode

## Coordinate handling

Particles from `pack_particles_for_gpu()` use center-at-origin coordinates, producing negative values for chunks at negative offsets. An XZ offset of `sim_radius * CHUNK_SIZE` is applied when uploading to GPU and removed when reading back, keeping all GPU-side positions in `[0, GRID_SIZE)`.

## Test plan

- [ ] `cargo build -p app` compiles cleanly
- [ ] `cargo run -p app` (no flags) still launches default island scene
- [ ] `cargo run -p app -- --world` launches with procedural terrain from WorldManager
- [ ] `cargo run -p app -- --world --headless --frames 5` runs headless with world terrain
- [ ] Walk across chunk boundary and verify streaming log messages appear
- [ ] `cargo run -p app -- --scene assets/scenes/lava_basin.ron` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)