### PR TITLE
[sim2] Add CA compute shaders: compact, thermal, Margolus

### DIFF
--- a/crates/shaders/src/ca_types.rs
+++ b/crates/shaders/src/ca_types.rs
@@ -1,0 +1,248 @@
+//! GPU-side type definitions for the CA (Cellular Automata) substrate.
+//!
+//! These mirror the CPU-side types in `shared::voxel`, `shared::chunk_gpu`,
+//! `shared::material_ca`, and `shared::reaction_ca`. Uses `spirv_std::glam`
+//! for SPIR-V compatibility. Memory layouts MUST be kept in sync manually.
+//!
+//! The voxel is a packed u32 with the following bit layout:
+//! - `material_id`: bits 0-9 (10 bits, 0-1023)
+//! - `temperature`: bits 10-17 (8 bits, 0-255)
+//! - `bonds`: bits 18-23 (6 bits, +X/-X/+Y/-Y/+Z/-Z)
+//! - `oxygen`: bits 24-27 (4 bits, 0-15)
+//! - `flags`: bits 28-31 (4 bits: dirty, burning, wet, poisoned)
+
+// ---- Constants (must match shared::constants) ----
+
+/// CA chunk size in voxels per axis.
+pub const CA_CHUNK_SIZE: u32 = 32;
+
+/// Total voxels per CA chunk (32^3).
+pub const CA_CHUNK_VOXELS: u32 = 32 * 32 * 32; // 32768
+
+/// Default ambient temperature for unloaded neighbors (game units).
+pub const CA_AMBIENT_TEMP: u32 = 128;
+
+/// Maximum number of material types in the CA system.
+pub const CA_MAX_MATERIALS: u32 = 1024;
+
+/// Maximum number of chemical reactions.
+pub const CA_MAX_REACTIONS: u32 = 256;
+
+/// Size of one slot in u32 units: voxels (32768) + dirty bitmask (1024).
+pub const SLOT_SIZE_U32: u32 = 33792;
+
+/// Number of u32 voxel entries per slot.
+pub const VOXELS_PER_SLOT_U32: u32 = 32768;
+
+/// Number of u32s in chunk metadata (64 bytes / 4).
+pub const META_SIZE_U32: u32 = 16;
+
+/// Number of u32s per MaterialPropertiesCA (64 bytes / 4).
+pub const MATERIAL_SIZE_U32: u32 = 16;
+
+/// Number of u32s per ReactionEntry (32 bytes / 4).
+pub const REACTION_SIZE_U32: u32 = 8;
+
+/// Workgroups per chunk for thermal pass (32/4 = 8 regions per axis, 8^3 = 512).
+pub const THERMAL_WG_PER_CHUNK: u32 = 512;
+
+/// Workgroups per chunk for Margolus pass (16^3 blocks / 64 threads = 64).
+pub const MARGOLUS_WG_PER_CHUNK: u32 = 64;
+
+// ---- Voxel pack/unpack (must match shared::voxel::Voxel bit layout) ----
+
+/// Extracts the material ID (bits 0-9) from a packed voxel.
+pub fn voxel_material_id(v: u32) -> u32 {
+    v & 0x3FF
+}
+
+/// Extracts the temperature (bits 10-17) from a packed voxel.
+pub fn voxel_temperature(v: u32) -> u32 {
+    (v >> 10) & 0xFF
+}
+
+/// Extracts the bond flags (bits 18-23) from a packed voxel.
+pub fn voxel_bonds(v: u32) -> u32 {
+    (v >> 18) & 0x3F
+}
+
+/// Extracts the oxygen level (bits 24-27) from a packed voxel.
+pub fn voxel_oxygen(v: u32) -> u32 {
+    (v >> 24) & 0xF
+}
+
+/// Extracts the flag bits (bits 28-31) from a packed voxel.
+pub fn voxel_flags(v: u32) -> u32 {
+    (v >> 28) & 0xF
+}
+
+/// Packs voxel fields into a single u32.
+///
+/// Values are masked to their respective bit widths.
+pub fn voxel_pack(material_id: u32, temperature: u32, bonds: u32, oxygen: u32, flags: u32) -> u32 {
+    (material_id & 0x3FF)
+        | ((temperature & 0xFF) << 10)
+        | ((bonds & 0x3F) << 18)
+        | ((oxygen & 0xF) << 24)
+        | ((flags & 0xF) << 28)
+}
+
+/// Returns a voxel with only the temperature field changed.
+pub fn voxel_set_temperature(v: u32, temp: u32) -> u32 {
+    (v & !(0xFF << 10)) | ((temp & 0xFF) << 10)
+}
+
+/// Returns a voxel with only the material ID field changed.
+pub fn voxel_set_material(v: u32, mat: u32) -> u32 {
+    (v & !0x3FF) | (mat & 0x3FF)
+}
+
+/// Returns a voxel with only the bonds field changed.
+pub fn voxel_set_bonds(v: u32, bonds: u32) -> u32 {
+    (v & !(0x3F << 18)) | ((bonds & 0x3F) << 18)
+}
+
+/// Returns a voxel with only the flags field changed.
+pub fn voxel_set_flags(v: u32, flags: u32) -> u32 {
+    (v & !(0xF << 28)) | ((flags & 0xF) << 28)
+}
+
+// ---- Slot addressing ----
+
+/// Computes the u32 index into the chunk pool for a voxel at (x, y, z) in the given slot.
+pub fn voxel_addr(slot_id: u32, local_x: u32, local_y: u32, local_z: u32) -> u32 {
+    let voxel_idx = local_z * CA_CHUNK_SIZE * CA_CHUNK_SIZE + local_y * CA_CHUNK_SIZE + local_x;
+    slot_id * SLOT_SIZE_U32 + voxel_idx
+}
+
+// ---- Material table access ----
+// MaterialPropertiesCA layout (16 u32s, must match shared::material_ca):
+//  [0] phase       [1] density      [2] viscosity    [3] conductivity
+//  [4] melt_temp   [5] boil_temp    [6] freeze_temp  [7] melt_into
+//  [8] boil_into   [9] freeze_into  [10] flammability [11] ignition_temp
+//  [12] burn_into  [13] burn_heat   [14] strength    [15] max_load
+
+/// Returns the phase (0=solid, 1=powder, 2=liquid, 3=gas) for a material.
+pub fn mat_phase(materials: &[u32], mat_id: u32) -> u32 {
+    materials[(mat_id * MATERIAL_SIZE_U32) as usize]
+}
+
+/// Returns the density for a material.
+pub fn mat_density(materials: &[u32], mat_id: u32) -> u32 {
+    materials[(mat_id * MATERIAL_SIZE_U32 + 1) as usize]
+}
+
+/// Returns the thermal conductivity for a material.
+pub fn mat_conductivity(materials: &[u32], mat_id: u32) -> u32 {
+    materials[(mat_id * MATERIAL_SIZE_U32 + 3) as usize]
+}
+
+/// Returns the melt temperature for a material.
+pub fn mat_melt_temp(materials: &[u32], mat_id: u32) -> u32 {
+    materials[(mat_id * MATERIAL_SIZE_U32 + 4) as usize]
+}
+
+/// Returns the boil temperature for a material.
+pub fn mat_boil_temp(materials: &[u32], mat_id: u32) -> u32 {
+    materials[(mat_id * MATERIAL_SIZE_U32 + 5) as usize]
+}
+
+/// Returns the freeze temperature for a material.
+pub fn mat_freeze_temp(materials: &[u32], mat_id: u32) -> u32 {
+    materials[(mat_id * MATERIAL_SIZE_U32 + 6) as usize]
+}
+
+/// Returns the material ID to become when melting.
+pub fn mat_melt_into(materials: &[u32], mat_id: u32) -> u32 {
+    materials[(mat_id * MATERIAL_SIZE_U32 + 7) as usize]
+}
+
+/// Returns the material ID to become when boiling.
+pub fn mat_boil_into(materials: &[u32], mat_id: u32) -> u32 {
+    materials[(mat_id * MATERIAL_SIZE_U32 + 8) as usize]
+}
+
+/// Returns the material ID to become when freezing.
+pub fn mat_freeze_into(materials: &[u32], mat_id: u32) -> u32 {
+    materials[(mat_id * MATERIAL_SIZE_U32 + 9) as usize]
+}
+
+// ---- Chunk metadata access ----
+// ChunkGpuMeta layout (16 u32s, must match shared::chunk_gpu):
+//  [0..3]  world_pos (IVec4: x,y,z,slot_id)
+//  [4..9]  neighbor_ids[6] (+X,-X,+Y,-Y,+Z,-Z as i32)
+//  [10]    activity
+//  [11]    flags
+//  [12..15] _pad
+
+/// Returns the neighbor slot ID for a given direction (0..5: +X,-X,+Y,-Y,+Z,-Z).
+///
+/// Returns -1 (as u32 = 0xFFFFFFFF) if the neighbor is not loaded.
+pub fn meta_neighbor_id(metadata: &[u32], slot_id: u32, direction: u32) -> u32 {
+    metadata[(slot_id * META_SIZE_U32 + 4 + direction) as usize]
+}
+
+/// Returns the flags field from chunk metadata.
+pub fn meta_flags(metadata: &[u32], slot_id: u32) -> u32 {
+    metadata[(slot_id * META_SIZE_U32 + 11) as usize]
+}
+
+/// Returns the activity level from chunk metadata.
+pub fn meta_activity(metadata: &[u32], slot_id: u32) -> u32 {
+    metadata[(slot_id * META_SIZE_U32 + 10) as usize]
+}
+
+// ---- Reaction table access ----
+// ReactionEntry layout (8 u32s, must match shared::reaction_ca):
+//  [0] input_a    [1] input_b    [2] output_a   [3] output_b
+//  [4] heat_delta [5] condition  [6] probability [7] impulse
+
+/// Returns the input_a material ID for a reaction.
+pub fn reaction_input_a(reactions: &[u32], idx: u32) -> u32 {
+    reactions[(idx * REACTION_SIZE_U32) as usize]
+}
+
+/// Returns the input_b material ID for a reaction.
+pub fn reaction_input_b(reactions: &[u32], idx: u32) -> u32 {
+    reactions[(idx * REACTION_SIZE_U32 + 1) as usize]
+}
+
+/// Returns the output_a material ID for a reaction.
+pub fn reaction_output_a(reactions: &[u32], idx: u32) -> u32 {
+    reactions[(idx * REACTION_SIZE_U32 + 2) as usize]
+}
+
+/// Returns the output_b material ID for a reaction.
+pub fn reaction_output_b(reactions: &[u32], idx: u32) -> u32 {
+    reactions[(idx * REACTION_SIZE_U32 + 3) as usize]
+}
+
+/// Returns the heat_delta for a reaction (reinterpreted as i32).
+pub fn reaction_heat_delta(reactions: &[u32], idx: u32) -> i32 {
+    reactions[(idx * REACTION_SIZE_U32 + 4) as usize] as i32
+}
+
+/// Returns the condition for a reaction (0=none, 1=needs_oxygen, 2=needs_high_temp).
+pub fn reaction_condition(reactions: &[u32], idx: u32) -> u32 {
+    reactions[(idx * REACTION_SIZE_U32 + 5) as usize]
+}
+
+/// Returns the probability (0-255) for a reaction.
+pub fn reaction_probability(reactions: &[u32], idx: u32) -> u32 {
+    reactions[(idx * REACTION_SIZE_U32 + 6) as usize]
+}
+
+// ---- Deterministic hash / RNG ----
+
+/// Deterministic spatial hash for pseudo-random number generation.
+///
+/// Returns a uniform-ish u32 from position and frame number.
+pub fn hash_position(x: u32, y: u32, z: u32, frame: u32) -> u32 {
+    let mut h = x.wrapping_mul(73856093)
+        ^ y.wrapping_mul(19349663)
+        ^ z.wrapping_mul(83492791)
+        ^ frame.wrapping_mul(48611);
+    h = h.wrapping_mul(2654435761);
+    h ^= h >> 16;
+    h
+}

--- a/crates/shaders/src/compute/ca_compact.rs
+++ b/crates/shaders/src/compute/ca_compact.rs
@@ -1,0 +1,109 @@
+//! Stream compaction compute shader for the CA substrate.
+//!
+//! Builds a list of dirty chunk IDs for indirect dispatch of subsequent CA passes.
+//! One thread per chunk checks the dirty flag in metadata and atomically appends
+//! the slot ID to the dirty list.
+//!
+//! Dirty list buffer layout (in u32s):
+//! - `[0]`: dirty_count (atomic counter)
+//! - `[1]`: dispatch_x (filled by thread 0 of a finalize pass, or same pass)
+//! - `[2]`: dispatch_y = 1
+//! - `[3]`: dispatch_z = 1
+//! - `[4..4+N]`: dirty chunk slot IDs
+
+use spirv_std::glam::UVec3;
+use spirv_std::spirv;
+
+use crate::ca_types;
+
+/// Push constants for the compact pass.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct CaCompactPush {
+    /// Total number of loaded chunks.
+    pub total_chunks: u32,
+    /// Workgroups-per-chunk for subsequent indirect dispatch (e.g., 512 for thermal).
+    pub workgroups_per_chunk: u32,
+    /// Padding to 16-byte alignment.
+    pub _pad: [u32; 2],
+}
+
+/// Header offset in the dirty list: slot IDs start at index 4.
+const DIRTY_LIST_HEADER: u32 = 4;
+
+/// Checks one chunk's metadata and appends it to the dirty list if flagged dirty.
+///
+/// Separated into a helper to satisfy the rust-gpu entry-point-must-call-helper rule
+/// (see CLAUDE.md trap #4a).
+fn compact_impl(
+    chunk_id: u32,
+    metadata: &[u32],
+    dirty_list: &mut [u32],
+    total_chunks: u32,
+    workgroups_per_chunk: u32,
+) {
+    if chunk_id >= total_chunks {
+        return;
+    }
+
+    // Read flags from metadata: bit 0 = dirty
+    let flags = ca_types::meta_flags(metadata, chunk_id);
+    let is_dirty = (flags & 1) != 0;
+
+    if is_dirty {
+        // Atomic increment of dirty_count at dirty_list[0]
+        let old_count = unsafe {
+            spirv_std::arch::atomic_i_add::<
+                u32,
+                { spirv_std::memory::Scope::Device as u32 },
+                { spirv_std::memory::Semantics::NONE.bits() },
+            >(&mut dirty_list[0], 1)
+        };
+        // Write slot ID at the next available position
+        dirty_list[(DIRTY_LIST_HEADER + old_count) as usize] = chunk_id;
+    }
+}
+
+/// Compute shader entry point: stream compaction of dirty chunks.
+///
+/// Descriptor set 0:
+/// - binding 0: metadata buffer (ChunkGpuMeta array as `&[u32]`)
+/// - binding 1: dirty_list buffer (`&mut [u32]`)
+///
+/// Dispatch: `(ceil(total_chunks / 256), 1, 1)` workgroups.
+#[spirv(compute(threads(256)))]
+pub fn ca_compact(
+    #[spirv(global_invocation_id)] global_id: UVec3,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] metadata: &[u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] dirty_list: &mut [u32],
+    #[spirv(push_constant)] push: &CaCompactPush,
+) {
+    compact_impl(
+        global_id.x,
+        metadata,
+        dirty_list,
+        push.total_chunks,
+        push.workgroups_per_chunk,
+    );
+}
+
+/// Finalize pass: writes VkDispatchIndirectCommand to dirty_list header.
+///
+/// Must be dispatched as a single workgroup (1,1,1) AFTER ca_compact and a barrier.
+/// Reads dirty_count from `dirty_list[0]` and writes dispatch args.
+#[spirv(compute(threads(1)))]
+pub fn ca_compact_finalize(
+    #[spirv(global_invocation_id)] _global_id: UVec3,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] dirty_list: &mut [u32],
+    #[spirv(push_constant)] push: &CaCompactPush,
+) {
+    finalize_impl(dirty_list, push.workgroups_per_chunk);
+}
+
+/// Writes the indirect dispatch command based on the dirty count.
+fn finalize_impl(dirty_list: &mut [u32], workgroups_per_chunk: u32) {
+    let dirty_count = dirty_list[0];
+    dirty_list[1] = dirty_count * workgroups_per_chunk; // dispatch_x
+    dirty_list[2] = 1; // dispatch_y
+    dirty_list[3] = 1; // dispatch_z
+}

--- a/crates/shaders/src/compute/ca_margolus.rs
+++ b/crates/shaders/src/compute/ca_margolus.rs
@@ -1,0 +1,525 @@
+//! Margolus 2x2x2 block automaton compute shader for falling sand + chemical reactions.
+//!
+//! Called twice per CA step: once with even offset (0,0,0) and once with odd offset (1,1,1).
+//! Each thread processes one 2x2x2 block within a dirty chunk.
+//!
+//! Workgroup layout: (4, 4, 4) = 64 threads per workgroup.
+//! Each chunk has 16x16x16 = 4096 blocks, needing 4096/64 = 64 workgroups.
+//! Dispatched indirectly: X = dirty_count * 64, Y = 1, Z = 1.
+
+use spirv_std::glam::UVec3;
+use spirv_std::spirv;
+
+use crate::ca_types;
+
+/// Push constants for the Margolus pass.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct CaMargolusPush {
+    /// Current frame number (for deterministic RNG).
+    pub frame_number: u32,
+    /// Block offset X (0 for even pass, 1 for odd pass).
+    pub offset_x: u32,
+    /// Block offset Y (0 for even, 1 for odd).
+    pub offset_y: u32,
+    /// Block offset Z (0 for even, 1 for odd).
+    pub offset_z: u32,
+    /// Number of active reactions in the reaction table.
+    pub num_reactions: u32,
+    /// Padding to 32-byte alignment.
+    pub _pad: [u32; 3],
+}
+
+/// Dirty list header size in u32s.
+const DIRTY_LIST_HEADER: u32 = 4;
+
+// ---- Voxel read/write helpers ----
+
+/// Reads a voxel from the chunk pool at (x, y, z) in the given slot.
+///
+/// Returns 0 (air) if coordinates are out of bounds.
+fn read_voxel(chunk_pool: &[u32], slot_id: u32, x: u32, y: u32, z: u32) -> u32 {
+    if x >= ca_types::CA_CHUNK_SIZE || y >= ca_types::CA_CHUNK_SIZE || z >= ca_types::CA_CHUNK_SIZE {
+        return 0;
+    }
+    let addr = ca_types::voxel_addr(slot_id, x, y, z);
+    chunk_pool[addr as usize]
+}
+
+/// Writes a voxel to the chunk pool at (x, y, z) in the given slot.
+fn write_voxel(chunk_pool: &mut [u32], slot_id: u32, x: u32, y: u32, z: u32, voxel: u32) {
+    if x >= ca_types::CA_CHUNK_SIZE || y >= ca_types::CA_CHUNK_SIZE || z >= ca_types::CA_CHUNK_SIZE {
+        return;
+    }
+    let addr = ca_types::voxel_addr(slot_id, x, y, z);
+    chunk_pool[addr as usize] = voxel;
+}
+
+// ---- Falling sand helpers ----
+
+/// Determines whether two voxels should swap positions (top falls into bottom).
+///
+/// Returns true if the top voxel is heavier and should sink.
+fn should_swap_falling(materials: &[u32], top_mat: u32, bot_mat: u32) -> bool {
+    // Air (material 0) is always displaced
+    if top_mat == 0 {
+        return false;
+    }
+    if bot_mat == 0 {
+        // Non-air on top, air on bottom: fall if top is powder/liquid/gas
+        let phase_top = ca_types::mat_phase(materials, top_mat);
+        // powder=1, liquid=2, gas=3 can all fall into air
+        return phase_top >= 1;
+    }
+
+    should_swap_by_density(materials, top_mat, bot_mat)
+}
+
+/// Checks density-based swapping for non-air voxels.
+///
+/// Powder sinks in liquid, liquid sinks in gas, etc.
+fn should_swap_by_density(materials: &[u32], top_mat: u32, bot_mat: u32) -> bool {
+    let phase_top = ca_types::mat_phase(materials, top_mat);
+    let phase_bot = ca_types::mat_phase(materials, bot_mat);
+
+    // Solids (phase 0) never move in CA
+    if phase_top == 0 {
+        return false;
+    }
+    // Can't displace a solid
+    if phase_bot == 0 {
+        return false;
+    }
+
+    let density_top = ca_types::mat_density(materials, top_mat);
+    let density_bot = ca_types::mat_density(materials, bot_mat);
+
+    // Heavier sinks: top is heavier than bottom
+    density_top > density_bot
+}
+
+/// Applies falling-sand rules to a vertical column pair within the 2x2x2 block.
+///
+/// Swaps top and bottom if the top is heavier. Returns (new_top, new_bot).
+fn apply_gravity_pair(materials: &[u32], top: u32, bot: u32) -> (u32, u32) {
+    let top_mat = ca_types::voxel_material_id(top);
+    let bot_mat = ca_types::voxel_material_id(bot);
+
+    if should_swap_falling(materials, top_mat, bot_mat) {
+        (bot, top)
+    } else {
+        (top, bot)
+    }
+}
+
+// ---- Gas buoyancy helper ----
+
+/// Applies gas buoyancy: gas rises through heavier materials.
+///
+/// If bottom is gas and top is heavier, swap. Returns (new_top, new_bot).
+fn apply_buoyancy_pair(materials: &[u32], top: u32, bot: u32) -> (u32, u32) {
+    let bot_mat = ca_types::voxel_material_id(bot);
+    if bot_mat == 0 {
+        return (top, bot);
+    }
+
+    let top_mat = ca_types::voxel_material_id(top);
+    if top_mat == 0 {
+        // Top is air, bottom is something: gas can rise into air
+        let phase_bot = ca_types::mat_phase(materials, bot_mat);
+        if phase_bot == 3 {
+            return (bot, top);
+        }
+        return (top, bot);
+    }
+
+    // Both non-air: gas phase rises through heavier
+    let phase_bot = ca_types::mat_phase(materials, bot_mat);
+    if phase_bot == 3 {
+        let density_top = ca_types::mat_density(materials, top_mat);
+        let density_bot = ca_types::mat_density(materials, bot_mat);
+        if density_top > density_bot {
+            return (bot, top);
+        }
+    }
+
+    (top, bot)
+}
+
+// ---- Reaction helpers ----
+
+/// Tries to apply a chemical reaction between two adjacent voxels.
+///
+/// Linear scans the reaction table for a match. On match, applies outputs
+/// and heat delta. Returns (new_a, new_b, reacted).
+fn try_reactions(
+    reactions: &[u32],
+    num_reactions: u32,
+    va: u32,
+    vb: u32,
+    rng: u32,
+) -> (u32, u32, bool) {
+    let mat_a = ca_types::voxel_material_id(va);
+    let mat_b = ca_types::voxel_material_id(vb);
+
+    // Skip if either is air
+    if mat_a == 0 {
+        return (va, vb, false);
+    }
+    if mat_b == 0 {
+        return (va, vb, false);
+    }
+
+    scan_reactions_forward(reactions, num_reactions, va, vb, mat_a, mat_b, rng)
+}
+
+/// Scans the reaction table for a matching pair (forward: a=input_a, b=input_b).
+fn scan_reactions_forward(
+    reactions: &[u32],
+    num_reactions: u32,
+    va: u32,
+    vb: u32,
+    mat_a: u32,
+    mat_b: u32,
+    rng: u32,
+) -> (u32, u32, bool) {
+    let mut i: u32 = 0;
+    loop {
+        if i >= num_reactions {
+            // Also try reversed order
+            return scan_reactions_reversed(reactions, num_reactions, va, vb, mat_a, mat_b, rng);
+        }
+
+        // Copy to locals to avoid &buffer[i] in loop (trap #21)
+        let r_input_a = ca_types::reaction_input_a(reactions, i);
+        let r_input_b = ca_types::reaction_input_b(reactions, i);
+
+        if r_input_a == mat_a && r_input_b == mat_b {
+            return apply_reaction_if_probable(reactions, i, va, vb, rng, false);
+        }
+
+        i += 1;
+    }
+}
+
+/// Scans the reaction table for a matching pair (reversed: a=input_b, b=input_a).
+fn scan_reactions_reversed(
+    reactions: &[u32],
+    num_reactions: u32,
+    va: u32,
+    vb: u32,
+    mat_a: u32,
+    mat_b: u32,
+    rng: u32,
+) -> (u32, u32, bool) {
+    let mut i: u32 = 0;
+    loop {
+        if i >= num_reactions {
+            return (va, vb, false);
+        }
+
+        let r_input_a = ca_types::reaction_input_a(reactions, i);
+        let r_input_b = ca_types::reaction_input_b(reactions, i);
+
+        if r_input_a == mat_b && r_input_b == mat_a {
+            return apply_reaction_if_probable(reactions, i, vb, va, rng, true);
+        }
+
+        i += 1;
+    }
+}
+
+/// Applies a reaction if the RNG passes the probability check.
+///
+/// `swapped` indicates whether the inputs were provided in reversed order.
+fn apply_reaction_if_probable(
+    reactions: &[u32],
+    idx: u32,
+    va_matched: u32,
+    vb_matched: u32,
+    rng: u32,
+    swapped: bool,
+) -> (u32, u32, bool) {
+    let prob = ca_types::reaction_probability(reactions, idx);
+    if (rng & 0xFF) >= prob {
+        if swapped {
+            return (vb_matched, va_matched, false);
+        }
+        return (va_matched, vb_matched, false);
+    }
+
+    let output_a_mat = ca_types::reaction_output_a(reactions, idx);
+    let output_b_mat = ca_types::reaction_output_b(reactions, idx);
+    let heat_delta = ca_types::reaction_heat_delta(reactions, idx);
+
+    let new_a = apply_reaction_outputs(va_matched, output_a_mat, heat_delta);
+    let new_b = apply_reaction_outputs(vb_matched, output_b_mat, heat_delta);
+
+    if swapped {
+        (new_b, new_a, true)
+    } else {
+        (new_a, new_b, true)
+    }
+}
+
+/// Applies reaction outputs to a single voxel: sets material and adjusts temperature.
+fn apply_reaction_outputs(voxel: u32, new_mat: u32, heat_delta: i32) -> u32 {
+    let mut v = ca_types::voxel_set_material(voxel, new_mat);
+    // Clear bonds on material change
+    v = ca_types::voxel_set_bonds(v, 0);
+    // Apply heat delta
+    let old_temp = ca_types::voxel_temperature(v) as i32;
+    let new_temp = old_temp + heat_delta;
+    let clamped = if new_temp < 0 {
+        0u32
+    } else if new_temp > 255 {
+        255u32
+    } else {
+        new_temp as u32
+    };
+    ca_types::voxel_set_temperature(v, clamped)
+}
+
+// ---- Main block processing ----
+
+/// Processes one 2x2x2 Margolus block: applies gravity and reactions.
+///
+/// This is the main orchestration function called from the entry point.
+fn margolus_main(
+    chunk_pool: &mut [u32],
+    materials: &[u32],
+    reactions: &[u32],
+    slot_id: u32,
+    bx: u32,
+    by: u32,
+    bz: u32,
+    frame: u32,
+    num_reactions: u32,
+) {
+    // Read 8 voxels of the 2x2x2 block (separate variables, not array — trap #21)
+    let mut v000 = read_voxel(chunk_pool, slot_id, bx, by, bz);
+    let mut v100 = read_voxel(chunk_pool, slot_id, bx + 1, by, bz);
+    let mut v010 = read_voxel(chunk_pool, slot_id, bx, by + 1, bz);
+    let mut v110 = read_voxel(chunk_pool, slot_id, bx + 1, by + 1, bz);
+    let mut v001 = read_voxel(chunk_pool, slot_id, bx, by, bz + 1);
+    let mut v101 = read_voxel(chunk_pool, slot_id, bx + 1, by, bz + 1);
+    let mut v011 = read_voxel(chunk_pool, slot_id, bx, by + 1, bz + 1);
+    let mut v111 = read_voxel(chunk_pool, slot_id, bx + 1, by + 1, bz + 1);
+
+    // --- Step 1: Apply gravity (falling sand) ---
+    // Process 4 vertical column pairs: y=1 (top) vs y=0 (bottom)
+    let (new_top, new_bot) = apply_gravity_pair(materials, v010, v000);
+    v010 = new_top;
+    v000 = new_bot;
+
+    let (new_top, new_bot) = apply_gravity_pair(materials, v110, v100);
+    v110 = new_top;
+    v100 = new_bot;
+
+    let (new_top, new_bot) = apply_gravity_pair(materials, v011, v001);
+    v011 = new_top;
+    v001 = new_bot;
+
+    let (new_top, new_bot) = apply_gravity_pair(materials, v111, v101);
+    v111 = new_top;
+    v101 = new_bot;
+
+    // --- Step 2: Apply gas buoyancy ---
+    let (new_top, new_bot) = apply_buoyancy_pair(materials, v010, v000);
+    v010 = new_top;
+    v000 = new_bot;
+
+    let (new_top, new_bot) = apply_buoyancy_pair(materials, v110, v100);
+    v110 = new_top;
+    v100 = new_bot;
+
+    let (new_top, new_bot) = apply_buoyancy_pair(materials, v011, v001);
+    v011 = new_top;
+    v001 = new_bot;
+
+    let (new_top, new_bot) = apply_buoyancy_pair(materials, v111, v101);
+    v111 = new_top;
+    v101 = new_bot;
+
+    // --- Step 3: Apply chemical reactions on edges ---
+    apply_block_reactions(
+        &mut v000, &mut v100, &mut v010, &mut v110,
+        &mut v001, &mut v101, &mut v011, &mut v111,
+        reactions, num_reactions, bx, by, bz, frame,
+    );
+
+    // --- Write back 8 voxels ---
+    write_voxel(chunk_pool, slot_id, bx, by, bz, v000);
+    write_voxel(chunk_pool, slot_id, bx + 1, by, bz, v100);
+    write_voxel(chunk_pool, slot_id, bx, by + 1, bz, v010);
+    write_voxel(chunk_pool, slot_id, bx + 1, by + 1, bz, v110);
+    write_voxel(chunk_pool, slot_id, bx, by, bz + 1, v001);
+    write_voxel(chunk_pool, slot_id, bx + 1, by, bz + 1, v101);
+    write_voxel(chunk_pool, slot_id, bx, by + 1, bz + 1, v011);
+    write_voxel(chunk_pool, slot_id, bx + 1, by + 1, bz + 1, v111);
+}
+
+/// Applies chemical reactions along the 12 edges of the 2x2x2 block.
+///
+/// Separated to keep branch count low per function (trap #15).
+#[allow(clippy::too_many_arguments)]
+fn apply_block_reactions(
+    v000: &mut u32, v100: &mut u32, v010: &mut u32, v110: &mut u32,
+    v001: &mut u32, v101: &mut u32, v011: &mut u32, v111: &mut u32,
+    reactions: &[u32],
+    num_reactions: u32,
+    bx: u32,
+    by: u32,
+    bz: u32,
+    frame: u32,
+) {
+    if num_reactions == 0 {
+        return;
+    }
+
+    // X-axis edges (4 edges)
+    apply_edge_reactions_x(v000, v100, reactions, num_reactions, bx, by, bz, frame);
+    apply_edge_reactions_x(v010, v110, reactions, num_reactions, bx, by + 1, bz, frame);
+    apply_edge_reactions_x(v001, v101, reactions, num_reactions, bx, by, bz + 1, frame);
+    apply_edge_reactions_x(v011, v111, reactions, num_reactions, bx, by + 1, bz + 1, frame);
+
+    // Y-axis edges (4 edges)
+    apply_edge_reactions_y(v000, v010, reactions, num_reactions, bx, by, bz, frame);
+    apply_edge_reactions_y(v100, v110, reactions, num_reactions, bx + 1, by, bz, frame);
+    apply_edge_reactions_y(v001, v011, reactions, num_reactions, bx, by, bz + 1, frame);
+    apply_edge_reactions_y(v101, v111, reactions, num_reactions, bx + 1, by, bz + 1, frame);
+
+    // Z-axis edges (4 edges)
+    apply_edge_reactions_z(v000, v001, reactions, num_reactions, bx, by, bz, frame);
+    apply_edge_reactions_z(v100, v101, reactions, num_reactions, bx + 1, by, bz, frame);
+    apply_edge_reactions_z(v010, v011, reactions, num_reactions, bx, by + 1, bz, frame);
+    apply_edge_reactions_z(v110, v111, reactions, num_reactions, bx + 1, by + 1, bz, frame);
+}
+
+/// Applies reactions between two X-adjacent voxels.
+fn apply_edge_reactions_x(
+    va: &mut u32, vb: &mut u32,
+    reactions: &[u32], num_reactions: u32,
+    x: u32, y: u32, z: u32, frame: u32,
+) {
+    let rng = ca_types::hash_position(x, y, z, frame);
+    let (new_a, new_b, _) = try_reactions(reactions, num_reactions, *va, *vb, rng);
+    *va = new_a;
+    *vb = new_b;
+}
+
+/// Applies reactions between two Y-adjacent voxels.
+fn apply_edge_reactions_y(
+    va: &mut u32, vb: &mut u32,
+    reactions: &[u32], num_reactions: u32,
+    x: u32, y: u32, z: u32, frame: u32,
+) {
+    let rng = ca_types::hash_position(x, y, z, frame.wrapping_add(7919));
+    let (new_a, new_b, _) = try_reactions(reactions, num_reactions, *va, *vb, rng);
+    *va = new_a;
+    *vb = new_b;
+}
+
+/// Applies reactions between two Z-adjacent voxels.
+fn apply_edge_reactions_z(
+    va: &mut u32, vb: &mut u32,
+    reactions: &[u32], num_reactions: u32,
+    x: u32, y: u32, z: u32, frame: u32,
+) {
+    let rng = ca_types::hash_position(x, y, z, frame.wrapping_add(15727));
+    let (new_a, new_b, _) = try_reactions(reactions, num_reactions, *va, *vb, rng);
+    *va = new_a;
+    *vb = new_b;
+}
+
+/// Compute shader entry point: Margolus block automaton for falling sand + reactions.
+///
+/// Descriptor set 0:
+/// - binding 0: chunk_pool (voxel gigabuffer, read/write)
+/// - binding 1: metadata (ChunkGpuMeta array as `&[u32]`, read)
+/// - binding 2: dirty_list (dirty chunk IDs with header, read)
+/// - binding 3: materials (MaterialPropertiesCA array as `&[u32]`, read)
+/// - binding 4: reactions (ReactionEntry array as `&[u32]`, read)
+///
+/// Dispatched indirectly: X = dirty_count * 64, Y = 1, Z = 1.
+#[spirv(compute(threads(4, 4, 4)))]
+pub fn ca_margolus(
+    #[spirv(local_invocation_id)] local_id: UVec3,
+    #[spirv(workgroup_id)] wg_id: UVec3,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] chunk_pool: &mut [u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] metadata: &[u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] dirty_list: &[u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] materials: &[u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 4)] reactions: &[u32],
+    #[spirv(push_constant)] push: &CaMargolusPush,
+) {
+    margolus_entry(
+        local_id, wg_id,
+        chunk_pool, metadata, dirty_list, materials, reactions,
+        push.frame_number, push.offset_x, push.offset_y, push.offset_z,
+        push.num_reactions,
+    );
+}
+
+/// Entry-point orchestration (helper for trap #4a compliance).
+#[allow(clippy::too_many_arguments)]
+fn margolus_entry(
+    local_id: UVec3,
+    wg_id: UVec3,
+    chunk_pool: &mut [u32],
+    metadata: &[u32],
+    dirty_list: &[u32],
+    materials: &[u32],
+    reactions: &[u32],
+    frame_number: u32,
+    offset_x: u32,
+    offset_y: u32,
+    offset_z: u32,
+    num_reactions: u32,
+) {
+    let wg_per_chunk = ca_types::MARGOLUS_WG_PER_CHUNK; // 64
+    let chunk_index = wg_id.x / wg_per_chunk;
+    let local_wg = wg_id.x % wg_per_chunk;
+
+    // Read dirty count from header
+    let dirty_count = dirty_list[0];
+    if chunk_index >= dirty_count {
+        return;
+    }
+
+    // Get slot_id
+    let slot_id = dirty_list[(DIRTY_LIST_HEADER + chunk_index) as usize];
+
+    // Decompose local_wg into 3D workgroup position within chunk
+    // 64 workgroups = 4x4x4 workgroups, each covering 4x4x4 threads = 4x4x4 blocks
+    let wg_z = local_wg / 16;
+    let wg_y = (local_wg / 4) % 4;
+    let wg_x = local_wg % 4;
+
+    // Each thread handles one 2x2x2 block
+    // Block coordinates within chunk (in voxel units, even-aligned)
+    let block_x = (wg_x * 4 + local_id.x) * 2 + offset_x;
+    let block_y = (wg_y * 4 + local_id.y) * 2 + offset_y;
+    let block_z = (wg_z * 4 + local_id.z) * 2 + offset_z;
+
+    // Bounds check: with odd offset, some blocks extend past chunk boundary
+    // Need block + 1 < 32, so block must be <= 30
+    if block_x + 1 >= ca_types::CA_CHUNK_SIZE {
+        return;
+    }
+    if block_y + 1 >= ca_types::CA_CHUNK_SIZE {
+        return;
+    }
+    if block_z + 1 >= ca_types::CA_CHUNK_SIZE {
+        return;
+    }
+
+    // Suppress unused metadata warning (reserved for cross-chunk Margolus in future)
+    let _ = metadata[0];
+
+    margolus_main(
+        chunk_pool, materials, reactions,
+        slot_id, block_x, block_y, block_z,
+        frame_number, num_reactions,
+    );
+}

--- a/crates/shaders/src/compute/ca_thermal.rs
+++ b/crates/shaders/src/compute/ca_thermal.rs
@@ -1,0 +1,273 @@
+//! Thermal diffusion compute shader for the CA substrate.
+//!
+//! Processes dirty chunks via indirect dispatch. Each thread handles one voxel,
+//! reading 6 face-neighbor temperatures, computing a conductivity-weighted delta,
+//! and checking phase transitions (melt/boil/freeze).
+//!
+//! All arithmetic is integer to ensure determinism across GPU vendors.
+//!
+//! Workgroup layout: (4, 4, 4) = 64 threads per workgroup.
+//! Each chunk needs 8x8x8 = 512 workgroups (one 4x4x4 region each).
+//! Dispatched indirectly: X = dirty_count * 512, Y = 1, Z = 1.
+
+use spirv_std::glam::UVec3;
+use spirv_std::spirv;
+
+use crate::ca_types;
+
+/// Push constants for the thermal diffusion pass.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct CaThermalPush {
+    /// Current frame number (for debugging/hashing).
+    pub frame_number: u32,
+    /// Padding to 16-byte alignment.
+    pub _pad: [u32; 3],
+}
+
+/// Dirty list header size in u32s: [dirty_count, dispatch_x, dispatch_y, dispatch_z].
+const DIRTY_LIST_HEADER: u32 = 4;
+
+// ---- Helper functions (trap #4a and #15 compliance) ----
+
+/// Reads the temperature of a neighbor voxel, handling chunk boundaries.
+///
+/// For interior neighbors (0 <= coord < 32), reads from the same slot.
+/// For boundary neighbors, looks up the neighbor chunk in metadata.
+/// If the neighbor chunk is not loaded, returns `CA_AMBIENT_TEMP`.
+fn read_neighbor_temp(
+    chunk_pool: &[u32],
+    metadata: &[u32],
+    slot_id: u32,
+    lx: i32,
+    ly: i32,
+    lz: i32,
+    direction: u32,
+) -> u32 {
+    let cs = ca_types::CA_CHUNK_SIZE as i32;
+
+    // Interior case: all coordinates are within [0, 32)
+    let in_bounds = lx >= 0 && lx < cs && ly >= 0 && ly < cs && lz >= 0 && lz < cs;
+    if in_bounds {
+        let addr = ca_types::voxel_addr(slot_id, lx as u32, ly as u32, lz as u32);
+        let voxel = chunk_pool[addr as usize];
+        return ca_types::voxel_temperature(voxel);
+    }
+
+    // Boundary case: read from neighbor chunk
+    read_neighbor_temp_cross_chunk(chunk_pool, metadata, slot_id, lx, ly, lz, direction)
+}
+
+/// Reads temperature from a cross-chunk neighbor voxel.
+///
+/// Looks up the neighbor chunk slot in metadata. If not loaded (-1), returns ambient.
+fn read_neighbor_temp_cross_chunk(
+    chunk_pool: &[u32],
+    metadata: &[u32],
+    slot_id: u32,
+    lx: i32,
+    ly: i32,
+    lz: i32,
+    direction: u32,
+) -> u32 {
+    let cs = ca_types::CA_CHUNK_SIZE as i32;
+    let neighbor_slot = ca_types::meta_neighbor_id(metadata, slot_id, direction);
+
+    // neighbor_slot == 0xFFFFFFFF means not loaded
+    if neighbor_slot == 0xFFFFFFFF {
+        return ca_types::CA_AMBIENT_TEMP;
+    }
+
+    // Wrap coordinates into [0, 32)
+    let wx = ((lx % cs) + cs) % cs;
+    let wy = ((ly % cs) + cs) % cs;
+    let wz = ((lz % cs) + cs) % cs;
+
+    let addr = ca_types::voxel_addr(neighbor_slot, wx as u32, wy as u32, wz as u32);
+    let voxel = chunk_pool[addr as usize];
+    ca_types::voxel_temperature(voxel)
+}
+
+/// Computes thermal delta using integer arithmetic for determinism.
+///
+/// Returns the signed temperature change to apply.
+fn compute_thermal_delta(
+    my_temp: u32,
+    neighbor_temps: [u32; 6],
+    conductivity: u32,
+) -> i32 {
+    // Average of 6 neighbors (integer division)
+    let sum = neighbor_temps[0] + neighbor_temps[1] + neighbor_temps[2]
+        + neighbor_temps[3] + neighbor_temps[4] + neighbor_temps[5];
+    let avg_temp = sum / 6;
+
+    // Delta = conductivity * (avg - my) >> 8  (fixed-point: conductivity/256)
+    let diff = avg_temp as i32 - my_temp as i32;
+    (conductivity as i32 * diff) >> 8
+}
+
+/// Checks for melting phase transition and returns a new voxel if triggered.
+///
+/// Returns `Some(new_voxel)` if melted, `None` otherwise.
+fn check_melt(materials: &[u32], mat_id: u32, new_temp: u32, voxel: u32) -> u32 {
+    let melt_temp = ca_types::mat_melt_temp(materials, mat_id);
+    let melt_into = ca_types::mat_melt_into(materials, mat_id);
+
+    if melt_into != 0 && new_temp > melt_temp && melt_temp > 0 {
+        let v = ca_types::voxel_set_material(voxel, melt_into);
+        // Clear bonds on phase transition
+        return ca_types::voxel_set_bonds(v, 0);
+    }
+    voxel
+}
+
+/// Checks for boiling phase transition and returns a new voxel if triggered.
+fn check_boil(materials: &[u32], mat_id: u32, new_temp: u32, voxel: u32) -> u32 {
+    let boil_temp = ca_types::mat_boil_temp(materials, mat_id);
+    let boil_into = ca_types::mat_boil_into(materials, mat_id);
+
+    if boil_into != 0 && new_temp > boil_temp && boil_temp > 0 {
+        let v = ca_types::voxel_set_material(voxel, boil_into);
+        return ca_types::voxel_set_bonds(v, 0);
+    }
+    voxel
+}
+
+/// Checks for freezing phase transition and returns a new voxel if triggered.
+fn check_freeze(materials: &[u32], mat_id: u32, new_temp: u32, voxel: u32) -> u32 {
+    let freeze_temp = ca_types::mat_freeze_temp(materials, mat_id);
+    let freeze_into = ca_types::mat_freeze_into(materials, mat_id);
+
+    if freeze_into != 0 && new_temp < freeze_temp {
+        let v = ca_types::voxel_set_material(voxel, freeze_into);
+        return ca_types::voxel_set_bonds(v, 0);
+    }
+    voxel
+}
+
+/// Clamps an i32 to [0, 255] and returns as u32.
+fn clamp_temp(t: i32) -> u32 {
+    if t < 0 {
+        0
+    } else if t > 255 {
+        255
+    } else {
+        t as u32
+    }
+}
+
+/// Main thermal diffusion logic for one voxel.
+///
+/// Reads neighbors, computes delta, checks phase transitions, writes back.
+fn thermal_main(
+    chunk_pool: &mut [u32],
+    metadata: &[u32],
+    materials: &[u32],
+    slot_id: u32,
+    lx: u32,
+    ly: u32,
+    lz: u32,
+) {
+    // Read current voxel
+    let addr = ca_types::voxel_addr(slot_id, lx, ly, lz);
+    let voxel = chunk_pool[addr as usize];
+
+    // Skip air (material_id == 0)
+    let mat_id = ca_types::voxel_material_id(voxel);
+    if mat_id == 0 {
+        return;
+    }
+
+    let my_temp = ca_types::voxel_temperature(voxel);
+    let conductivity = ca_types::mat_conductivity(materials, mat_id);
+
+    // Skip insulators (conductivity == 0)
+    if conductivity == 0 {
+        return;
+    }
+
+    // Read 6 face-neighbor temperatures
+    // Directions: 0=+X, 1=-X, 2=+Y, 3=-Y, 4=+Z, 5=-Z
+    let ix = lx as i32;
+    let iy = ly as i32;
+    let iz = lz as i32;
+
+    let t0 = read_neighbor_temp(chunk_pool, metadata, slot_id, ix + 1, iy, iz, 0);
+    let t1 = read_neighbor_temp(chunk_pool, metadata, slot_id, ix - 1, iy, iz, 1);
+    let t2 = read_neighbor_temp(chunk_pool, metadata, slot_id, ix, iy + 1, iz, 2);
+    let t3 = read_neighbor_temp(chunk_pool, metadata, slot_id, ix, iy - 1, iz, 3);
+    let t4 = read_neighbor_temp(chunk_pool, metadata, slot_id, ix, iy, iz + 1, 4);
+    let t5 = read_neighbor_temp(chunk_pool, metadata, slot_id, ix, iy, iz - 1, 5);
+
+    let neighbor_temps = [t0, t1, t2, t3, t4, t5];
+
+    // Compute temperature delta
+    let delta = compute_thermal_delta(my_temp, neighbor_temps, conductivity);
+    let new_temp = clamp_temp(my_temp as i32 + delta);
+
+    // Update temperature in voxel
+    let mut updated = ca_types::voxel_set_temperature(voxel, new_temp);
+
+    // Check phase transitions (each in its own function to avoid >3 branches)
+    updated = check_melt(materials, mat_id, new_temp, updated);
+    // Re-read material in case it changed from melt
+    let cur_mat = ca_types::voxel_material_id(updated);
+    updated = check_boil(materials, cur_mat, new_temp, updated);
+    let cur_mat2 = ca_types::voxel_material_id(updated);
+    updated = check_freeze(materials, cur_mat2, new_temp, updated);
+
+    // Write back
+    chunk_pool[addr as usize] = updated;
+}
+
+/// Compute shader entry point: thermal diffusion on dirty chunks.
+///
+/// Descriptor set 0:
+/// - binding 0: chunk_pool (voxel gigabuffer, read/write)
+/// - binding 1: metadata (ChunkGpuMeta array as `&[u32]`, read)
+/// - binding 2: dirty_list (dirty chunk IDs with header, read)
+/// - binding 3: materials (MaterialPropertiesCA array as `&[u32]`, read)
+///
+/// Dispatched indirectly: X = dirty_count * 512, Y = 1, Z = 1.
+#[spirv(compute(threads(4, 4, 4)))]
+pub fn ca_thermal(
+    #[spirv(local_invocation_id)] local_id: UVec3,
+    #[spirv(workgroup_id)] wg_id: UVec3,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] chunk_pool: &mut [u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] metadata: &[u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] dirty_list: &[u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] materials: &[u32],
+    #[spirv(push_constant)] _push: &CaThermalPush,
+) {
+    // Map workgroup to dirty chunk + region within chunk
+    let wg_per_chunk = ca_types::THERMAL_WG_PER_CHUNK; // 512
+    let chunk_index = wg_id.x / wg_per_chunk;
+    let region_in_chunk = wg_id.x % wg_per_chunk;
+
+    // Read dirty count from header
+    let dirty_count = dirty_list[0];
+    if chunk_index >= dirty_count {
+        return;
+    }
+
+    // Get slot_id from dirty list (offset by header)
+    let slot_id = dirty_list[(DIRTY_LIST_HEADER + chunk_index) as usize];
+
+    // Decompose region_in_chunk into 3D region coordinates
+    // 8 regions per axis (32/4 = 8), so 8x8x8 = 512 regions
+    let rz = region_in_chunk / 64;
+    let ry = (region_in_chunk / 8) % 8;
+    let rx = region_in_chunk % 8;
+
+    // Compute voxel position within chunk
+    let local_x = rx * 4 + local_id.x;
+    let local_y = ry * 4 + local_id.y;
+    let local_z = rz * 4 + local_id.z;
+
+    // Bounds check (should always pass for 32^3 with 4x4x4 workgroups)
+    if local_x >= ca_types::CA_CHUNK_SIZE || local_y >= ca_types::CA_CHUNK_SIZE || local_z >= ca_types::CA_CHUNK_SIZE {
+        return;
+    }
+
+    thermal_main(chunk_pool, metadata, materials, slot_id, local_x, local_y, local_z);
+}

--- a/crates/shaders/src/compute/mod.rs
+++ b/crates/shaders/src/compute/mod.rs
@@ -9,6 +9,9 @@
 //!
 //! Both views alias the same GPU buffer. Each `GridCell` = 12 contiguous f32s.
 
+pub mod ca_compact;
+pub mod ca_margolus;
+pub mod ca_thermal;
 pub mod clear_grid;
 pub mod clear_grid_sparse;
 pub mod clear_hash_grid;

--- a/crates/shaders/src/lib.rs
+++ b/crates/shaders/src/lib.rs
@@ -14,5 +14,6 @@
 
 #![cfg_attr(target_arch = "spirv", no_std)]
 
+pub mod ca_types;
 pub mod compute;
 pub mod types;


### PR DESCRIPTION
## Summary
- **ca_types.rs**: GPU-side voxel pack/unpack, material/metadata/reaction table accessors, slot addressing helpers, and deterministic spatial hash RNG. Mirrors `shared::voxel`, `shared::chunk_gpu`, `shared::material_ca`, `shared::reaction_ca` layouts.
- **ca_compact**: Stream compaction shader building dirty chunk ID list with atomic append + finalize pass for `VkDispatchIndirectCommand`.
- **ca_thermal**: Thermal diffusion on dirty chunks with cross-chunk boundary reads, integer-only arithmetic, and melt/boil/freeze phase transitions.
- **ca_margolus**: Margolus 2x2x2 block automaton for falling sand (density-based gravity), gas buoyancy, and chemical reactions (probabilistic via deterministic hash).

All shaders comply with rust-gpu constraints (traps #4a, #11, #13, #15, #21).

Closes #246

## Test plan
- [x] `cargo build -p server` compiles SPIR-V successfully
- [ ] GPU integration test: dispatch ca_compact, verify dirty list output
- [ ] GPU integration test: dispatch ca_thermal, verify temperature diffusion
- [ ] GPU integration test: dispatch ca_margolus, verify sand falls and reactions fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)