### PR TITLE
fix: hash grid overflow + OOB readback throttle

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -63,6 +63,8 @@ pub(crate) struct App {
     /// Cached result from `readback_any_active()` — one frame late but safe
     /// to query outside command buffer recording.
     world_is_static: bool,
+    /// Last time OOB flag was checked (throttled to avoid GPU stalls).
+    last_oob_check: Instant,
     /// Number of consecutive frames with no render (for logging).
     frames_skipped: u64,
     /// Frame counter for FPS calculation, reset every second.
@@ -228,6 +230,7 @@ impl App {
             prev_eye: [0.0; 3],
             prev_target: [0.0; 3],
             world_is_static: false,
+            last_oob_check: Instant::now(),
             frames_skipped: 0,
             fps_frame_count: 0,
             fps_timer: Instant::now(),
@@ -624,8 +627,9 @@ impl ApplicationHandler for App {
                     }
                 }
 
-                // --- OOB particle detection ---
-                if self.world.is_some() {
+                // --- OOB particle detection (throttled to avoid GPU stalls) ---
+                if self.world.is_some() && now.duration_since(self.last_oob_check).as_millis() >= 500 {
+                    self.last_oob_check = now;
                     if let (Some(sim), Some(ctx)) = (self.sim.as_ref(), self.ctx.as_ref()) {
                         if sim.readback_oob_flag(ctx).unwrap_or(false) {
                             tracing::warn!("Particles out of bounds detected");

--- a/crates/shaders/src/types.rs
+++ b/crates/shaders/src/types.rs
@@ -92,7 +92,7 @@ pub struct GridCell {
 pub const GRID_SIZE: u32 = 256;
 
 /// Default hash grid capacity (synced with shared::constants).
-pub const HASH_GRID_DEFAULT_CAPACITY: u32 = 1 << 21;
+pub const HASH_GRID_DEFAULT_CAPACITY: u32 = 1 << 23;
 
 /// Empty sentinel for hash grid keys (synced with shared::constants).
 pub const HASH_GRID_EMPTY_KEY: u32 = 0xFFFF_FFFF;

--- a/crates/shared/src/constants.rs
+++ b/crates/shared/src/constants.rs
@@ -62,9 +62,12 @@ pub const DIRTY_TILES_Y: u32 = (RENDER_HEIGHT + DIRTY_TILE_SIZE - 1) / DIRTY_TIL
 pub const DIRTY_TILE_COUNT: u32 = DIRTY_TILES_X * DIRTY_TILES_Y;
 
 /// Default hash grid capacity (number of slots).
-/// Should be ~2x the expected max active cells for low collision rate.
+/// Each particle touches up to 27 grid cells during P2G; with 4M particles
+/// the number of unique cells can reach 2-3M. Capacity must be well above
+/// that to keep the open-addressing load factor below 50%.
+/// 8M slots: keys = 32MB, values = 384MB, total ~416MB.
 /// Must be a power of 2 for fast modulo via bitwise AND.
-pub const HASH_GRID_DEFAULT_CAPACITY: u32 = 1 << 21; // 2M slots = ~104MB
+pub const HASH_GRID_DEFAULT_CAPACITY: u32 = 1 << 23; // 8M slots
 
 /// Empty sentinel for hash grid keys.
 /// Represents an unoccupied slot in the hash grid.
@@ -128,7 +131,7 @@ mod tests {
     fn hash_grid_capacity_is_power_of_two() {
         assert!(HASH_GRID_DEFAULT_CAPACITY.is_power_of_two());
         assert!(HASH_GRID_DEFAULT_CAPACITY > 0);
-        assert_eq!(HASH_GRID_DEFAULT_CAPACITY, 1 << 21); // 2M slots
+        assert_eq!(HASH_GRID_DEFAULT_CAPACITY, 1 << 23); // 8M slots
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- **Hash grid capacity 2M -> 8M**: With up to 4M particles each touching ~27 grid cells, the 2M-slot hash grid overflows (load factor >100%). Linear probing fails after 128 probes, dropping P2G contributions and freezing particles. 8M slots keeps load factor under 50%. VRAM cost: ~416MB (keys 32MB + values 384MB), acceptable on RTX 4090.
- **OOB readback throttled to 500ms**: `readback_oob_flag()` was called every frame, causing a synchronous GPU->CPU stall that manifested as camera rotation lag. Now checked every 500ms.
- **Explosion shader checked for sleep skipping**: No sleep check found in the explosion shader, so Bug 3 from the issue is not applicable.

Constants synced between `shared::constants` and `shaders::types` per trap #12.

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test -p shared -p sim-cpu -p protocol -p content` all pass
- [ ] `cargo run -p app -- --world` should show no particle freezing with high particle counts
- [ ] Camera rotation should be smooth (no stall from OOB readback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)