### PR TITLE
fix: GPU column-scan gravity + thermal air temp fix

### DIFF
--- a/crates/server/src/ca_simulation.rs
+++ b/crates/server/src/ca_simulation.rs
@@ -37,6 +37,9 @@ const THERMAL_WG_PER_CHUNK: u32 = 512;
 /// Workgroups per chunk for Margolus pass: 4x4x4 = 64.
 const MARGOLUS_WG_PER_CHUNK: u32 = 64;
 
+/// Workgroups per chunk for gravity pass: 32/8 = 4 per axis, 4*4 = 16.
+const GRAVITY_WG_PER_CHUNK: u32 = 16;
+
 // ---------------------------------------------------------------------------
 // Push constant structs (mirroring shader-side definitions)
 // ---------------------------------------------------------------------------
@@ -78,6 +81,16 @@ pub struct CaMargolusPush {
     /// Number of active reactions.
     pub num_reactions: u32,
     /// Padding to 32-byte alignment.
+    pub _pad: [u32; 3],
+}
+
+/// Push constants for the CA gravity pass.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct CaGravityPush {
+    /// Current frame number.
+    pub frame_number: u32,
+    /// Padding to 16-byte alignment.
     pub _pad: [u32; 3],
 }
 
@@ -127,6 +140,7 @@ pub struct CaSimulation {
     compact_finalize_pass: ComputePass,
     thermal_pass: ComputePass,
     margolus_pass: ComputePass,
+    gravity_pass: ComputePass,
 
     // Shader module (kept alive for pipeline lifetime)
     shader_module: vk::ShaderModule,
@@ -216,10 +230,10 @@ impl CaSimulation {
         // ca_to_render: 4, render: 7, compute_dirty_tiles: 2 = 26 total
         let pool_sizes = [vk::DescriptorPoolSize {
             ty: vk::DescriptorType::STORAGE_BUFFER,
-            descriptor_count: 32, // headroom for all passes
+            descriptor_count: 36, // headroom for all passes
         }];
         let descriptor_pool =
-            pipeline::create_descriptor_pool(ctx, &pool_sizes, 7, "ca-descriptor-pool")?;
+            pipeline::create_descriptor_pool(ctx, &pool_sizes, 8, "ca-descriptor-pool")?;
 
         // 6. Create compute passes
 
@@ -284,6 +298,22 @@ impl CaSimulation {
             mem::size_of::<CaMargolusPush>() as u32,
             descriptor_pool,
             "ca-margolus",
+        )?;
+
+        // gravity pass: binding 0 = voxel_buffer, 1 = metadata, 2 = dirty_list, 3 = materials
+        let gravity_pass = passes::create_pass(
+            ctx,
+            shader_module,
+            c"compute::ca_gravity::ca_gravity",
+            &[
+                chunk_pool.voxel_buffer(),
+                chunk_pool.metadata_buffer(),
+                chunk_pool.dirty_list_buffer(),
+                &material_buffer,
+            ],
+            mem::size_of::<CaGravityPush>() as u32,
+            descriptor_pool,
+            "ca-gravity",
         )?;
 
         // 7. Create render bridge buffers
@@ -448,6 +478,7 @@ impl CaSimulation {
             compact_finalize_pass,
             thermal_pass,
             margolus_pass,
+            gravity_pass,
             shader_module,
             descriptor_pool,
             pbmpm,
@@ -472,7 +503,8 @@ impl CaSimulation {
     /// Record one CA simulation step into the given command buffer.
     ///
     /// Dispatches: compact -> finalize(thermal) -> thermal(indirect) ->
-    /// finalize(margolus) -> margolus_even(indirect) -> margolus_odd(indirect).
+    /// finalize(margolus) -> margolus_even(indirect) -> margolus_odd(indirect) ->
+    /// finalize(gravity) -> gravity(indirect).
     pub fn step(&mut self, cmd: vk::CommandBuffer, _ctx: &VulkanContext) {
         let total_loaded = self.loaded_chunks.len() as u32;
         if total_loaded == 0 {
@@ -680,6 +712,75 @@ impl CaSimulation {
                 vk::ShaderStageFlags::COMPUTE,
                 0,
                 bytemuck::bytes_of(&margolus_odd_push),
+            );
+        }
+        pipeline::cmd_dispatch_indirect(
+            &self.device,
+            cmd,
+            self.chunk_pool.dirty_list_buffer(),
+            4,
+        );
+        passes::barrier(cmd, &self.device);
+
+        // 8. Re-finalize for gravity (wg_per_chunk = 16)
+        let finalize_gravity_push = CaCompactPush {
+            total_chunks: total_loaded,
+            workgroups_per_chunk: GRAVITY_WG_PER_CHUNK,
+            _pad: [0; 2],
+        };
+        passes::dispatch(
+            &self.device,
+            cmd,
+            &self.compact_finalize_pass,
+            1,
+            1,
+            1,
+            bytemuck::bytes_of(&finalize_gravity_push),
+        );
+
+        // Barrier: compute -> indirect + compute
+        let indirect_barrier_gravity = vk::MemoryBarrier::default()
+            .src_access_mask(vk::AccessFlags::SHADER_WRITE)
+            .dst_access_mask(
+                vk::AccessFlags::INDIRECT_COMMAND_READ | vk::AccessFlags::SHADER_READ,
+            );
+        unsafe {
+            self.device.cmd_pipeline_barrier(
+                cmd,
+                vk::PipelineStageFlags::COMPUTE_SHADER,
+                vk::PipelineStageFlags::DRAW_INDIRECT | vk::PipelineStageFlags::COMPUTE_SHADER,
+                vk::DependencyFlags::empty(),
+                &[indirect_barrier_gravity],
+                &[],
+                &[],
+            );
+        }
+
+        // 9. Dispatch gravity pass (INDIRECT)
+        let gravity_push = CaGravityPush {
+            frame_number: self.frame_number,
+            _pad: [0; 3],
+        };
+        unsafe {
+            self.device.cmd_bind_pipeline(
+                cmd,
+                vk::PipelineBindPoint::COMPUTE,
+                self.gravity_pass.pipeline,
+            );
+            self.device.cmd_bind_descriptor_sets(
+                cmd,
+                vk::PipelineBindPoint::COMPUTE,
+                self.gravity_pass.pipeline_layout,
+                0,
+                &[self.gravity_pass.descriptor_set],
+                &[],
+            );
+            self.device.cmd_push_constants(
+                cmd,
+                self.gravity_pass.pipeline_layout,
+                vk::ShaderStageFlags::COMPUTE,
+                0,
+                bytemuck::bytes_of(&gravity_push),
             );
         }
         pipeline::cmd_dispatch_indirect(
@@ -1206,6 +1307,7 @@ impl CaSimulation {
             &self.compact_finalize_pass,
             &self.thermal_pass,
             &self.margolus_pass,
+            &self.gravity_pass,
             &self.ca_to_render_pass,
             &self.render_pass,
             &self.compute_dirty_tiles_pass,

--- a/crates/shaders/src/ca_types.rs
+++ b/crates/shaders/src/ca_types.rs
@@ -49,6 +49,9 @@ pub const THERMAL_WG_PER_CHUNK: u32 = 512;
 /// Workgroups per chunk for Margolus pass (16^3 blocks / 64 threads = 64).
 pub const MARGOLUS_WG_PER_CHUNK: u32 = 64;
 
+/// Workgroups per chunk for gravity pass (32/8 = 4 per axis, 4*4 = 16).
+pub const GRAVITY_WG_PER_CHUNK: u32 = 16;
+
 // ---- Voxel pack/unpack (must match shared::voxel::Voxel bit layout) ----
 
 /// Extracts the material ID (bits 0-9) from a packed voxel.

--- a/crates/shaders/src/compute/ca_gravity.rs
+++ b/crates/shaders/src/compute/ca_gravity.rs
@@ -1,0 +1,171 @@
+//! Column-scan gravity compute shader for the CA substrate.
+//!
+//! Scans each (x, z) column within dirty chunks and drops non-solid voxels
+//! down through air gaps. Processes entire columns for fast multi-voxel falling,
+//! unlike Margolus which only moves 1 voxel per step within 2x2x2 blocks.
+//!
+//! Workgroup layout: (8, 1, 8) = 64 threads per workgroup.
+//! Each thread processes one column (x, z) within a chunk.
+//! 32/8 = 4 workgroups per axis -> 4*4 = 16 workgroups per chunk.
+//! Dispatched indirectly: X = dirty_count * 16, Y = 1, Z = 1.
+
+use spirv_std::glam::UVec3;
+use spirv_std::spirv;
+
+use crate::ca_types;
+
+/// Push constants for the gravity pass.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct CaGravityPush {
+    /// Current frame number.
+    pub frame_number: u32,
+    /// Padding to 16-byte alignment.
+    pub _pad: [u32; 3],
+}
+
+/// Dirty list header size in u32s: [dirty_count, dispatch_x, dispatch_y, dispatch_z].
+const DIRTY_LIST_HEADER: u32 = 4;
+
+/// Reads a voxel from the chunk pool. Returns 0 (air) for out-of-bounds.
+fn read_voxel(chunk_pool: &[u32], slot_id: u32, x: u32, y: u32, z: u32) -> u32 {
+    if y >= ca_types::CA_CHUNK_SIZE {
+        return 0;
+    }
+    let addr = ca_types::voxel_addr(slot_id, x, y, z);
+    chunk_pool[addr as usize]
+}
+
+/// Writes a voxel to the chunk pool.
+fn write_voxel(chunk_pool: &mut [u32], slot_id: u32, x: u32, y: u32, z: u32, voxel: u32) {
+    let addr = ca_types::voxel_addr(slot_id, x, y, z);
+    chunk_pool[addr as usize] = voxel;
+}
+
+/// Checks if a voxel can fall (phase >= 1: powder, liquid, gas).
+fn can_fall(materials: &[u32], voxel: u32) -> bool {
+    let mat_id = ca_types::voxel_material_id(voxel);
+    if mat_id == 0 {
+        return false;
+    }
+    let phase = ca_types::mat_phase(materials, mat_id);
+    phase >= 1
+}
+
+/// Performs one bottom-to-top sweep of a column, dropping non-solid voxels into air below.
+///
+/// Returns true if any swap occurred.
+fn sweep_column(
+    chunk_pool: &mut [u32],
+    materials: &[u32],
+    slot_id: u32,
+    x: u32,
+    z: u32,
+) -> bool {
+    let mut swapped = false;
+    let mut y: u32 = 0;
+    loop {
+        if y >= 31 {
+            return swapped;
+        }
+        let here = read_voxel(chunk_pool, slot_id, x, y, z);
+        let above = read_voxel(chunk_pool, slot_id, x, y + 1, z);
+
+        // Copy to locals to check (trap #21)
+        let here_mat = ca_types::voxel_material_id(here);
+        let fall = can_fall(materials, above);
+
+        if here_mat == 0 && fall {
+            write_voxel(chunk_pool, slot_id, x, y, z, above);
+            write_voxel(chunk_pool, slot_id, x, y + 1, z, here);
+            swapped = true;
+        }
+
+        y += 1;
+    }
+}
+
+/// Processes one column with multiple passes for faster cascading.
+fn process_column(
+    chunk_pool: &mut [u32],
+    materials: &[u32],
+    slot_id: u32,
+    x: u32,
+    z: u32,
+) {
+    // 4 passes to allow voxels to fall up to 4 cells per dispatch
+    let mut pass: u32 = 0;
+    loop {
+        if pass >= 4 {
+            return;
+        }
+        let did_swap = sweep_column(chunk_pool, materials, slot_id, x, z);
+        if !did_swap {
+            return;
+        }
+        pass += 1;
+    }
+}
+
+/// Main gravity logic: maps thread to chunk + column, then processes.
+fn gravity_impl(
+    wg_id: UVec3,
+    local_id: UVec3,
+    chunk_pool: &mut [u32],
+    dirty_list: &[u32],
+    materials: &[u32],
+) {
+    let wg_per_chunk = ca_types::GRAVITY_WG_PER_CHUNK; // 16
+    let chunk_index = wg_id.x / wg_per_chunk;
+    let local_wg = wg_id.x % wg_per_chunk;
+
+    // Read dirty count from header
+    let dirty_count = dirty_list[0];
+    if chunk_index >= dirty_count {
+        return;
+    }
+
+    // Get slot_id from dirty list (offset by header)
+    let slot_id = dirty_list[(DIRTY_LIST_HEADER + chunk_index) as usize];
+
+    // Decompose local_wg into 2D workgroup position (4x4 grid of workgroups)
+    let wg_z = local_wg / 4;
+    let wg_x = local_wg % 4;
+
+    // Compute column (x, z) within chunk
+    let col_x = wg_x * 8 + local_id.x;
+    let col_z = wg_z * 8 + local_id.z;
+
+    // Bounds check
+    if col_x >= ca_types::CA_CHUNK_SIZE {
+        return;
+    }
+    if col_z >= ca_types::CA_CHUNK_SIZE {
+        return;
+    }
+
+    process_column(chunk_pool, materials, slot_id, col_x, col_z);
+}
+
+/// Compute shader entry point: column-scan gravity on dirty chunks.
+///
+/// Descriptor set 0:
+/// - binding 0: chunk_pool (voxel gigabuffer, read/write)
+/// - binding 1: metadata (ChunkGpuMeta array as `&[u32]`, read)
+/// - binding 2: dirty_list (dirty chunk IDs with header, read)
+/// - binding 3: materials (MaterialPropertiesCA array as `&[u32]`, read)
+///
+/// Dispatched indirectly: X = dirty_count * 16, Y = 1, Z = 1.
+#[spirv(compute(threads(8, 1, 8)))]
+pub fn ca_gravity(
+    #[spirv(local_invocation_id)] local_id: UVec3,
+    #[spirv(workgroup_id)] wg_id: UVec3,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] chunk_pool: &mut [u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] _metadata: &[u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] dirty_list: &[u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] materials: &[u32],
+    #[spirv(push_constant)] _push: &CaGravityPush,
+) {
+    // Entry point must call a helper function (trap #4a)
+    gravity_impl(wg_id, local_id, chunk_pool, dirty_list, materials);
+}

--- a/crates/shaders/src/compute/ca_thermal.rs
+++ b/crates/shaders/src/compute/ca_thermal.rs
@@ -51,6 +51,11 @@ fn read_neighbor_temp(
     if in_bounds {
         let addr = ca_types::voxel_addr(slot_id, lx as u32, ly as u32, lz as u32);
         let voxel = chunk_pool[addr as usize];
+        let neighbor_mat = ca_types::voxel_material_id(voxel);
+        // Air should be at ambient temperature for thermal calculations
+        if neighbor_mat == 0 {
+            return ca_types::CA_AMBIENT_TEMP;
+        }
         return ca_types::voxel_temperature(voxel);
     }
 
@@ -85,6 +90,11 @@ fn read_neighbor_temp_cross_chunk(
 
     let addr = ca_types::voxel_addr(neighbor_slot, wx as u32, wy as u32, wz as u32);
     let voxel = chunk_pool[addr as usize];
+    let neighbor_mat = ca_types::voxel_material_id(voxel);
+    // Air should be at ambient temperature for thermal calculations
+    if neighbor_mat == 0 {
+        return ca_types::CA_AMBIENT_TEMP;
+    }
     ca_types::voxel_temperature(voxel)
 }
 

--- a/crates/shaders/src/compute/mod.rs
+++ b/crates/shaders/src/compute/mod.rs
@@ -10,6 +10,7 @@
 //! Both views alias the same GPU buffer. Each `GridCell` = 12 contiguous f32s.
 
 pub mod ca_compact;
+pub mod ca_gravity;
 pub mod ca_margolus;
 pub mod ca_thermal;
 pub mod ca_to_render;


### PR DESCRIPTION
## Summary
- **New GPU column-scan gravity shader** (`ca_gravity.rs`): Replaces broken Margolus 2x2x2 gravity that oscillated and only moved 1 voxel/step. The new shader scans entire (x,z) columns within dirty chunks, dropping non-solid voxels through air gaps with 4 cascading passes per dispatch for faster falling.
- **Thermal air temperature fix**: Air voxels (material_id=0) now use `CA_AMBIENT_TEMP` (128) instead of their stored temperature (0) in thermal diffusion calculations, preventing water from falsely freezing when surrounded by air.
- **Gravity wired into CA pipeline**: Gravity dispatches after Margolus via indirect dispatch with 16 workgroups per chunk (8x1x8 threads covering 32x32 columns).

## Files Changed
- `crates/shaders/src/compute/ca_gravity.rs` — New column-scan gravity shader
- `crates/shaders/src/compute/mod.rs` — Register `ca_gravity` module
- `crates/shaders/src/ca_types.rs` — Add `GRAVITY_WG_PER_CHUNK` constant
- `crates/shaders/src/compute/ca_thermal.rs` — Air neighbors use ambient temp
- `crates/server/src/ca_simulation.rs` — Wire up gravity pass, push constants, destroy

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test -p server -- --test-threads=1` — all 33 tests + integration pass
- [ ] `cargo run -p app -- --sim2` — visual: floating blocks fall, water doesn't freeze

🤖 Generated with [Claude Code](https://claude.com/claude-code)