### PR TITLE
[sim2] Wire CaSimulation to app with --sim2 flag and render bridge

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -13,6 +13,7 @@ use content::MaterialDatabase;
 use glam::Vec3;
 use gpu_core::VulkanContext;
 use server::{GpuSimulation, ToolbarPushConstants, TOOLBAR_MAX_MATERIALS};
+use server::ca_simulation::{CaSimulation, CA_RENDER_GRID_SIZE};
 use shared::{GRID_SIZE, PHASE_LIQUID, Particle, RENDER_HEIGHT, RENDER_WIDTH};
 use winit::{
     application::ApplicationHandler,
@@ -77,6 +78,10 @@ pub(crate) struct App {
     world: Option<WorldManager>,
     /// Current chunk coordinate the camera is in.
     current_chunk: ChunkCoord,
+    /// If true, use CaSimulation (sim2) instead of GpuSimulation.
+    use_ca_sim: bool,
+    /// CaSimulation instance (when `--sim2` is used).
+    ca_sim: Option<CaSimulation>,
 }
 
 impl App {
@@ -94,6 +99,7 @@ impl App {
         model_path: Option<&str>,
         model_pos: Option<(f32, f32, f32)>,
         use_world: bool,
+        use_ca_sim: bool,
     ) -> Self {
         // Try loading materials from RON file, fall back to hardcoded defaults
         let material_db = match content::load_material_database("assets/materials.ron") {
@@ -237,6 +243,8 @@ impl App {
             current_fps: 0.0,
             world: world_mgr,
             current_chunk: start_chunk,
+            use_ca_sim,
+            ca_sim: None,
         }
     }
 
@@ -385,25 +393,54 @@ impl ApplicationHandler for App {
             Ok(r) => r,
             Err(e) => { tracing::error!("Failed to create Renderer: {}", e); event_loop.exit(); return; }
         };
-        let mut sim = match if let Some(db) = &self.material_db {
-            let materials = db.material_params();
-            let (transitions, count) = db.phase_transition_rules();
-            GpuSimulation::new_with_materials(&ctx, &materials, &transitions, count)
+        if self.use_ca_sim {
+            // Create CaSimulation (sim2)
+            let ca_mats = server::ca_simulation::default_ca_materials();
+            let ca_reactions = server::ca_simulation::default_ca_reactions();
+            let mut ca_sim = match CaSimulation::new(&ctx, &ca_mats, &ca_reactions, 64) {
+                Ok(s) => s,
+                Err(e) => { tracing::error!("Failed to create CaSimulation: {}", e); event_loop.exit(); return; }
+            };
+
+            // Generate and load test scene
+            let scene = server::ca_simulation::generate_test_scene();
+            tracing::info!("Loading {} CA chunks for test scene", scene.len());
+            for (coord, voxel_data) in &scene {
+                if let Err(e) = ca_sim.load_chunk(&ctx, *coord, voxel_data, [-1; 6]) {
+                    tracing::error!("Failed to load chunk {:?}: {}", coord, e);
+                }
+            }
+            tracing::info!("CaSimulation initialized with {} chunks", ca_sim.loaded_count());
+
+            // Place camera to look at the center of the test scene
+            let gs = CA_RENDER_GRID_SIZE as f32;
+            self.player = PlayerController::new(Camera::look_at(
+                Vec3::new(gs * 0.75, gs * 0.4, gs * 0.75),
+                Vec3::new(gs * 0.5, gs * 0.3, gs * 0.5),
+            ));
+
+            self.ca_sim = Some(ca_sim);
         } else {
-            GpuSimulation::new(&ctx)
-        } {
-            Ok(s) => s,
-            Err(e) => { tracing::error!("Failed to create GpuSimulation: {}", e); event_loop.exit(); return; }
-        };
-        if let Err(e) = sim.init_particles(&ctx, &self.particles) {
-            tracing::error!("Failed to upload particles: {}", e); event_loop.exit(); return;
+            let mut sim = match if let Some(db) = &self.material_db {
+                let materials = db.material_params();
+                let (transitions, count) = db.phase_transition_rules();
+                GpuSimulation::new_with_materials(&ctx, &materials, &transitions, count)
+            } else {
+                GpuSimulation::new(&ctx)
+            } {
+                Ok(s) => s,
+                Err(e) => { tracing::error!("Failed to create GpuSimulation: {}", e); event_loop.exit(); return; }
+            };
+            if let Err(e) = sim.init_particles(&ctx, &self.particles) {
+                tracing::error!("Failed to upload particles: {}", e); event_loop.exit(); return;
+            }
+            tracing::info!("GpuSimulation initialized with {} particles", self.particles.len());
+            self.sim = Some(sim);
         }
-        tracing::info!("GpuSimulation initialized with {} particles", self.particles.len());
 
         self.window = Some(window);
         self.ctx = Some(ctx);
         self.renderer = Some(renderer);
-        self.sim = Some(sim);
     }
 
     fn window_event(&mut self, event_loop: &ActiveEventLoop, _window_id: WindowId, event: WindowEvent) {
@@ -411,6 +448,7 @@ impl ApplicationHandler for App {
             WindowEvent::CloseRequested => {
                 if let Some(ctx) = self.ctx.as_ref() {
                     if let Some(sim) = self.sim.as_mut() { sim.destroy(ctx); }
+                    if let Some(ca_sim) = self.ca_sim.take() { ca_sim.destroy(ctx); }
                     if let Some(renderer) = self.renderer.as_mut() { renderer.destroy(ctx); }
                 }
                 event_loop.exit();
@@ -510,48 +548,62 @@ impl ApplicationHandler for App {
                 let has_explosion = explosion.is_some();
                 let need_render = camera_moved || !self.world_is_static || has_explosion;
 
-                if let (Some(renderer), Some(ctx), Some(sim)) = (self.renderer.as_mut(), self.ctx.as_ref(), self.sim.as_ref()) {
-                    if let Err(e) = ctx.execute_one_shot(|cmd| {
-                        for _ in 0..substeps { sim.step_physics_with_time(cmd, now); }
-                        if run_react {
-                            sim.step_react(cmd);
+                if let (Some(renderer), Some(ctx)) = (self.renderer.as_mut(), self.ctx.as_ref()) {
+                    // --- CA simulation path (--sim2) ---
+                    if let Some(ref mut ca_sim) = self.ca_sim {
+                        if let Err(e) = ctx.execute_one_shot(|cmd| {
+                            for _ in 0..substeps { ca_sim.step(cmd, ctx); }
+                            ca_sim.render(cmd, RENDER_WIDTH, RENDER_HEIGHT, eye_arr, target_arr);
+                            ca_sim.finalize_render(cmd);
+                        }) {
+                            tracing::error!("CA simulation/render error: {}", e);
                         }
-                        if let Some(center) = explosion {
-                            sim.apply_explosion(cmd, center, EXPLOSION_RADIUS, EXPLOSION_STRENGTH);
+                        match renderer.draw_frame_with_buffer(ctx, ca_sim.render_output_buffer(), RENDER_WIDTH, RENDER_HEIGHT) {
+                            Ok(_) => {}
+                            Err(e) => tracing::error!("Frame error: {}", e),
                         }
+                    }
+                    // --- Standard MPM simulation path ---
+                    else if let Some(ref sim) = self.sim {
+                        if let Err(e) = ctx.execute_one_shot(|cmd| {
+                            for _ in 0..substeps { sim.step_physics_with_time(cmd, now); }
+                            if run_react {
+                                sim.step_react(cmd);
+                            }
+                            if let Some(center) = explosion {
+                                sim.apply_explosion(cmd, center, EXPLOSION_RADIUS, EXPLOSION_STRENGTH);
+                            }
+                            if need_render {
+                                sim.render(cmd, RENDER_WIDTH, RENDER_HEIGHT, eye_arr, target_arr);
+                                sim.render_toolbar(cmd, &toolbar_pc);
+                                sim.finalize_render(cmd);
+                            }
+                        }) {
+                            tracing::error!("Simulation/render error: {}", e);
+                        }
+
+                        // Readback the any_active flag AFTER GPU work completes.
+                        if now.duration_since(self.last_oob_check).as_millis() >= 250 {
+                            if let Ok(any_active) = sim.readback_any_active(ctx) {
+                                self.world_is_static = !any_active;
+                            }
+                        }
+
                         if need_render {
-                            sim.render(cmd, RENDER_WIDTH, RENDER_HEIGHT, eye_arr, target_arr);
-                            sim.render_toolbar(cmd, &toolbar_pc);
-                            sim.finalize_render(cmd);
-                        }
-                    }) {
-                        tracing::error!("Simulation/render error: {}", e);
-                    }
-
-                    // Readback the any_active flag AFTER GPU work completes.
-                    // This forces a GPU flush so we throttle it to 250ms.
-                    if now.duration_since(self.last_oob_check).as_millis() >= 250 {
-                        if let Ok(any_active) = sim.readback_any_active(ctx) {
-                            self.world_is_static = !any_active;
-                        }
-                    }
-
-                    if need_render {
-                        if self.frames_skipped > 0 {
-                            tracing::debug!("Render resumed after {} skipped frames", self.frames_skipped);
-                            self.frames_skipped = 0;
-                        }
-                        match renderer.draw_frame_with_buffer(ctx, sim.render_output_buffer(), RENDER_WIDTH, RENDER_HEIGHT) {
-                            Ok(_) => {}
-                            Err(e) => tracing::error!("Frame error: {}", e),
-                        }
-                    } else {
-                        self.frames_skipped += 1;
-                        // Still present the previous frame to the swapchain so
-                        // the window stays responsive.
-                        match renderer.draw_frame_with_buffer(ctx, sim.render_output_buffer(), RENDER_WIDTH, RENDER_HEIGHT) {
-                            Ok(_) => {}
-                            Err(e) => tracing::error!("Frame error: {}", e),
+                            if self.frames_skipped > 0 {
+                                tracing::debug!("Render resumed after {} skipped frames", self.frames_skipped);
+                                self.frames_skipped = 0;
+                            }
+                            match renderer.draw_frame_with_buffer(ctx, sim.render_output_buffer(), RENDER_WIDTH, RENDER_HEIGHT) {
+                                Ok(_) => {}
+                                Err(e) => tracing::error!("Frame error: {}", e),
+                            }
+                        } else {
+                            self.frames_skipped += 1;
+                            match renderer.draw_frame_with_buffer(ctx, sim.render_output_buffer(), RENDER_WIDTH, RENDER_HEIGHT) {
+                                Ok(_) => {}
+                                Err(e) => tracing::error!("Frame error: {}", e),
+                            }
                         }
                     }
                 }
@@ -648,20 +700,21 @@ impl ApplicationHandler for App {
                 let elapsed = self.fps_timer.elapsed().as_secs_f32();
                 if elapsed >= 1.0 {
                     self.current_fps = self.fps_frame_count as f32 / elapsed;
-                    let num_particles = self.sim.as_ref().map_or(0, |s| s.num_particles());
-                    tracing::info!(
-                        "FPS: {:.0} | Frame: {:.1}ms | Particles: {}",
-                        self.current_fps,
-                        frame_time_ms,
-                        num_particles,
-                    );
+                    let info_str = if let Some(ref ca) = self.ca_sim {
+                        format!(
+                            "FPS: {:.0} | Frame: {:.1}ms | CA chunks: {}",
+                            self.current_fps, frame_time_ms, ca.loaded_count(),
+                        )
+                    } else {
+                        let num_particles = self.sim.as_ref().map_or(0, |s| s.num_particles());
+                        format!(
+                            "FPS: {:.0} | Frame: {:.1}ms | Particles: {}",
+                            self.current_fps, frame_time_ms, num_particles,
+                        )
+                    };
+                    tracing::info!("{}", info_str);
                     if let Some(window) = &self.window {
-                        window.set_title(&format!(
-                            "VOX | {:.0} FPS | {:.1}ms | {} particles",
-                            self.current_fps,
-                            frame_time_ms,
-                            num_particles,
-                        ));
+                        window.set_title(&format!("VOX | {}", info_str));
                     }
                     self.fps_frame_count = 0;
                     self.fps_timer = Instant::now();

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -33,6 +33,8 @@ struct Args {
     model_pos: Option<(f32, f32, f32)>,
     /// If true, use WorldManager for chunk-streamed procedural terrain.
     world: bool,
+    /// If true, use CaSimulation (sim2) instead of GpuSimulation.
+    sim2: bool,
 }
 
 fn parse_args() -> Args {
@@ -64,6 +66,7 @@ fn parse_args() -> Args {
         .and_then(|i| args.get(i + 1).cloned());
     let big = args.contains(&"--big".to_string());
     let world = args.contains(&"--world".to_string());
+    let sim2 = args.contains(&"--sim2".to_string());
     let model_pos = args
         .iter()
         .position(|a| a == "--model-pos")
@@ -80,7 +83,7 @@ fn parse_args() -> Args {
                 None
             }
         });
-    Args { headless, frames, output, substeps, scene, big, model, model_pos, world }
+    Args { headless, frames, output, substeps, scene, big, model, model_pos, world, sim2 }
 }
 
 fn main() -> Result<()> {
@@ -94,7 +97,7 @@ fn main() -> Result<()> {
     if args.headless { return headless::run_headless(&args); }
 
     let event_loop = EventLoop::new()?;
-    let mut application = app::App::new(args.substeps, args.scene.as_deref(), args.big, args.model.as_deref(), args.model_pos, args.world);
+    let mut application = app::App::new(args.substeps, args.scene.as_deref(), args.big, args.model.as_deref(), args.model_pos, args.world, args.sim2);
     event_loop.run_app(&mut application)?;
     tracing::info!("VOX Engine shut down");
     Ok(())

--- a/crates/server/src/ca_simulation.rs
+++ b/crates/server/src/ca_simulation.rs
@@ -26,6 +26,7 @@ use shared::{
 
 use crate::passes::{self, ComputePass};
 use crate::pbmpm_zones::{ActivationTrigger, PbmpmZoneManager};
+use crate::push_constants::{DirtyTilesPushConstants, RenderPushConstants};
 
 /// Compiled SPIR-V shader module bytes, included at compile time.
 const SHADER_BYTES: &[u8] = include_bytes!(env!("SHADERS_SPV_PATH"));
@@ -80,6 +81,40 @@ pub struct CaMargolusPush {
     pub _pad: [u32; 3],
 }
 
+/// Push constants for the CA-to-render conversion shader.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct CaToRenderPush {
+    /// Number of loaded chunks to process.
+    pub num_chunks: u32,
+    /// Flat render grid dimension.
+    pub grid_size: u32,
+    /// World offset of the flat grid origin (X).
+    pub grid_origin_x: i32,
+    /// World offset of the flat grid origin (Y).
+    pub grid_origin_y: i32,
+    /// World offset of the flat grid origin (Z).
+    pub grid_origin_z: i32,
+    /// Padding to 32-byte alignment.
+    pub _pad: [u32; 3],
+}
+
+/// Render grid size for the CA-to-render bridge (128^3 voxels).
+pub const CA_RENDER_GRID_SIZE: u32 = 128;
+
+/// Number of bricks per axis for the CA render grid (128 / 8 = 16).
+const CA_BRICKS_PER_AXIS: u32 = CA_RENDER_GRID_SIZE / 8;
+/// Total bricks in the CA render grid.
+const CA_TOTAL_BRICKS: u32 = CA_BRICKS_PER_AXIS * CA_BRICKS_PER_AXIS * CA_BRICKS_PER_AXIS;
+
+/// Super-brick size (in bricks per axis).
+const CA_SUPER_BRICK_BRICKS: u32 = 8;
+/// Super-bricks per axis.
+const CA_SUPER_BRICKS_PER_AXIS: u32 = CA_BRICKS_PER_AXIS / CA_SUPER_BRICK_BRICKS;
+/// Total super-bricks.
+const CA_TOTAL_SUPER_BRICKS: u32 =
+    CA_SUPER_BRICKS_PER_AXIS * CA_SUPER_BRICKS_PER_AXIS * CA_SUPER_BRICKS_PER_AXIS;
+
 /// CA substrate simulation. Manages chunk pool and dispatches CA compute passes.
 pub struct CaSimulation {
     // GPU resources
@@ -101,6 +136,19 @@ pub struct CaSimulation {
 
     // PB-MPM zone manager (optional, created alongside CA)
     pbmpm: Option<PbmpmZoneManager>,
+
+    // Render bridge
+    render_voxel_buffer: GpuBuffer,
+    render_output_buffer: GpuBuffer,
+    prev_render_output_buffer: GpuBuffer,
+    brick_occupancy_buffer: GpuBuffer,
+    super_brick_occupancy_buffer: GpuBuffer,
+    dirty_tile_buffer: GpuBuffer,
+    material_render_buffer: GpuBuffer,
+    sleep_state_buffer: GpuBuffer,
+    ca_to_render_pass: ComputePass,
+    render_pass: ComputePass,
+    compute_dirty_tiles_pass: ComputePass,
 
     // CPU state
     loaded_chunks: HashMap<[i32; 3], u32>,
@@ -164,13 +212,14 @@ impl CaSimulation {
 
         // 5. Create descriptor pool
         // Total storage buffer bindings across all passes:
-        // compact: 2, compact_finalize: 1, thermal: 4, margolus: 5 = 12 total
+        // compact: 2, compact_finalize: 2, thermal: 4, margolus: 5,
+        // ca_to_render: 4, render: 7, compute_dirty_tiles: 2 = 26 total
         let pool_sizes = [vk::DescriptorPoolSize {
             ty: vk::DescriptorType::STORAGE_BUFFER,
-            descriptor_count: 16, // some headroom
+            descriptor_count: 32, // headroom for all passes
         }];
         let descriptor_pool =
-            pipeline::create_descriptor_pool(ctx, &pool_sizes, 4, "ca-descriptor-pool")?;
+            pipeline::create_descriptor_pool(ctx, &pool_sizes, 7, "ca-descriptor-pool")?;
 
         // 6. Create compute passes
 
@@ -237,6 +286,148 @@ impl CaSimulation {
             "ca-margolus",
         )?;
 
+        // 7. Create render bridge buffers
+
+        // Flat render voxel buffer: CA_RENDER_GRID_SIZE^3 * 4 u32s * 4 bytes = 32 MB
+        let render_voxel_buf_size = (CA_RENDER_GRID_SIZE as u64)
+            .pow(3)
+            * 4
+            * mem::size_of::<u32>() as u64;
+        let render_voxel_buffer = buffer::create_device_local_buffer(
+            ctx,
+            render_voxel_buf_size as vk::DeviceSize,
+            vk::BufferUsageFlags::STORAGE_BUFFER | vk::BufferUsageFlags::TRANSFER_DST,
+            "ca-render-voxel-buffer",
+        )?;
+        tracing::info!(
+            "CA render voxel buffer: {:.1}MB ({}^3 grid)",
+            render_voxel_buf_size as f64 / (1024.0 * 1024.0),
+            CA_RENDER_GRID_SIZE,
+        );
+
+        // Render output buffer: BGRA u32 per pixel
+        let render_output_size = (shared::RENDER_WIDTH as u64)
+            * (shared::RENDER_HEIGHT as u64)
+            * mem::size_of::<u32>() as u64;
+        let render_output_buffer = buffer::create_device_local_buffer(
+            ctx,
+            render_output_size as vk::DeviceSize,
+            vk::BufferUsageFlags::STORAGE_BUFFER | vk::BufferUsageFlags::TRANSFER_SRC,
+            "ca-render-output-buffer",
+        )?;
+        let prev_render_output_buffer = buffer::create_device_local_buffer(
+            ctx,
+            render_output_size as vk::DeviceSize,
+            vk::BufferUsageFlags::STORAGE_BUFFER | vk::BufferUsageFlags::TRANSFER_DST,
+            "ca-prev-render-output-buffer",
+        )?;
+
+        // Brick occupancy: 1 u32 per brick
+        let brick_occupancy_buffer = buffer::create_device_local_buffer(
+            ctx,
+            (CA_TOTAL_BRICKS as u64 * 4) as vk::DeviceSize,
+            vk::BufferUsageFlags::STORAGE_BUFFER | vk::BufferUsageFlags::TRANSFER_DST,
+            "ca-brick-occupancy-buffer",
+        )?;
+
+        // Super-brick occupancy
+        let super_brick_count = CA_TOTAL_SUPER_BRICKS.max(1);
+        let super_brick_occupancy_buffer = buffer::create_device_local_buffer(
+            ctx,
+            (super_brick_count as u64 * 4) as vk::DeviceSize,
+            vk::BufferUsageFlags::STORAGE_BUFFER | vk::BufferUsageFlags::TRANSFER_DST,
+            "ca-super-brick-occupancy-buffer",
+        )?;
+
+        // Dirty tile buffer
+        let dirty_tile_buffer = buffer::create_device_local_buffer(
+            ctx,
+            (shared::DIRTY_TILE_COUNT as u64 * 4) as vk::DeviceSize,
+            vk::BufferUsageFlags::STORAGE_BUFFER | vk::BufferUsageFlags::TRANSFER_DST,
+            "ca-dirty-tile-buffer",
+        )?;
+
+        // Material render buffer: MaterialParams for the render shader
+        // Map CA materials to render-compatible MaterialParams
+        let render_materials = ca_materials_to_render_params(materials);
+        let mat_render_buf_size =
+            (render_materials.len() * mem::size_of::<shared::material::MaterialParams>())
+                as vk::DeviceSize;
+        let material_render_buffer = buffer::create_device_local_buffer(
+            ctx,
+            mat_render_buf_size,
+            vk::BufferUsageFlags::STORAGE_BUFFER,
+            "ca-material-render-buffer",
+        )?;
+        buffer::upload(ctx, &render_materials, &material_render_buffer)?;
+
+        // Sleep state buffer (dummy, filled with zeros = all awake)
+        // Needed by compute_dirty_tiles pass
+        let sleep_state_buffer = buffer::create_device_local_buffer(
+            ctx,
+            (CA_TOTAL_BRICKS as u64 * 4) as vk::DeviceSize,
+            vk::BufferUsageFlags::STORAGE_BUFFER | vk::BufferUsageFlags::TRANSFER_DST,
+            "ca-sleep-state-buffer",
+        )?;
+        let zeros = vec![0u32; CA_TOTAL_BRICKS as usize];
+        buffer::upload(ctx, &zeros, &sleep_state_buffer)?;
+
+        // 8. Create render bridge compute passes
+
+        // ca_to_render: chunk_pool(r), metadata(r), render_voxels(w), ca_materials(r)
+        let ca_to_render_pass = passes::create_pass(
+            ctx,
+            shader_module,
+            c"compute::ca_to_render::ca_to_render",
+            &[
+                chunk_pool.voxel_buffer(),
+                chunk_pool.metadata_buffer(),
+                &render_voxel_buffer,
+                &material_buffer,
+            ],
+            mem::size_of::<CaToRenderPush>() as u32,
+            descriptor_pool,
+            "ca-to-render",
+        )?;
+
+        // compute_dirty_tiles: sleep_state(r), dirty_tiles(w)
+        let compute_dirty_tiles_pass = passes::create_pass(
+            ctx,
+            shader_module,
+            c"compute::compute_dirty_tiles::compute_dirty_tiles",
+            &[&sleep_state_buffer, &dirty_tile_buffer],
+            mem::size_of::<DirtyTilesPushConstants>() as u32,
+            descriptor_pool,
+            "ca-compute-dirty-tiles",
+        )?;
+
+        // render_pass: voxels(r), output(w), materials(r), brick_occ(r),
+        //              super_brick_occ(r), dirty_tiles(r), prev_output(r)
+        let render_pass = passes::create_pass(
+            ctx,
+            shader_module,
+            c"compute::render::render_voxels",
+            &[
+                &render_voxel_buffer,
+                &render_output_buffer,
+                &material_render_buffer,
+                &brick_occupancy_buffer,
+                &super_brick_occupancy_buffer,
+                &dirty_tile_buffer,
+                &prev_render_output_buffer,
+            ],
+            mem::size_of::<RenderPushConstants>() as u32,
+            descriptor_pool,
+            "ca-render",
+        )?;
+
+        // Clean up the sleep state buffer (owned by ca_simulation, not stored)
+        // Actually we need it for dirty tiles, but the buffer ref is captured in the descriptor set.
+        // We must keep it alive. Store it? No -- we just need it for the descriptor set binding.
+        // The descriptor set references the buffer, so we MUST keep it alive.
+        // Let's store it as an extra field... Actually, let's just leak-proof it by keeping
+        // a reference. For simplicity, store it.
+
         // Create PB-MPM zone manager (non-fatal if it fails)
         let pbmpm = match PbmpmZoneManager::new(ctx) {
             Ok(mgr) => {
@@ -260,6 +451,17 @@ impl CaSimulation {
             shader_module,
             descriptor_pool,
             pbmpm,
+            render_voxel_buffer,
+            render_output_buffer,
+            prev_render_output_buffer,
+            brick_occupancy_buffer,
+            super_brick_occupancy_buffer,
+            dirty_tile_buffer,
+            material_render_buffer,
+            sleep_state_buffer,
+            ca_to_render_pass,
+            render_pass,
+            compute_dirty_tiles_pass,
             loaded_chunks: HashMap::new(),
             frame_number: 0,
             num_reactions: reactions.len() as u32,
@@ -499,6 +701,200 @@ impl CaSimulation {
         self.frame_number += 1;
     }
 
+    /// Convert CA chunks to flat render voxels, then dispatch the ray-march render.
+    ///
+    /// This is the "bridge" that reuses the existing render pipeline with CA data.
+    /// Steps:
+    /// 1. Clear flat voxel buffer
+    /// 2. Dispatch ca_to_render shader (CA chunks -> flat voxels)
+    /// 3. Fill brick/super-brick occupancy with 1 (all occupied, POC)
+    /// 4. Mark all dirty tiles
+    /// 5. Dispatch existing render shader
+    pub fn render(
+        &self,
+        cmd: vk::CommandBuffer,
+        width: u32,
+        height: u32,
+        eye: [f32; 3],
+        target: [f32; 3],
+    ) {
+        let num_chunks = self.loaded_chunks.len() as u32;
+
+        // 1. Clear flat voxel buffer to zero
+        let voxel_buf_size = (CA_RENDER_GRID_SIZE as u64).pow(3) * 4 * 4;
+        unsafe {
+            self.device.cmd_fill_buffer(
+                cmd,
+                self.render_voxel_buffer.buffer,
+                0,
+                voxel_buf_size,
+                0,
+            );
+        }
+
+        // Transfer -> compute barrier
+        let transfer_barrier = vk::MemoryBarrier::default()
+            .src_access_mask(vk::AccessFlags::TRANSFER_WRITE)
+            .dst_access_mask(vk::AccessFlags::SHADER_READ | vk::AccessFlags::SHADER_WRITE);
+        unsafe {
+            self.device.cmd_pipeline_barrier(
+                cmd,
+                vk::PipelineStageFlags::TRANSFER,
+                vk::PipelineStageFlags::COMPUTE_SHADER,
+                vk::DependencyFlags::empty(),
+                &[transfer_barrier],
+                &[],
+                &[],
+            );
+        }
+
+        // 2. Dispatch ca_to_render: convert CA chunks to flat voxel buffer
+        if num_chunks > 0 {
+            let push = CaToRenderPush {
+                num_chunks,
+                grid_size: CA_RENDER_GRID_SIZE,
+                grid_origin_x: 0,
+                grid_origin_y: 0,
+                grid_origin_z: 0,
+                _pad: [0; 3],
+            };
+            // Each chunk is 32x32x32, workgroup is 4x4x4, so we need 8x8x8 WGs per chunk
+            // X dimension covers all chunks * 32 / 4 = num_chunks * 8
+            let wg_x = num_chunks * 8;
+            let wg_y = 8; // 32 / 4
+            let wg_z = 8; // 32 / 4
+            passes::dispatch(
+                &self.device,
+                cmd,
+                &self.ca_to_render_pass,
+                wg_x,
+                wg_y,
+                wg_z,
+                bytemuck::bytes_of(&push),
+            );
+            passes::barrier(cmd, &self.device);
+        }
+
+        // 3. Fill brick occupancy with 1 (all occupied for POC)
+        unsafe {
+            self.device.cmd_fill_buffer(
+                cmd,
+                self.brick_occupancy_buffer.buffer,
+                0,
+                CA_TOTAL_BRICKS as u64 * 4,
+                1,
+            );
+            self.device.cmd_fill_buffer(
+                cmd,
+                self.super_brick_occupancy_buffer.buffer,
+                0,
+                CA_TOTAL_SUPER_BRICKS.max(1) as u64 * 4,
+                1,
+            );
+        }
+
+        // 4. Mark all dirty tiles (fill with 1)
+        unsafe {
+            self.device.cmd_fill_buffer(
+                cmd,
+                self.dirty_tile_buffer.buffer,
+                0,
+                shared::DIRTY_TILE_COUNT as u64 * 4,
+                1,
+            );
+        }
+
+        // Barrier: transfer -> compute
+        unsafe {
+            self.device.cmd_pipeline_barrier(
+                cmd,
+                vk::PipelineStageFlags::TRANSFER,
+                vk::PipelineStageFlags::COMPUTE_SHADER,
+                vk::DependencyFlags::empty(),
+                &[transfer_barrier],
+                &[],
+                &[],
+            );
+        }
+
+        // 5. Dispatch render shader
+        let render_push = RenderPushConstants {
+            width,
+            height,
+            grid_size: CA_RENDER_GRID_SIZE,
+            _pad: 0,
+            eye: glam::Vec4::new(eye[0], eye[1], eye[2], 0.0),
+            target: glam::Vec4::new(target[0], target[1], target[2], 0.0),
+        };
+        let wg_x = (width + 7) / 8;
+        let wg_y = (height + 7) / 8;
+        passes::dispatch(
+            &self.device,
+            cmd,
+            &self.render_pass,
+            wg_x,
+            wg_y,
+            1,
+            bytemuck::bytes_of(&render_push),
+        );
+    }
+
+    /// Returns the Vulkan buffer handle for the render output.
+    ///
+    /// The buffer contains packed BGRA u32 pixels, sized `width * height`.
+    pub fn render_output_buffer(&self) -> vk::Buffer {
+        self.render_output_buffer.buffer
+    }
+
+    /// Insert a final barrier and copy current render output to the previous-frame buffer.
+    ///
+    /// Must be called after [`render`].
+    pub fn finalize_render(&self, cmd: vk::CommandBuffer) {
+        // Barrier: SHADER_WRITE -> TRANSFER_READ | TRANSFER_WRITE
+        let memory_barrier = vk::MemoryBarrier::default()
+            .src_access_mask(vk::AccessFlags::SHADER_WRITE)
+            .dst_access_mask(vk::AccessFlags::TRANSFER_READ | vk::AccessFlags::TRANSFER_WRITE);
+        unsafe {
+            self.device.cmd_pipeline_barrier(
+                cmd,
+                vk::PipelineStageFlags::COMPUTE_SHADER,
+                vk::PipelineStageFlags::TRANSFER,
+                vk::DependencyFlags::empty(),
+                &[memory_barrier],
+                &[],
+                &[],
+            );
+        }
+
+        // Copy current render output to previous frame buffer
+        let copy_size = self.render_output_buffer.size;
+        let region = vk::BufferCopy::default().size(copy_size);
+        unsafe {
+            self.device.cmd_copy_buffer(
+                cmd,
+                self.render_output_buffer.buffer,
+                self.prev_render_output_buffer.buffer,
+                &[region],
+            );
+        }
+
+        // Barrier: ensure the copy finishes before next frame's shader reads
+        let copy_barrier = vk::MemoryBarrier::default()
+            .src_access_mask(vk::AccessFlags::TRANSFER_WRITE)
+            .dst_access_mask(vk::AccessFlags::SHADER_READ);
+        unsafe {
+            self.device.cmd_pipeline_barrier(
+                cmd,
+                vk::PipelineStageFlags::TRANSFER,
+                vk::PipelineStageFlags::COMPUTE_SHADER,
+                vk::DependencyFlags::empty(),
+                &[copy_barrier],
+                &[],
+                &[],
+            );
+        }
+    }
+
     /// Activate a PB-MPM physics zone at the given trigger location.
     ///
     /// Spawns particles from the chunk at the trigger position and starts
@@ -642,6 +1038,9 @@ impl CaSimulation {
             &self.compact_finalize_pass,
             &self.thermal_pass,
             &self.margolus_pass,
+            &self.ca_to_render_pass,
+            &self.render_pass,
+            &self.compute_dirty_tiles_pass,
         ] {
             pipeline::destroy_pipeline(ctx, pass.pipeline);
             pipeline::destroy_pipeline_layout(ctx, pass.pipeline_layout);
@@ -657,6 +1056,14 @@ impl CaSimulation {
 
         buffer::destroy_buffer(ctx, self.material_buffer);
         buffer::destroy_buffer(ctx, self.reaction_buffer);
+        buffer::destroy_buffer(ctx, self.render_voxel_buffer);
+        buffer::destroy_buffer(ctx, self.render_output_buffer);
+        buffer::destroy_buffer(ctx, self.prev_render_output_buffer);
+        buffer::destroy_buffer(ctx, self.brick_occupancy_buffer);
+        buffer::destroy_buffer(ctx, self.super_brick_occupancy_buffer);
+        buffer::destroy_buffer(ctx, self.dirty_tile_buffer);
+        buffer::destroy_buffer(ctx, self.material_render_buffer);
+        buffer::destroy_buffer(ctx, self.sleep_state_buffer);
         self.chunk_pool.destroy(ctx);
 
         tracing::info!("CaSimulation destroyed");
@@ -734,6 +1141,59 @@ pub fn default_ca_reactions() -> Vec<ReactionEntry> {
 }
 
 // ---------------------------------------------------------------------------
+// Material bridge: CA materials -> render MaterialParams
+// ---------------------------------------------------------------------------
+
+/// Convert CA material properties to render-compatible [`MaterialParams`].
+///
+/// The render shader reads `MaterialParams` (4 x Vec4 = 64 bytes each).
+/// This creates a table with appropriate colors for each CA material.
+pub fn ca_materials_to_render_params(
+    ca_mats: &[MaterialPropertiesCA],
+) -> Vec<shared::material::MaterialParams> {
+    use shared::material::MaterialParams;
+
+    // Pre-defined colors per material index
+    let colors: &[(f32, f32, f32)] = &[
+        (0.0, 0.0, 0.0),       // 0 = Air (transparent/black)
+        (0.5, 0.5, 0.5),       // 1 = Stone (gray)
+        (0.76, 0.70, 0.50),    // 2 = Sand (tan)
+        (0.2, 0.4, 0.8),       // 3 = Water (blue)
+        (1.0, 0.3, 0.1),       // 4 = Lava (orange-red)
+        (0.9, 0.9, 0.95),      // 5 = Steam (white-ish)
+        (0.7, 0.85, 1.0),      // 6 = Ice (light blue)
+    ];
+
+    let mut result = Vec::with_capacity(ca_mats.len());
+    for (i, ca) in ca_mats.iter().enumerate() {
+        let (r, g, b) = if i < colors.len() {
+            colors[i]
+        } else {
+            (0.6, 0.6, 0.6) // default gray for unknown materials
+        };
+
+        // Determine emissive temperature (lava glows)
+        let emissive_temp = if i == 4 { 100.0 } else { 10000.0 }; // lava glows, others don't
+
+        // Opacity: air=0, everything else=1
+        let opacity = if i == 0 { 0.0 } else { 1.0 };
+
+        result.push(MaterialParams {
+            elastic: glam::Vec4::new(1000.0, 0.3, 100.0, ca.viscosity as f32),
+            thermal: glam::Vec4::new(
+                ca.melt_temp as f32 * 10.0,
+                ca.boil_temp as f32 * 10.0,
+                ca.conductivity as f32,
+                1.0,
+            ),
+            visual: glam::Vec4::new(ca.density as f32, emissive_temp, opacity, 0.0),
+            color: glam::Vec4::new(r, g, b, 1.0),
+        });
+    }
+    result
+}
+
+// ---------------------------------------------------------------------------
 // Test scene generator
 // ---------------------------------------------------------------------------
 
@@ -808,6 +1268,7 @@ mod tests {
         assert_eq!(mem::size_of::<CaCompactPush>(), 16);
         assert_eq!(mem::size_of::<CaThermalPush>(), 16);
         assert_eq!(mem::size_of::<CaMargolusPush>(), 32);
+        assert_eq!(mem::size_of::<CaToRenderPush>(), 32);
     }
 
     #[test]
@@ -820,6 +1281,20 @@ mod tests {
         // Water
         assert_eq!(mats[3].phase, 2);
         assert_eq!(mats[3].boil_temp, 200);
+    }
+
+    #[test]
+    fn test_ca_materials_to_render_params() {
+        let ca_mats = default_ca_materials();
+        let render_mats = ca_materials_to_render_params(&ca_mats);
+        assert_eq!(render_mats.len(), ca_mats.len());
+        // Air should have zero opacity
+        assert_eq!(render_mats[0].visual.z, 0.0);
+        // Stone should have full opacity and gray color
+        assert_eq!(render_mats[1].visual.z, 1.0);
+        assert!(render_mats[1].color.x > 0.4 && render_mats[1].color.x < 0.6);
+        // Water should be blue
+        assert!(render_mats[3].color.z > 0.7);
     }
 
     #[test]

--- a/crates/shaders/src/compute/ca_to_render.rs
+++ b/crates/shaders/src/compute/ca_to_render.rs
@@ -1,0 +1,199 @@
+//! Compute shader that converts CA chunk voxels into the flat render voxel buffer format.
+//!
+//! This bridge shader reads from the CA gigabuffer (packed u32 voxels per chunk)
+//! and writes into the dense flat voxel buffer that the existing render shader expects.
+//!
+//! ## Voxel buffer layout (4 u32s per cell, matching `voxelize.rs`):
+//!
+//! | Offset | Field | Description |
+//! |--------|-------|-------------|
+//! | 0 | packed_material | `(0xFF << 24) \| (material_id << 16) \| (phase << 8) \| 0xFF` |
+//! | 1 | temperature | f32 reinterpreted as u32 bits |
+//! | 2 | _reserved | unused (zero) |
+//! | 3 | occupied | 1 if non-air, 0 otherwise |
+
+use spirv_std::glam::UVec3;
+use spirv_std::spirv;
+
+/// Push constants for the CA-to-render conversion shader.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct CaToRenderPush {
+    /// Number of loaded chunks to process.
+    pub num_chunks: u32,
+    /// Flat render grid dimension (e.g. 128).
+    pub grid_size: u32,
+    /// World offset of the flat grid origin (X).
+    pub grid_origin_x: i32,
+    /// World offset of the flat grid origin (Y).
+    pub grid_origin_y: i32,
+    /// World offset of the flat grid origin (Z).
+    pub grid_origin_z: i32,
+    /// Padding to 32-byte alignment.
+    pub _pad: [u32; 3],
+}
+
+/// CA voxel bit layout constants (mirroring shared::voxel).
+const MATERIAL_ID_MASK: u32 = 0x3FF; // bits 0-9
+const TEMPERATURE_SHIFT: u32 = 10;
+const TEMPERATURE_MASK: u32 = 0xFF; // bits 10-17
+
+/// Number of voxels per chunk axis.
+const CHUNK_SIZE: u32 = 32;
+/// Total voxels per chunk (32^3).
+const VOXELS_PER_CHUNK: u32 = CHUNK_SIZE * CHUNK_SIZE * CHUNK_SIZE;
+
+/// Number of u32s per voxel in the flat render buffer.
+const U32S_PER_VOXEL: u32 = 4;
+
+/// Metadata stride in u32s. ChunkGpuMeta = 64 bytes = 16 u32s.
+const META_U32S: u32 = 16;
+
+/// Slot stride in u32s. Each slot = 135168 bytes = 33792 u32s.
+/// (32768 voxels * 4 bytes + 4096 bitmask bytes) / 4.
+const SLOT_U32S: u32 = 33792;
+
+/// Extract material_id from a CA voxel.
+fn ca_material_id(voxel: u32) -> u32 {
+    voxel & MATERIAL_ID_MASK
+}
+
+/// Extract temperature from a CA voxel.
+fn ca_temperature(voxel: u32) -> u32 {
+    (voxel >> TEMPERATURE_SHIFT) & TEMPERATURE_MASK
+}
+
+/// Convert one CA voxel to the flat render buffer format and write it.
+///
+/// This helper exists so the entry point is not inlined (rust-gpu trap #4a).
+fn convert_and_write(
+    chunk_idx: u32,
+    local_x: u32,
+    local_y: u32,
+    local_z: u32,
+    push: &CaToRenderPush,
+    chunk_pool: &[u32],
+    metadata: &[u32],
+    render_voxels: &mut [u32],
+    materials: &[u32],
+) {
+    if chunk_idx >= push.num_chunks {
+        return;
+    }
+
+    // Read chunk metadata: world_pos is at offset 0 of the metadata entry (IVec4 = 4 i32s)
+    let meta_base = (chunk_idx * META_U32S) as usize;
+    // world_pos: x, y, z, w=slot_id stored as i32 in the first 4 u32 slots
+    let chunk_wx = metadata[meta_base] as i32;
+    let chunk_wy = metadata[meta_base + 1] as i32;
+    let chunk_wz = metadata[meta_base + 2] as i32;
+    let slot_id = metadata[meta_base + 3];
+
+    // World position of this voxel
+    let wx = chunk_wx * CHUNK_SIZE as i32 + local_x as i32;
+    let wy = chunk_wy * CHUNK_SIZE as i32 + local_y as i32;
+    let wz = chunk_wz * CHUNK_SIZE as i32 + local_z as i32;
+
+    // Convert to flat grid coordinates
+    let gx = wx - push.grid_origin_x;
+    let gy = wy - push.grid_origin_y;
+    let gz = wz - push.grid_origin_z;
+
+    // Bounds check
+    let gs = push.grid_size as i32;
+    if gx < 0 || gy < 0 || gz < 0 || gx >= gs || gy >= gs || gz >= gs {
+        return;
+    }
+
+    // Read CA voxel from chunk pool using slot_id
+    // Each slot = SLOT_U32S u32s, voxel data is at the start of the slot
+    let voxel_offset = slot_id * SLOT_U32S;
+    let local_idx = local_z * CHUNK_SIZE * CHUNK_SIZE + local_y * CHUNK_SIZE + local_x;
+    let ca_voxel = chunk_pool[(voxel_offset + local_idx) as usize];
+
+    let mat_id = ca_material_id(ca_voxel);
+
+    // Flat grid index
+    let flat_idx = (gz as u32 * push.grid_size * push.grid_size
+        + gy as u32 * push.grid_size
+        + gx as u32) as usize;
+    let base = flat_idx * U32S_PER_VOXEL as usize;
+
+    if mat_id == 0 {
+        // Air: write zeros
+        render_voxels[base] = 0;
+        render_voxels[base + 1] = 0;
+        render_voxels[base + 2] = 0;
+        render_voxels[base + 3] = 0;
+        return;
+    }
+
+    let temp = ca_temperature(ca_voxel);
+
+    // Look up phase from material table
+    // MaterialPropertiesCA is 64 bytes = 16 u32s; phase is the first u32
+    let mat_table_base = (mat_id * 16) as usize;
+    let phase = if mat_table_base < materials.len() {
+        materials[mat_table_base]
+    } else {
+        0
+    };
+
+    // Pack material: (0xFF << 24) | (material_id << 16) | (phase << 8) | 0xFF
+    let packed_material = (0xFF << 24) | ((mat_id & 0xFF) << 16) | ((phase & 0xFF) << 8) | 0xFF;
+
+    // Temperature as f32 bits (scale from 0-255 game units to a reasonable range)
+    let temp_f32 = temp as f32 * 10.0; // Scale up for render shader
+    let temp_bits = temp_f32.to_bits();
+
+    render_voxels[base] = packed_material;
+    render_voxels[base + 1] = temp_bits;
+    render_voxels[base + 2] = 0;
+    render_voxels[base + 3] = 1; // occupied
+}
+
+/// Compute shader entry point: convert CA chunk voxels to flat render voxel buffer.
+///
+/// Each workgroup processes a 4x4x4 region within a chunk.
+/// Dispatch with `(num_chunks * 8, 8, 8)` workgroups (8 WGs per axis for 32^3 / 4^3).
+///
+/// Descriptor set 0:
+/// - binding 0: chunk_pool voxel buffer (CA format, read)
+/// - binding 1: chunk metadata buffer (read)
+/// - binding 2: flat render voxel buffer (write)
+/// - binding 3: CA material table (read)
+///
+/// Push constants: `CaToRenderPush`.
+#[spirv(compute(threads(4, 4, 4)))]
+pub fn ca_to_render(
+    #[spirv(global_invocation_id)] global_id: UVec3,
+    #[spirv(push_constant)] push: &CaToRenderPush,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] chunk_pool: &[u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] metadata: &[u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] render_voxels: &mut [u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] materials: &[u32],
+) {
+    // global_id.x covers all chunks * 32 voxels in X
+    // Determine which chunk and local position
+    let total_x = global_id.x;
+    let chunk_idx = total_x / CHUNK_SIZE;
+    let local_x = total_x % CHUNK_SIZE;
+    let local_y = global_id.y;
+    let local_z = global_id.z;
+
+    if local_y >= CHUNK_SIZE || local_z >= CHUNK_SIZE {
+        return;
+    }
+
+    convert_and_write(
+        chunk_idx,
+        local_x,
+        local_y,
+        local_z,
+        push,
+        chunk_pool,
+        metadata,
+        render_voxels,
+        materials,
+    );
+}

--- a/crates/shaders/src/compute/mod.rs
+++ b/crates/shaders/src/compute/mod.rs
@@ -12,6 +12,7 @@
 pub mod ca_compact;
 pub mod ca_margolus;
 pub mod ca_thermal;
+pub mod ca_to_render;
 pub mod clear_grid;
 pub mod clear_grid_sparse;
 pub mod clear_hash_grid;


### PR DESCRIPTION
## Summary
- Adds `--sim2` CLI flag to run CaSimulation instead of GpuSimulation
- New `ca_to_render` compute shader converts CA chunk voxels into the flat render buffer format (UVec4 per cell)
- Reuses the entire existing ray-march render pipeline for immediate visual parity
- `ca_materials_to_render_params()` maps CA materials to render-compatible MaterialParams with colors
- Test scene: 4x2x4 chunks (128x64x128 voxels) with stone floor, sand pile, water pool, and lava source

## Architecture
```
CA Chunks (gigabuffer) --> [ca_to_render shader] --> Flat Voxel Buffer (128^3)
                                                          |
                                                    [existing render shader]
                                                          |
                                                    BGRA pixel output --> Swapchain
```

## Test plan
- [x] `cargo build` succeeds
- [x] Push constant size tests pass
- [x] `ca_materials_to_render_params` unit test passes
- [ ] `cargo run -p app -- --sim2` launches and shows CA test scene
- [ ] Camera movement works (WASD + mouse)
- [ ] CA simulation steps visibly (sand/water/lava should move)

## Usage
```bash
cargo run -p app -- --sim2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)