### PR TITLE
[sim2] Terrain scene, explosions, and material spawning for CA demo

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -13,8 +13,11 @@ use content::MaterialDatabase;
 use glam::Vec3;
 use gpu_core::VulkanContext;
 use server::{GpuSimulation, ToolbarPushConstants, TOOLBAR_MAX_MATERIALS};
-use server::ca_simulation::{CaSimulation, CA_RENDER_GRID_SIZE};
+use server::ca_simulation::CaSimulation;
+use server::pbmpm_zones::ActivationTrigger;
 use shared::{GRID_SIZE, PHASE_LIQUID, Particle, RENDER_HEIGHT, RENDER_WIDTH};
+use shared::constants::CA_CHUNK_SIZE;
+use shared::voxel::Voxel;
 use winit::{
     application::ApplicationHandler,
     event::{DeviceEvent, DeviceId, ElementState, MouseButton, WindowEvent},
@@ -24,7 +27,7 @@ use winit::{
 };
 
 use crate::scene::{
-    MaterialSlot, create_island_particles, create_mountain_particles,
+    MaterialSlot, ca_material_palette, create_island_particles, create_mountain_particles,
     generate_heightmap, generate_mountain_heightmap, material_palette, spawn_cell,
 };
 
@@ -229,7 +232,7 @@ impl App {
             last_frame_time: Instant::now(),
             substeps,
             selected_material: 0,
-            palette: material_palette(),
+            palette: if use_ca_sim { ca_material_palette() } else { material_palette() },
             pending_explosion: None,
             material_db,
             last_react_time: Instant::now(),
@@ -360,6 +363,122 @@ impl App {
         }
     }
 
+    /// Spawn a cluster of CA voxels of the selected material in front of the camera.
+    fn ca_spawn_voxels(&mut self) {
+        let ca_mat_id = self.ca_palette_material_id();
+        let temp: u8 = if ca_mat_id == 4 { 250 } else { 128 };
+        let center = self.player.camera.eye() + self.player.camera.forward() * SPAWN_DISTANCE;
+
+        let (ctx, ca_sim) = match (self.ctx.as_ref(), self.ca_sim.as_mut()) {
+            (Some(c), Some(s)) => (c, s),
+            _ => return,
+        };
+        let wx = center.x as i32;
+        let wy = center.y as i32;
+        let wz = center.z as i32;
+        let cs = CA_CHUNK_SIZE as i32;
+
+        let chunk_coord = [wx.div_euclid(cs), wy.div_euclid(cs), wz.div_euclid(cs)];
+        let mut data = match ca_sim.download_chunk(ctx, chunk_coord) {
+            Ok(d) => d,
+            Err(e) => {
+                tracing::debug!("Cannot spawn CA voxels: {}", e);
+                return;
+            }
+        };
+
+        let lx = wx.rem_euclid(cs) as usize;
+        let ly = wy.rem_euclid(cs) as usize;
+        let lz = wz.rem_euclid(cs) as usize;
+
+        // Place a 3x3x3 cube of material
+        for dz in 0..3i32 {
+            for dy in 0..3i32 {
+                for dx in 0..3i32 {
+                    let px = (lx as i32 + dx).clamp(0, 31) as usize;
+                    let py = (ly as i32 + dy).clamp(0, 31) as usize;
+                    let pz = (lz as i32 + dz).clamp(0, 31) as usize;
+                    let idx = pz * 32 * 32 + py * 32 + px;
+                    data[idx] = Voxel::new(ca_mat_id, temp, 0, 15, 0).0;
+                }
+            }
+        }
+
+        if let Err(e) = ca_sim.upload_chunk_voxels(ctx, chunk_coord, &data) {
+            tracing::warn!("Failed to upload CA voxels: {}", e);
+        } else {
+            tracing::debug!("Spawned CA material {} at chunk {:?}", ca_mat_id, chunk_coord);
+        }
+    }
+
+    /// Remove CA voxels (set to air) in front of the camera.
+    fn ca_remove_voxels(&mut self) {
+        let (ctx, ca_sim) = match (self.ctx.as_ref(), self.ca_sim.as_mut()) {
+            (Some(c), Some(s)) => (c, s),
+            _ => return,
+        };
+        let center = self.player.camera.eye() + self.player.camera.forward() * SPAWN_DISTANCE;
+        let wx = center.x as i32;
+        let wy = center.y as i32;
+        let wz = center.z as i32;
+        let cs = CA_CHUNK_SIZE as i32;
+
+        let chunk_coord = [wx.div_euclid(cs), wy.div_euclid(cs), wz.div_euclid(cs)];
+        let mut data = match ca_sim.download_chunk(ctx, chunk_coord) {
+            Ok(d) => d,
+            Err(e) => {
+                tracing::debug!("Cannot remove CA voxels: {}", e);
+                return;
+            }
+        };
+
+        let lx = wx.rem_euclid(cs) as usize;
+        let ly = wy.rem_euclid(cs) as usize;
+        let lz = wz.rem_euclid(cs) as usize;
+
+        // Clear a 3x3x3 cube to air
+        for dz in 0..3i32 {
+            for dy in 0..3i32 {
+                for dx in 0..3i32 {
+                    let px = (lx as i32 + dx).clamp(0, 31) as usize;
+                    let py = (ly as i32 + dy).clamp(0, 31) as usize;
+                    let pz = (lz as i32 + dz).clamp(0, 31) as usize;
+                    let idx = pz * 32 * 32 + py * 32 + px;
+                    data[idx] = Voxel::air().0;
+                }
+            }
+        }
+
+        if let Err(e) = ca_sim.upload_chunk_voxels(ctx, chunk_coord, &data) {
+            tracing::warn!("Failed to upload CA voxels (remove): {}", e);
+        } else {
+            tracing::debug!("Removed CA voxels at chunk {:?}", chunk_coord);
+        }
+    }
+
+    /// Trigger a PB-MPM physics zone explosion in the CA simulation.
+    fn ca_trigger_explosion(&mut self) {
+        let center = self.player.camera.eye() + self.player.camera.forward() * SPAWN_DISTANCE;
+        self.pending_explosion = Some([center.x, center.y, center.z]);
+        tracing::info!("CA explosion at [{:.1}, {:.1}, {:.1}]", center.x, center.y, center.z);
+    }
+
+    /// Map selected_material index to a CA material ID.
+    ///
+    /// CA materials: 0=air, 1=stone, 2=sand, 3=water, 4=lava, 5=steam, 6=ice.
+    fn ca_palette_material_id(&self) -> u16 {
+        // Palette: 0=Stone(1), 1=Water(3), 2=Lava(4), 3=Sand(2), 4=Ice(6), 5=Wood(7)
+        match self.selected_material {
+            0 => 1,  // Stone
+            1 => 3,  // Water
+            2 => 4,  // Lava
+            3 => 2,  // Sand
+            4 => 6,  // Ice
+            5 => 7,  // Wood (if exists)
+            _ => 1,  // Default to stone
+        }
+    }
+
     /// Apply keyboard-driven movement to the player controller.
     fn update_movement(&mut self, dt: f32) {
         let keys: Vec<PhysicalKey> = self.pressed_keys.iter().copied().collect();
@@ -412,11 +531,11 @@ impl ApplicationHandler for App {
             }
             tracing::info!("CaSimulation initialized with {} chunks", ca_sim.loaded_count());
 
-            // Place camera to look at the center of the test scene
-            let gs = CA_RENDER_GRID_SIZE as f32;
+            // Place camera above and behind the terrain, looking at the center
+            // Terrain center is at (64, ~40, 64), volcano peak around y=90
             self.player = PlayerController::new(Camera::look_at(
-                Vec3::new(gs * 0.75, gs * 0.4, gs * 0.75),
-                Vec3::new(gs * 0.5, gs * 0.3, gs * 0.5),
+                Vec3::new(64.0, 80.0, -20.0),
+                Vec3::new(64.0, 30.0, 64.0),
             ));
 
             self.ca_sim = Some(ca_sim);
@@ -503,7 +622,16 @@ impl ApplicationHandler for App {
             WindowEvent::MouseInput { state: ElementState::Pressed, button, .. } => {
                 if !self.cursor_captured {
                     self.capture_cursor();
+                } else if self.ca_sim.is_some() {
+                    // CA simulation (--sim2) interactions
+                    match button {
+                        MouseButton::Left => self.ca_spawn_voxels(),
+                        MouseButton::Right => self.ca_remove_voxels(),
+                        MouseButton::Middle => self.ca_trigger_explosion(),
+                        _ => {}
+                    }
                 } else {
+                    // Standard MPM simulation interactions
                     match button {
                         MouseButton::Left => self.spawn_particles(),
                         MouseButton::Right => self.remove_particles(),
@@ -551,6 +679,18 @@ impl ApplicationHandler for App {
                 if let (Some(renderer), Some(ctx)) = (self.renderer.as_mut(), self.ctx.as_ref()) {
                     // --- CA simulation path (--sim2) ---
                     if let Some(ref mut ca_sim) = self.ca_sim {
+                        // Handle pending explosion via PB-MPM zone activation
+                        if let Some(explosion_pos) = explosion {
+                            let trigger = ActivationTrigger {
+                                center: explosion_pos,
+                                radius: EXPLOSION_RADIUS,
+                                impulse: EXPLOSION_STRENGTH,
+                            };
+                            if let Err(e) = ca_sim.activate_physics_zone(ctx, trigger) {
+                                tracing::warn!("Failed to activate physics zone: {}", e);
+                            }
+                        }
+
                         if let Err(e) = ctx.execute_one_shot(|cmd| {
                             for _ in 0..substeps { ca_sim.step(cmd, ctx); }
                             ca_sim.render(cmd, RENDER_WIDTH, RENDER_HEIGHT, eye_arr, target_arr);

--- a/crates/app/src/scene.rs
+++ b/crates/app/src/scene.rs
@@ -80,6 +80,49 @@ pub(crate) fn material_palette() -> Vec<MaterialSlot> {
     ]
 }
 
+/// Build the material palette for CA simulation (--sim2 mode).
+///
+/// Maps to CA material IDs: 1=stone, 2=sand, 3=water, 4=lava, 6=ice.
+pub(crate) fn ca_material_palette() -> Vec<MaterialSlot> {
+    vec![
+        MaterialSlot {
+            name: "Stone",
+            mat_id: 1,
+            phase: PHASE_SOLID,
+            temperature: 0.0,
+            color: glam::Vec4::new(0.5, 0.5, 0.5, 1.0),
+        },
+        MaterialSlot {
+            name: "Water",
+            mat_id: 3,
+            phase: PHASE_LIQUID,
+            temperature: 0.0,
+            color: glam::Vec4::new(0.2, 0.4, 0.9, 1.0),
+        },
+        MaterialSlot {
+            name: "Lava",
+            mat_id: 4,
+            phase: PHASE_LIQUID,
+            temperature: 2000.0,
+            color: glam::Vec4::new(1.0, 0.3, 0.0, 1.0),
+        },
+        MaterialSlot {
+            name: "Sand",
+            mat_id: 2,
+            phase: PHASE_SOLID,
+            temperature: 0.0,
+            color: glam::Vec4::new(0.76, 0.70, 0.50, 1.0),
+        },
+        MaterialSlot {
+            name: "Ice",
+            mat_id: 6,
+            phase: PHASE_SOLID,
+            temperature: -50.0,
+            color: glam::Vec4::new(0.7, 0.85, 0.95, 1.0),
+        },
+    ]
+}
+
 /// Compute terrain height at a given (x, z) world position.
 ///
 /// Uses multi-octave sine-based noise combined with island falloff to produce

--- a/crates/server/src/ca_simulation.rs
+++ b/crates/server/src/ca_simulation.rs
@@ -1018,6 +1018,24 @@ impl CaSimulation {
         Ok(self.chunk_pool.download_chunk_voxels(ctx, slot_id)?)
     }
 
+    /// Re-upload modified voxel data for a loaded chunk.
+    ///
+    /// `voxel_data` must contain exactly `CA_CHUNK_VOXELS` u32 values.
+    pub fn upload_chunk_voxels(
+        &self,
+        ctx: &VulkanContext,
+        coord: [i32; 3],
+        voxel_data: &[u32],
+    ) -> anyhow::Result<()> {
+        let slot_id = *self
+            .loaded_chunks
+            .get(&coord)
+            .ok_or_else(|| anyhow::anyhow!("chunk not loaded at {:?}", coord))?;
+        self.chunk_pool
+            .upload_chunk_voxels(ctx, vk::CommandBuffer::null(), slot_id, voxel_data)?;
+        Ok(())
+    }
+
     /// Number of loaded chunks.
     pub fn loaded_count(&self) -> usize {
         self.loaded_chunks.len()
@@ -1197,46 +1215,132 @@ pub fn ca_materials_to_render_params(
 // Test scene generator
 // ---------------------------------------------------------------------------
 
-/// Generate a simple test scene: stone floor + sand + water pool + lava.
+/// Simple hash-based noise for terrain generation.
+fn noise2d(x: usize, z: usize) -> f32 {
+    let n = (x as u32).wrapping_mul(374761393)
+        .wrapping_add((z as u32).wrapping_mul(668265263));
+    let n = n ^ (n >> 13);
+    let n = n.wrapping_mul(n.wrapping_mul(n.wrapping_mul(60493)).wrapping_add(19990303));
+    let n = n ^ (n >> 16);
+    (n as f32) / (u32::MAX as f32)
+}
+
+/// Smoothed noise with interpolation for terrain.
+fn smooth_noise(x: f32, z: f32) -> f32 {
+    let ix = x.floor() as usize;
+    let iz = z.floor() as usize;
+    let fx = x - x.floor();
+    let fz = z - z.floor();
+
+    // Smoothstep
+    let fx = fx * fx * (3.0 - 2.0 * fx);
+    let fz = fz * fz * (3.0 - 2.0 * fz);
+
+    let n00 = noise2d(ix, iz);
+    let n10 = noise2d(ix + 1, iz);
+    let n01 = noise2d(ix, iz + 1);
+    let n11 = noise2d(ix + 1, iz + 1);
+
+    let nx0 = n00 + (n10 - n00) * fx;
+    let nx1 = n01 + (n11 - n01) * fx;
+    nx0 + (nx1 - nx0) * fz
+}
+
+/// Multi-octave terrain height at world (x, z).
+fn terrain_height(wx: usize, wz: usize) -> usize {
+    let x = wx as f32;
+    let z = wz as f32;
+
+    // Base terrain: rolling hills
+    let mut h = 0.0f32;
+    h += smooth_noise(x * 0.02, z * 0.02) * 40.0;   // large hills
+    h += smooth_noise(x * 0.05, z * 0.05) * 15.0;   // medium detail
+    h += smooth_noise(x * 0.1, z * 0.1) * 5.0;      // small bumps
+
+    // Add a volcano/mountain in the center
+    let cx = 64.0f32;
+    let cz = 64.0f32;
+    let dist_to_center = ((x - cx) * (x - cx) + (z - cz) * (z - cz)).sqrt();
+    if dist_to_center < 30.0 {
+        let volcano = (1.0 - dist_to_center / 30.0) * 50.0;
+        h += volcano;
+    }
+    // Volcano crater at the very top
+    if dist_to_center < 8.0 {
+        h -= (1.0 - dist_to_center / 8.0) * 15.0;
+    }
+
+    let base_height = 20;
+    (h as usize).saturating_add(base_height).min(120)
+}
+
+/// Generate a voxel at world position (wx, wy, wz) given terrain height.
+fn generate_voxel(wx: usize, wy: usize, wz: usize, height: usize) -> Voxel {
+    let water_level = 35;
+
+    let cx = 64.0f32;
+    let cz = 64.0f32;
+    let dist_to_center = (((wx as f32) - cx).powi(2) + ((wz as f32) - cz).powi(2)).sqrt();
+
+    if wy > height && wy > water_level {
+        return Voxel::air();
+    }
+
+    // Lava in volcano crater
+    if dist_to_center < 6.0 && wy > height.saturating_sub(3) && wy <= height {
+        return Voxel::new(4, 250, 0, 0, 0);
+    }
+
+    // Water fills below water level
+    if wy > height && wy <= water_level {
+        return Voxel::new(3, 128, 0, 10, 0);
+    }
+
+    // Surface layer
+    if wy == height {
+        if wy < water_level + 2 && wy >= water_level.saturating_sub(1) {
+            // Beach sand near water
+            return Voxel::new(2, 128, 0, 15, 0);
+        }
+        // Normal surface: stone with bonds
+        return Voxel::new(1, 128, 0b111111, 15, 0);
+    }
+
+    // Below surface
+    if wy < height {
+        return Voxel::new(1, 128, 0b111111, 15, 0);
+    }
+
+    Voxel::air()
+}
+
+/// Generate a terrain-based test scene filling the full 128x128x128 render grid.
 ///
-/// Returns chunks as `(coord, voxel_data)` pairs for a 4x2x4 grid
-/// (128x64x128 voxels).
+/// Features: rolling hills, a volcano with lava crater in the center,
+/// water filling low areas, sand beaches near the waterline.
+/// Returns chunks as `(coord, voxel_data)` pairs for a 4x4x4 grid
+/// (128x128x128 voxels).
 pub fn generate_test_scene() -> Vec<([i32; 3], Vec<u32>)> {
     let mut chunks = Vec::new();
 
+    // Generate 4x4x4 = 64 chunks covering 128x128x128 voxels
     for cx in 0..4i32 {
-        for cy in 0..2i32 {
+        for cy in 0..4i32 {
             for cz in 0..4i32 {
                 let mut data = vec![0u32; CA_CHUNK_VOXELS];
-                let base_y = cy as usize * 32;
 
                 for lz in 0..32usize {
-                    for ly in 0..32usize {
-                        for lx in 0..32usize {
-                            let wy = base_y + ly;
+                    for lx in 0..32usize {
+                        let wx = cx as usize * 32 + lx;
+                        let wz = cz as usize * 32 + lz;
+
+                        let height = terrain_height(wx, wz);
+
+                        for ly in 0..32usize {
+                            let wy = cy as usize * 32 + ly;
                             let idx = lz * 32 * 32 + ly * 32 + lx;
 
-                            let voxel = if wy < 4 {
-                                // Stone floor
-                                Voxel::new(1, 128, 0b111111, 15, 0)
-                            } else if wy < 8 && cx == 1 && cz == 1 {
-                                // Sand pile in center
-                                Voxel::new(2, 128, 0, 15, 0)
-                            } else if wy >= 4 && wy < 10 && cx == 2 && cz == 2 {
-                                // Water pool
-                                Voxel::new(3, 128, 0, 10, 0)
-                            } else if wy == 8
-                                && cx == 0
-                                && cz == 0
-                                && lx < 4
-                                && lz < 4
-                            {
-                                // Small lava source
-                                Voxel::new(4, 250, 0, 0, 0)
-                            } else {
-                                Voxel::air()
-                            };
-
+                            let voxel = generate_voxel(wx, wy, wz, height);
                             data[idx] = voxel.0;
                         }
                     }
@@ -1308,17 +1412,17 @@ mod tests {
     #[test]
     fn test_generate_test_scene() {
         let scene = generate_test_scene();
-        // 4x2x4 = 32 chunks
-        assert_eq!(scene.len(), 32);
+        // 4x4x4 = 64 chunks
+        assert_eq!(scene.len(), 64);
         // Each chunk has CA_CHUNK_VOXELS voxels
         for (_, data) in &scene {
             assert_eq!(data.len(), CA_CHUNK_VOXELS);
         }
-        // First chunk (0,0,0) should have stone floor at y<4
+        // First chunk (0,0,0) should have stone underground
         let (_, data) = &scene[0]; // (0,0,0)
         // Voxel at (0, 0, 0) -> index 0*32*32 + 0*32 + 0 = 0
         let v = Voxel(data[0]);
-        assert_eq!(v.material_id(), 1); // stone
+        assert_eq!(v.material_id(), 1); // stone (underground)
     }
 
     // --- GPU tests (require VulkanContext, run with --test-threads=1) ---


### PR DESCRIPTION
## Summary
- Replace flat test scene with terrain-based 128^3 world (4x4x4 chunks) featuring rolling hills, a volcano with lava crater, water-filled lowlands, and sand beaches
- Wire up player interactions in --sim2 mode: left-click spawns voxels, right-click removes them, middle-click triggers PB-MPM physics zone explosion
- Add `upload_chunk_voxels` method to CaSimulation for voxel modification after download
- Add CA-specific material palette (Stone, Water, Lava, Sand, Ice) mapped to CA material IDs
- Reposition camera to overlook terrain from above

## Test plan
- [ ] `cargo build` passes
- [ ] `cargo test -p server test_generate_test_scene` passes (64 chunks, correct voxels)
- [ ] `cargo run -p app -- --sim2` shows terrain with volcano, water, and sand
- [ ] Left-click places selected material voxels
- [ ] Right-click removes voxels (sets to air)
- [ ] Middle-click triggers explosion via PB-MPM zone activation
- [ ] Number keys / scroll wheel switch materials in the CA palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)