### PR TITLE
[sim2] Add CA voxel types, chunk metadata, material/reaction structs

### DIFF
--- a/crates/shared/src/chunk_gpu.rs
+++ b/crates/shared/src/chunk_gpu.rs
@@ -1,0 +1,53 @@
+//! GPU-side chunk metadata for the CA substrate.
+//!
+//! Each loaded chunk has a [`ChunkGpuMeta`] entry in the metadata buffer,
+//! indexed by its slot ID in the chunk pool.
+
+use bytemuck::{Pod, Zeroable};
+use glam::IVec4;
+
+/// GPU-side chunk metadata. Stored in metadata buffer, indexed by slot_id.
+///
+/// Size: 48 bytes, padded to 64 bytes for 16-byte alignment.
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+#[repr(C)]
+pub struct ChunkGpuMeta {
+    /// xyz = chunk world coordinates, w = slot_id in chunk pool.
+    pub world_pos: IVec4,
+    /// Indices of neighbor chunks in pool: +X, -X, +Y, -Y, +Z, -Z.
+    /// -1 = not loaded.
+    pub neighbor_ids: [i32; 6],
+    /// Activity level: 0=Sleeping, 1=CAOnly, 2=Physics.
+    pub activity: u32,
+    /// Bit flags: bit 0 = dirty, bit 1 = has_physics_zone.
+    pub flags: u32,
+    /// Padding to reach 64 bytes for 16-byte alignment.
+    pub _pad: [u32; 4],
+}
+
+// Compile-time size check
+const _: () = assert!(core::mem::size_of::<ChunkGpuMeta>() == 64);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::{align_of, size_of};
+
+    #[test]
+    fn test_size_align() {
+        assert_eq!(size_of::<ChunkGpuMeta>(), 64);
+        // With VK_EXT_scalar_block_layout, 4-byte alignment is sufficient.
+        // Size is a multiple of 16 for GPU buffer array indexing.
+        assert!(size_of::<ChunkGpuMeta>() % 16 == 0);
+        assert!(align_of::<ChunkGpuMeta>() >= 4);
+    }
+
+    #[test]
+    fn test_bytemuck_zeroed() {
+        let meta: ChunkGpuMeta = ChunkGpuMeta::zeroed();
+        assert_eq!(meta.world_pos, IVec4::ZERO);
+        assert_eq!(meta.neighbor_ids, [0; 6]);
+        assert_eq!(meta.activity, 0);
+        assert_eq!(meta.flags, 0);
+    }
+}

--- a/crates/shared/src/constants.rs
+++ b/crates/shared/src/constants.rs
@@ -102,6 +102,38 @@ pub const ACTIVITY_VELOCITY_THRESHOLD_SQ: f32 = 0.01;
 /// At 60 Hz physics, 30 frames = 0.5 seconds of calm before sleeping.
 pub const SLEEP_THRESHOLD: u32 = 30;
 
+// === Simulation 2.0: CA Substrate ===
+
+/// Chunk size in voxels per axis for the CA substrate.
+pub const CA_CHUNK_SIZE: usize = 32;
+
+/// Total number of voxels per CA chunk (32^3).
+pub const CA_CHUNK_VOXELS: usize = CA_CHUNK_SIZE * CA_CHUNK_SIZE * CA_CHUNK_SIZE; // 32768
+
+/// Size of a CA chunk's voxel data in bytes (32768 * 4 = 128 KB).
+pub const CA_CHUNK_BYTES: usize = CA_CHUNK_VOXELS * 4; // 131072
+
+/// Number of u32s in the dirty bitmask for one CA chunk (32768 / 32 = 1024).
+pub const CA_CHUNK_DIRTY_BITMASK_U32S: usize = CA_CHUNK_VOXELS / 32; // 1024
+
+/// Size of a CA chunk's dirty bitmask in bytes (1024 * 4 = 4 KB).
+pub const CA_CHUNK_DIRTY_BITMASK_BYTES: usize = CA_CHUNK_DIRTY_BITMASK_U32S * 4; // 4096
+
+/// Total bytes per CA chunk slot (voxels + dirty bitmask = 132 KB).
+pub const CA_SLOT_BYTES: usize = CA_CHUNK_BYTES + CA_CHUNK_DIRTY_BITMASK_BYTES; // 135168
+
+/// Maximum number of loaded CA chunks.
+pub const CA_MAX_CHUNKS: usize = 2048;
+
+/// Maximum number of material types in the CA system.
+pub const CA_MAX_MATERIALS: usize = 1024;
+
+/// Maximum number of chemical reactions in the CA system.
+pub const CA_MAX_REACTIONS: usize = 256;
+
+/// Default ambient temperature for unloaded neighbor chunks (game units).
+pub const CA_AMBIENT_TEMP: u8 = 128;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -8,16 +8,20 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+pub mod chunk_gpu;
 pub mod config;
 pub mod constants;
 pub mod far_field;
 pub mod indirect;
 pub mod material;
+pub mod material_ca;
 pub mod particle;
 pub mod phase;
 pub mod physics;
 pub mod reaction;
+pub mod reaction_ca;
 pub mod svd;
+pub mod voxel;
 
 pub use config::*;
 pub use constants::*;

--- a/crates/shared/src/material_ca.rs
+++ b/crates/shared/src/material_ca.rs
@@ -1,0 +1,83 @@
+//! Material properties for the CA substrate.
+//!
+//! Each material type has a [`MaterialPropertiesCA`] entry in a GPU buffer,
+//! indexed by material_id (0-1023).
+
+use bytemuck::{Pod, Zeroable};
+
+/// Material properties for the CA substrate. 64 bytes, 16-byte aligned.
+///
+/// All temperatures are in game units (0-255). Phase transitions and
+/// combustion are driven by comparing voxel temperature against these
+/// thresholds.
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+#[repr(C)]
+pub struct MaterialPropertiesCA {
+    /// Phase: 0=solid, 1=powder, 2=liquid, 3=gas.
+    pub phase: u32,
+    /// Density (arbitrary units, higher = heavier).
+    pub density: u32,
+    /// Viscosity (0=free-flowing, higher=thicker).
+    pub viscosity: u32,
+    /// Thermal conductivity (0=insulator, higher=conducts faster).
+    pub conductivity: u32,
+    /// Temperature above which this material melts.
+    pub melt_temp: u32,
+    /// Temperature above which this material boils/evaporates.
+    pub boil_temp: u32,
+    /// Temperature below which this material freezes.
+    pub freeze_temp: u32,
+    /// Material ID to become when melting.
+    pub melt_into: u32,
+    /// Material ID to become when boiling.
+    pub boil_into: u32,
+    /// Material ID to become when freezing.
+    pub freeze_into: u32,
+    /// Flammability (0=fireproof, higher=catches fire easier).
+    pub flammability: u32,
+    /// Temperature at which this material ignites.
+    pub ignition_temp: u32,
+    /// Material ID to become when burned.
+    pub burn_into: u32,
+    /// Heat released when burning (added to temperature).
+    pub burn_heat: u32,
+    /// Structural strength (for bond/support calculations).
+    pub strength: u32,
+    /// Maximum load before structural failure.
+    pub max_load: u32,
+}
+
+// Compile-time size check
+const _: () = assert!(core::mem::size_of::<MaterialPropertiesCA>() == 64);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::size_of;
+
+    #[test]
+    fn test_size() {
+        assert_eq!(size_of::<MaterialPropertiesCA>(), 64);
+    }
+
+    #[test]
+    fn test_bytemuck_zeroed() {
+        let mat: MaterialPropertiesCA = MaterialPropertiesCA::zeroed();
+        assert_eq!(mat.phase, 0);
+        assert_eq!(mat.density, 0);
+        assert_eq!(mat.viscosity, 0);
+        assert_eq!(mat.conductivity, 0);
+        assert_eq!(mat.melt_temp, 0);
+        assert_eq!(mat.boil_temp, 0);
+        assert_eq!(mat.freeze_temp, 0);
+        assert_eq!(mat.melt_into, 0);
+        assert_eq!(mat.boil_into, 0);
+        assert_eq!(mat.freeze_into, 0);
+        assert_eq!(mat.flammability, 0);
+        assert_eq!(mat.ignition_temp, 0);
+        assert_eq!(mat.burn_into, 0);
+        assert_eq!(mat.burn_heat, 0);
+        assert_eq!(mat.strength, 0);
+        assert_eq!(mat.max_load, 0);
+    }
+}

--- a/crates/shared/src/reaction_ca.rs
+++ b/crates/shared/src/reaction_ca.rs
@@ -1,0 +1,59 @@
+//! Chemical reaction entries for the CA substrate.
+//!
+//! Each [`ReactionEntry`] describes a pairwise material reaction checked
+//! during the CA step when two adjacent voxels meet the conditions.
+
+use bytemuck::{Pod, Zeroable};
+
+/// Chemical reaction entry for CA substrate. 32 bytes.
+///
+/// When voxel A (material `input_a`) is adjacent to voxel B (material `input_b`)
+/// and the `condition` is met, both are replaced with `output_a` / `output_b`
+/// and `heat_delta` is applied. `probability` controls stochastic firing (0-255).
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+#[repr(C)]
+pub struct ReactionEntry {
+    /// Material ID of the first input.
+    pub input_a: u32,
+    /// Material ID of the second input.
+    pub input_b: u32,
+    /// Material ID that replaces `input_a`.
+    pub output_a: u32,
+    /// Material ID that replaces `input_b`.
+    pub output_b: u32,
+    /// Temperature change applied on reaction (can be negative).
+    pub heat_delta: i32,
+    /// Condition: 0=none, 1=needs_oxygen, 2=needs_high_temp.
+    pub condition: u32,
+    /// Probability of firing per tick (0-255).
+    pub probability: u32,
+    /// Impulse strength: 0=none, 1=weak, 2=medium, 3=explosion.
+    pub impulse: u32,
+}
+
+// Compile-time size check
+const _: () = assert!(core::mem::size_of::<ReactionEntry>() == 32);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::size_of;
+
+    #[test]
+    fn test_size() {
+        assert_eq!(size_of::<ReactionEntry>(), 32);
+    }
+
+    #[test]
+    fn test_bytemuck_zeroed() {
+        let r: ReactionEntry = ReactionEntry::zeroed();
+        assert_eq!(r.input_a, 0);
+        assert_eq!(r.input_b, 0);
+        assert_eq!(r.output_a, 0);
+        assert_eq!(r.output_b, 0);
+        assert_eq!(r.heat_delta, 0);
+        assert_eq!(r.condition, 0);
+        assert_eq!(r.probability, 0);
+        assert_eq!(r.impulse, 0);
+    }
+}

--- a/crates/shared/src/voxel.rs
+++ b/crates/shared/src/voxel.rs
@@ -1,0 +1,344 @@
+//! Packed u32 voxel type for the CA substrate.
+//!
+//! Each voxel is exactly 4 bytes, packed as:
+//! - `material_id`: bits 0-9 (10 bits, 0-1023)
+//! - `temperature`: bits 10-17 (8 bits, 0-255 game units)
+//! - `bonds`: bits 18-23 (6 bits, +X/-X/+Y/-Y/+Z/-Z neighbor bonds)
+//! - `oxygen`: bits 24-27 (4 bits, 0-15)
+//! - `flags`: bits 28-31 (4 bits: dirty, burning, wet, poisoned)
+
+use bytemuck::{Pod, Zeroable};
+
+/// Packed voxel representation for the Cellular Automata substrate.
+///
+/// Layout: `[material_id:10][temperature:8][bonds:6][oxygen:4][flags:4]` = 32 bits.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Pod, Zeroable)]
+#[repr(transparent)]
+pub struct Voxel(pub u32);
+
+// Bit layout constants
+const MATERIAL_ID_BITS: u32 = 10;
+const TEMPERATURE_BITS: u32 = 8;
+const BONDS_BITS: u32 = 6;
+const OXYGEN_BITS: u32 = 4;
+
+const MATERIAL_ID_SHIFT: u32 = 0;
+const TEMPERATURE_SHIFT: u32 = MATERIAL_ID_SHIFT + MATERIAL_ID_BITS; // 10
+const BONDS_SHIFT: u32 = TEMPERATURE_SHIFT + TEMPERATURE_BITS; // 18
+const OXYGEN_SHIFT: u32 = BONDS_SHIFT + BONDS_BITS; // 24
+const FLAGS_SHIFT: u32 = OXYGEN_SHIFT + OXYGEN_BITS; // 28
+
+const MATERIAL_ID_MASK: u32 = (1 << MATERIAL_ID_BITS) - 1; // 0x3FF
+const TEMPERATURE_MASK: u32 = (1 << TEMPERATURE_BITS) - 1; // 0xFF
+const BONDS_MASK: u32 = (1 << BONDS_BITS) - 1; // 0x3F
+const OXYGEN_MASK: u32 = (1 << OXYGEN_BITS) - 1; // 0xF
+const FLAGS_MASK: u32 = (1 << 4) - 1; // 0xF
+
+// Bond bit indices within the bonds field
+const BOND_POS_X: u32 = 0;
+const BOND_NEG_X: u32 = 1;
+const BOND_POS_Y: u32 = 2;
+const BOND_NEG_Y: u32 = 3;
+const BOND_POS_Z: u32 = 4;
+const BOND_NEG_Z: u32 = 5;
+
+// Flag bit indices within the flags field
+const FLAG_DIRTY: u32 = 0;
+const FLAG_BURNING: u32 = 1;
+const FLAG_WET: u32 = 2;
+const FLAG_POISONED: u32 = 3;
+
+impl Voxel {
+    /// Creates a new voxel with the given field values.
+    ///
+    /// Values are masked to their respective bit widths.
+    pub fn new(material_id: u16, temperature: u8, bonds: u8, oxygen: u8, flags: u8) -> Self {
+        let mut v = 0u32;
+        v |= (material_id as u32 & MATERIAL_ID_MASK) << MATERIAL_ID_SHIFT;
+        v |= (temperature as u32 & TEMPERATURE_MASK) << TEMPERATURE_SHIFT;
+        v |= (bonds as u32 & BONDS_MASK) << BONDS_SHIFT;
+        v |= (oxygen as u32 & OXYGEN_MASK) << OXYGEN_SHIFT;
+        v |= (flags as u32 & FLAGS_MASK) << FLAGS_SHIFT;
+        Self(v)
+    }
+
+    /// Creates an air voxel (all zeros).
+    pub fn air() -> Self {
+        Self(0)
+    }
+
+    /// Returns `true` if this voxel is air (material_id == 0).
+    pub fn is_air(&self) -> bool {
+        self.material_id() == 0
+    }
+
+    // --- Getters ---
+
+    /// Returns the material ID (0-1023).
+    pub fn material_id(&self) -> u16 {
+        ((self.0 >> MATERIAL_ID_SHIFT) & MATERIAL_ID_MASK) as u16
+    }
+
+    /// Returns the temperature (0-255 game units).
+    pub fn temperature(&self) -> u8 {
+        ((self.0 >> TEMPERATURE_SHIFT) & TEMPERATURE_MASK) as u8
+    }
+
+    /// Returns the bond flags (6 bits).
+    pub fn bonds(&self) -> u8 {
+        ((self.0 >> BONDS_SHIFT) & BONDS_MASK) as u8
+    }
+
+    /// Returns the oxygen level (0-15).
+    pub fn oxygen(&self) -> u8 {
+        ((self.0 >> OXYGEN_SHIFT) & OXYGEN_MASK) as u8
+    }
+
+    /// Returns the flag bits (4 bits).
+    pub fn flags(&self) -> u8 {
+        ((self.0 >> FLAGS_SHIFT) & FLAGS_MASK) as u8
+    }
+
+    // --- Setters ---
+
+    /// Sets the material ID (0-1023).
+    pub fn set_material_id(&mut self, v: u16) {
+        self.0 = (self.0 & !(MATERIAL_ID_MASK << MATERIAL_ID_SHIFT))
+            | ((v as u32 & MATERIAL_ID_MASK) << MATERIAL_ID_SHIFT);
+    }
+
+    /// Sets the temperature (0-255).
+    pub fn set_temperature(&mut self, v: u8) {
+        self.0 = (self.0 & !(TEMPERATURE_MASK << TEMPERATURE_SHIFT))
+            | ((v as u32 & TEMPERATURE_MASK) << TEMPERATURE_SHIFT);
+    }
+
+    /// Sets the bond flags (6 bits).
+    pub fn set_bonds(&mut self, v: u8) {
+        self.0 = (self.0 & !(BONDS_MASK << BONDS_SHIFT))
+            | ((v as u32 & BONDS_MASK) << BONDS_SHIFT);
+    }
+
+    /// Sets the oxygen level (0-15).
+    pub fn set_oxygen(&mut self, v: u8) {
+        self.0 = (self.0 & !(OXYGEN_MASK << OXYGEN_SHIFT))
+            | ((v as u32 & OXYGEN_MASK) << OXYGEN_SHIFT);
+    }
+
+    /// Sets the flag bits (4 bits).
+    pub fn set_flags(&mut self, v: u8) {
+        self.0 = (self.0 & !(FLAGS_MASK << FLAGS_SHIFT))
+            | ((v as u32 & FLAGS_MASK) << FLAGS_SHIFT);
+    }
+
+    // --- Bond helpers ---
+
+    fn get_bond(&self, bit: u32) -> bool {
+        (self.bonds() >> bit) & 1 != 0
+    }
+
+    fn set_bond(&mut self, bit: u32, v: bool) {
+        let mut b = self.bonds();
+        if v {
+            b |= 1 << bit;
+        } else {
+            b &= !(1 << bit);
+        }
+        self.set_bonds(b);
+    }
+
+    /// Returns `true` if the +X neighbor bond is set.
+    pub fn has_bond_pos_x(&self) -> bool {
+        self.get_bond(BOND_POS_X)
+    }
+
+    /// Sets or clears the +X neighbor bond.
+    pub fn set_bond_pos_x(&mut self, v: bool) {
+        self.set_bond(BOND_POS_X, v);
+    }
+
+    /// Returns `true` if the -X neighbor bond is set.
+    pub fn has_bond_neg_x(&self) -> bool {
+        self.get_bond(BOND_NEG_X)
+    }
+
+    /// Sets or clears the -X neighbor bond.
+    pub fn set_bond_neg_x(&mut self, v: bool) {
+        self.set_bond(BOND_NEG_X, v);
+    }
+
+    /// Returns `true` if the +Y neighbor bond is set.
+    pub fn has_bond_pos_y(&self) -> bool {
+        self.get_bond(BOND_POS_Y)
+    }
+
+    /// Sets or clears the +Y neighbor bond.
+    pub fn set_bond_pos_y(&mut self, v: bool) {
+        self.set_bond(BOND_POS_Y, v);
+    }
+
+    /// Returns `true` if the -Y neighbor bond is set.
+    pub fn has_bond_neg_y(&self) -> bool {
+        self.get_bond(BOND_NEG_Y)
+    }
+
+    /// Sets or clears the -Y neighbor bond.
+    pub fn set_bond_neg_y(&mut self, v: bool) {
+        self.set_bond(BOND_NEG_Y, v);
+    }
+
+    /// Returns `true` if the +Z neighbor bond is set.
+    pub fn has_bond_pos_z(&self) -> bool {
+        self.get_bond(BOND_POS_Z)
+    }
+
+    /// Sets or clears the +Z neighbor bond.
+    pub fn set_bond_pos_z(&mut self, v: bool) {
+        self.set_bond(BOND_POS_Z, v);
+    }
+
+    /// Returns `true` if the -Z neighbor bond is set.
+    pub fn has_bond_neg_z(&self) -> bool {
+        self.get_bond(BOND_NEG_Z)
+    }
+
+    /// Sets or clears the -Z neighbor bond.
+    pub fn set_bond_neg_z(&mut self, v: bool) {
+        self.set_bond(BOND_NEG_Z, v);
+    }
+
+    // --- Flag helpers ---
+
+    fn get_flag(&self, bit: u32) -> bool {
+        (self.flags() >> bit) & 1 != 0
+    }
+
+    fn set_flag(&mut self, bit: u32, v: bool) {
+        let mut f = self.flags();
+        if v {
+            f |= 1 << bit;
+        } else {
+            f &= !(1 << bit);
+        }
+        self.set_flags(f);
+    }
+
+    /// Returns `true` if the dirty flag is set.
+    pub fn is_dirty(&self) -> bool {
+        self.get_flag(FLAG_DIRTY)
+    }
+
+    /// Sets or clears the dirty flag.
+    pub fn set_dirty(&mut self, v: bool) {
+        self.set_flag(FLAG_DIRTY, v);
+    }
+
+    /// Returns `true` if the burning flag is set.
+    pub fn is_burning(&self) -> bool {
+        self.get_flag(FLAG_BURNING)
+    }
+
+    /// Sets or clears the burning flag.
+    pub fn set_burning(&mut self, v: bool) {
+        self.set_flag(FLAG_BURNING, v);
+    }
+
+    /// Returns `true` if the wet flag is set.
+    pub fn is_wet(&self) -> bool {
+        self.get_flag(FLAG_WET)
+    }
+
+    /// Sets or clears the wet flag.
+    pub fn set_wet(&mut self, v: bool) {
+        self.set_flag(FLAG_WET, v);
+    }
+
+    /// Returns `true` if the poisoned flag is set.
+    pub fn is_poisoned(&self) -> bool {
+        self.get_flag(FLAG_POISONED)
+    }
+
+    /// Sets or clears the poisoned flag.
+    pub fn set_poisoned(&mut self, v: bool) {
+        self.set_flag(FLAG_POISONED, v);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::{align_of, size_of};
+
+    #[test]
+    fn test_air_is_zero() {
+        assert_eq!(Voxel::air().0, 0);
+        assert!(Voxel::air().is_air());
+    }
+
+    #[test]
+    fn test_pack_unpack_roundtrip() {
+        let v = Voxel::new(42, 200, 0b101010, 13, 0b1010);
+        assert_eq!(v.material_id(), 42);
+        assert_eq!(v.temperature(), 200);
+        assert_eq!(v.bonds(), 0b101010);
+        assert_eq!(v.oxygen(), 13);
+        assert_eq!(v.flags(), 0b1010);
+    }
+
+    #[test]
+    fn test_material_id_max() {
+        let v = Voxel::new(1023, 0, 0, 0, 0);
+        assert_eq!(v.material_id(), 1023);
+    }
+
+    #[test]
+    fn test_temperature_max() {
+        let v = Voxel::new(0, 255, 0, 0, 0);
+        assert_eq!(v.temperature(), 255);
+    }
+
+    #[test]
+    fn test_bonds_all_set() {
+        let v = Voxel::new(0, 0, 0b111111, 0, 0);
+        assert_eq!(v.bonds(), 0b111111);
+        assert!(v.has_bond_pos_x());
+        assert!(v.has_bond_neg_x());
+        assert!(v.has_bond_pos_y());
+        assert!(v.has_bond_neg_y());
+        assert!(v.has_bond_pos_z());
+        assert!(v.has_bond_neg_z());
+    }
+
+    #[test]
+    fn test_flags_all_set() {
+        let v = Voxel::new(0, 0, 0, 0, 0b1111);
+        assert!(v.is_dirty());
+        assert!(v.is_burning());
+        assert!(v.is_wet());
+        assert!(v.is_poisoned());
+    }
+
+    #[test]
+    fn test_set_field_preserves_others() {
+        let mut v = Voxel::new(100, 50, 0b110011, 7, 0b0101);
+        v.set_temperature(200);
+        assert_eq!(v.material_id(), 100);
+        assert_eq!(v.temperature(), 200);
+        assert_eq!(v.bonds(), 0b110011);
+        assert_eq!(v.oxygen(), 7);
+        assert_eq!(v.flags(), 0b0101);
+    }
+
+    #[test]
+    fn test_bytemuck_zeroed() {
+        let v: Voxel = Voxel::zeroed();
+        assert!(v.is_air());
+        assert_eq!(v.0, 0);
+    }
+
+    #[test]
+    fn test_size_align() {
+        assert_eq!(size_of::<Voxel>(), 4);
+        assert_eq!(align_of::<Voxel>(), 4);
+    }
+}


### PR DESCRIPTION
## Summary
- **`Voxel`** (`voxel.rs`): Packed u32 (4 bytes/voxel) with bitfields for material_id (10b), temperature (8b), bonds (6b), oxygen (4b), flags (4b). Full getters/setters/bond helpers/flag helpers.
- **`ChunkGpuMeta`** (`chunk_gpu.rs`): 64-byte GPU chunk metadata with world_pos, neighbor_ids, activity level, flags.
- **`MaterialPropertiesCA`** (`material_ca.rs`): 64-byte material properties (phase, density, thermal, combustion, structural).
- **`ReactionEntry`** (`reaction_ca.rs`): 32-byte chemical reaction entry (inputs, outputs, conditions, probability, impulse).
- **Constants**: CA_CHUNK_SIZE, CA_MAX_CHUNKS, CA_MAX_MATERIALS, CA_MAX_REACTIONS, CA_AMBIENT_TEMP, etc.

All types are `#[repr(C)]` + `bytemuck::Pod` + `no_std` compatible. Sizes verified with compile-time asserts.

## Test plan
- [x] `cargo test -p shared` — all 89 tests pass (9 new tests for CA types)
- [x] Compile-time size asserts for ChunkGpuMeta (64B), MaterialPropertiesCA (64B), ReactionEntry (32B)
- [x] Voxel roundtrip tests for all fields, max values, bond/flag helpers
- [x] Bytemuck zeroed tests for all types

Closes #244