### PR TITLE
feat: horizontal water spreading + structural integrity

### DIFF
--- a/crates/server/src/ca_simulation.rs
+++ b/crates/server/src/ca_simulation.rs
@@ -40,6 +40,12 @@ const MARGOLUS_WG_PER_CHUNK: u32 = 64;
 /// Workgroups per chunk for gravity pass: 32/8 = 4 per axis, 4*4 = 16.
 const GRAVITY_WG_PER_CHUNK: u32 = 16;
 
+/// Workgroups per chunk for spread pass (same layout as gravity).
+const SPREAD_WG_PER_CHUNK: u32 = 16;
+
+/// Workgroups per chunk for support pass (same layout as gravity).
+const SUPPORT_WG_PER_CHUNK: u32 = 16;
+
 // ---------------------------------------------------------------------------
 // Push constant structs (mirroring shader-side definitions)
 // ---------------------------------------------------------------------------
@@ -94,6 +100,26 @@ pub struct CaGravityPush {
     pub _pad: [u32; 3],
 }
 
+/// Push constants for the CA spread pass.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct CaSpreadPush {
+    /// Current frame number.
+    pub frame_number: u32,
+    /// Padding to 16-byte alignment.
+    pub _pad: [u32; 3],
+}
+
+/// Push constants for the CA support pass.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct CaSupportPush {
+    /// Current frame number.
+    pub frame_number: u32,
+    /// Padding to 16-byte alignment.
+    pub _pad: [u32; 3],
+}
+
 /// Push constants for the CA-to-render conversion shader.
 #[repr(C)]
 #[derive(Debug, Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
@@ -141,6 +167,8 @@ pub struct CaSimulation {
     thermal_pass: ComputePass,
     margolus_pass: ComputePass,
     gravity_pass: ComputePass,
+    spread_pass: ComputePass,
+    support_pass: ComputePass,
 
     // Shader module (kept alive for pipeline lifetime)
     shader_module: vk::ShaderModule,
@@ -227,13 +255,14 @@ impl CaSimulation {
         // 5. Create descriptor pool
         // Total storage buffer bindings across all passes:
         // compact: 2, compact_finalize: 2, thermal: 4, margolus: 5,
-        // ca_to_render: 4, render: 7, compute_dirty_tiles: 2 = 26 total
+        // gravity: 4, spread: 4, support: 4,
+        // ca_to_render: 4, render: 7, compute_dirty_tiles: 2 = 38 total
         let pool_sizes = [vk::DescriptorPoolSize {
             ty: vk::DescriptorType::STORAGE_BUFFER,
-            descriptor_count: 36, // headroom for all passes
+            descriptor_count: 44, // headroom for all passes
         }];
         let descriptor_pool =
-            pipeline::create_descriptor_pool(ctx, &pool_sizes, 8, "ca-descriptor-pool")?;
+            pipeline::create_descriptor_pool(ctx, &pool_sizes, 10, "ca-descriptor-pool")?;
 
         // 6. Create compute passes
 
@@ -314,6 +343,38 @@ impl CaSimulation {
             mem::size_of::<CaGravityPush>() as u32,
             descriptor_pool,
             "ca-gravity",
+        )?;
+
+        // spread pass: binding 0 = voxel_buffer, 1 = metadata, 2 = dirty_list, 3 = materials
+        let spread_pass = passes::create_pass(
+            ctx,
+            shader_module,
+            c"compute::ca_spread::ca_spread",
+            &[
+                chunk_pool.voxel_buffer(),
+                chunk_pool.metadata_buffer(),
+                chunk_pool.dirty_list_buffer(),
+                &material_buffer,
+            ],
+            mem::size_of::<CaSpreadPush>() as u32,
+            descriptor_pool,
+            "ca-spread",
+        )?;
+
+        // support pass: binding 0 = voxel_buffer, 1 = metadata, 2 = dirty_list, 3 = materials
+        let support_pass = passes::create_pass(
+            ctx,
+            shader_module,
+            c"compute::ca_support::ca_support",
+            &[
+                chunk_pool.voxel_buffer(),
+                chunk_pool.metadata_buffer(),
+                chunk_pool.dirty_list_buffer(),
+                &material_buffer,
+            ],
+            mem::size_of::<CaSupportPush>() as u32,
+            descriptor_pool,
+            "ca-support",
         )?;
 
         // 7. Create render bridge buffers
@@ -479,6 +540,8 @@ impl CaSimulation {
             thermal_pass,
             margolus_pass,
             gravity_pass,
+            spread_pass,
+            support_pass,
             shader_module,
             descriptor_pool,
             pbmpm,
@@ -722,7 +785,76 @@ impl CaSimulation {
         );
         passes::barrier(cmd, &self.device);
 
-        // 8. Re-finalize for gravity (wg_per_chunk = 16)
+        // 8. Re-finalize for support (wg_per_chunk = 16)
+        let finalize_support_push = CaCompactPush {
+            total_chunks: total_loaded,
+            workgroups_per_chunk: SUPPORT_WG_PER_CHUNK,
+            _pad: [0; 2],
+        };
+        passes::dispatch(
+            &self.device,
+            cmd,
+            &self.compact_finalize_pass,
+            1,
+            1,
+            1,
+            bytemuck::bytes_of(&finalize_support_push),
+        );
+
+        // Barrier: compute -> indirect + compute
+        let indirect_barrier_support = vk::MemoryBarrier::default()
+            .src_access_mask(vk::AccessFlags::SHADER_WRITE)
+            .dst_access_mask(
+                vk::AccessFlags::INDIRECT_COMMAND_READ | vk::AccessFlags::SHADER_READ,
+            );
+        unsafe {
+            self.device.cmd_pipeline_barrier(
+                cmd,
+                vk::PipelineStageFlags::COMPUTE_SHADER,
+                vk::PipelineStageFlags::DRAW_INDIRECT | vk::PipelineStageFlags::COMPUTE_SHADER,
+                vk::DependencyFlags::empty(),
+                &[indirect_barrier_support],
+                &[],
+                &[],
+            );
+        }
+
+        // 9. Dispatch support pass (INDIRECT) — converts unsupported solids to rubble
+        let support_push = CaSupportPush {
+            frame_number: self.frame_number,
+            _pad: [0; 3],
+        };
+        unsafe {
+            self.device.cmd_bind_pipeline(
+                cmd,
+                vk::PipelineBindPoint::COMPUTE,
+                self.support_pass.pipeline,
+            );
+            self.device.cmd_bind_descriptor_sets(
+                cmd,
+                vk::PipelineBindPoint::COMPUTE,
+                self.support_pass.pipeline_layout,
+                0,
+                &[self.support_pass.descriptor_set],
+                &[],
+            );
+            self.device.cmd_push_constants(
+                cmd,
+                self.support_pass.pipeline_layout,
+                vk::ShaderStageFlags::COMPUTE,
+                0,
+                bytemuck::bytes_of(&support_push),
+            );
+        }
+        pipeline::cmd_dispatch_indirect(
+            &self.device,
+            cmd,
+            self.chunk_pool.dirty_list_buffer(),
+            4,
+        );
+        passes::barrier(cmd, &self.device);
+
+        // 10. Re-finalize for gravity (wg_per_chunk = 16)
         let finalize_gravity_push = CaCompactPush {
             total_chunks: total_loaded,
             workgroups_per_chunk: GRAVITY_WG_PER_CHUNK,
@@ -756,7 +888,7 @@ impl CaSimulation {
             );
         }
 
-        // 9. Dispatch gravity pass (INDIRECT)
+        // 11. Dispatch gravity pass (INDIRECT)
         let gravity_push = CaGravityPush {
             frame_number: self.frame_number,
             _pad: [0; 3],
@@ -781,6 +913,75 @@ impl CaSimulation {
                 vk::ShaderStageFlags::COMPUTE,
                 0,
                 bytemuck::bytes_of(&gravity_push),
+            );
+        }
+        pipeline::cmd_dispatch_indirect(
+            &self.device,
+            cmd,
+            self.chunk_pool.dirty_list_buffer(),
+            4,
+        );
+        passes::barrier(cmd, &self.device);
+
+        // 12. Re-finalize for spread (wg_per_chunk = 16)
+        let finalize_spread_push = CaCompactPush {
+            total_chunks: total_loaded,
+            workgroups_per_chunk: SPREAD_WG_PER_CHUNK,
+            _pad: [0; 2],
+        };
+        passes::dispatch(
+            &self.device,
+            cmd,
+            &self.compact_finalize_pass,
+            1,
+            1,
+            1,
+            bytemuck::bytes_of(&finalize_spread_push),
+        );
+
+        // Barrier: compute -> indirect + compute
+        let indirect_barrier_spread = vk::MemoryBarrier::default()
+            .src_access_mask(vk::AccessFlags::SHADER_WRITE)
+            .dst_access_mask(
+                vk::AccessFlags::INDIRECT_COMMAND_READ | vk::AccessFlags::SHADER_READ,
+            );
+        unsafe {
+            self.device.cmd_pipeline_barrier(
+                cmd,
+                vk::PipelineStageFlags::COMPUTE_SHADER,
+                vk::PipelineStageFlags::DRAW_INDIRECT | vk::PipelineStageFlags::COMPUTE_SHADER,
+                vk::DependencyFlags::empty(),
+                &[indirect_barrier_spread],
+                &[],
+                &[],
+            );
+        }
+
+        // 13. Dispatch spread pass (INDIRECT) — horizontal liquid spreading
+        let spread_push = CaSpreadPush {
+            frame_number: self.frame_number,
+            _pad: [0; 3],
+        };
+        unsafe {
+            self.device.cmd_bind_pipeline(
+                cmd,
+                vk::PipelineBindPoint::COMPUTE,
+                self.spread_pass.pipeline,
+            );
+            self.device.cmd_bind_descriptor_sets(
+                cmd,
+                vk::PipelineBindPoint::COMPUTE,
+                self.spread_pass.pipeline_layout,
+                0,
+                &[self.spread_pass.descriptor_set],
+                &[],
+            );
+            self.device.cmd_push_constants(
+                cmd,
+                self.spread_pass.pipeline_layout,
+                vk::ShaderStageFlags::COMPUTE,
+                0,
+                bytemuck::bytes_of(&spread_push),
             );
         }
         pipeline::cmd_dispatch_indirect(
@@ -1336,6 +1537,8 @@ impl CaSimulation {
             &self.thermal_pass,
             &self.margolus_pass,
             &self.gravity_pass,
+            &self.spread_pass,
+            &self.support_pass,
             &self.ca_to_render_pass,
             &self.render_pass,
             &self.compute_dirty_tiles_pass,
@@ -1426,6 +1629,11 @@ pub fn default_ca_materials() -> Vec<MaterialPropertiesCA> {
         mats[i] = mats[1]; // copy stone properties
     }
 
+    // 10 = Rubble (falling stone: powder-phase so gravity drops it)
+    mats[10].phase = 1; // powder (falls!)
+    mats[10].density = 200; // same as stone
+    mats[10].conductivity = 2;
+
     mats
 }
 
@@ -1471,6 +1679,7 @@ pub fn ca_materials_to_render_params(
         (0.42, 0.40, 0.38),    // render 7 = Dark stone
         (0.55, 0.50, 0.45),    // render 8 = Light stone
         (0.45, 0.47, 0.42),    // render 9 = Mossy stone (green tint)
+        (0.48, 0.45, 0.40),    // render 10 = Rubble (falling stone, brownish gray)
     ];
 
     let mut result = Vec::with_capacity(ca_mats.len());

--- a/crates/shaders/src/ca_types.rs
+++ b/crates/shaders/src/ca_types.rs
@@ -52,6 +52,12 @@ pub const MARGOLUS_WG_PER_CHUNK: u32 = 64;
 /// Workgroups per chunk for gravity pass (32/8 = 4 per axis, 4*4 = 16).
 pub const GRAVITY_WG_PER_CHUNK: u32 = 16;
 
+/// Workgroups per chunk for spread pass (same layout as gravity: 4*4 = 16).
+pub const SPREAD_WG_PER_CHUNK: u32 = 16;
+
+/// Workgroups per chunk for support pass (same layout as gravity: 4*4 = 16).
+pub const SUPPORT_WG_PER_CHUNK: u32 = 16;
+
 // ---- Voxel pack/unpack (must match shared::voxel::Voxel bit layout) ----
 
 /// Extracts the material ID (bits 0-9) from a packed voxel.

--- a/crates/shaders/src/compute/ca_spread.rs
+++ b/crates/shaders/src/compute/ca_spread.rs
@@ -1,0 +1,340 @@
+//! Horizontal liquid spread compute shader for the CA substrate.
+//!
+//! Runs AFTER gravity. For each column (x, z), scans bottom to top.
+//! If a liquid voxel is supported (solid/liquid/powder below), tries to
+//! spread into one adjacent horizontal air cell.
+//!
+//! Uses frame-based direction hashing to randomize spread direction per tick.
+//! Only ONE spread per column per tick to prevent mass loss.
+//!
+//! Workgroup layout: (8, 1, 8) = 64 threads per workgroup.
+//! Each thread processes one column (x, z) within a chunk.
+//! 32/8 = 4 workgroups per axis -> 4*4 = 16 workgroups per chunk.
+//! Dispatched indirectly: X = dirty_count * 16, Y = 1, Z = 1.
+
+use spirv_std::glam::UVec3;
+use spirv_std::spirv;
+
+use crate::ca_types;
+
+/// Push constants for the spread pass.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct CaSpreadPush {
+    /// Current frame number.
+    pub frame_number: u32,
+    /// Padding to 16-byte alignment.
+    pub _pad: [u32; 3],
+}
+
+/// Dirty list header size in u32s: [dirty_count, dispatch_x, dispatch_y, dispatch_z].
+const DIRTY_LIST_HEADER: u32 = 4;
+
+/// Reads a voxel from the chunk pool. Returns 0 (air) for out-of-bounds.
+fn read_voxel(chunk_pool: &[u32], slot_id: u32, x: u32, y: u32, z: u32) -> u32 {
+    if y >= ca_types::CA_CHUNK_SIZE {
+        return 0;
+    }
+    let addr = ca_types::voxel_addr(slot_id, x, y, z);
+    chunk_pool[addr as usize]
+}
+
+/// Writes a voxel to the chunk pool.
+fn write_voxel(chunk_pool: &mut [u32], slot_id: u32, x: u32, y: u32, z: u32, voxel: u32) {
+    let addr = ca_types::voxel_addr(slot_id, x, y, z);
+    chunk_pool[addr as usize] = voxel;
+}
+
+/// Checks if a voxel is liquid (phase == 2).
+fn is_liquid(materials: &[u32], voxel: u32) -> bool {
+    let mat_id = ca_types::voxel_material_id(voxel);
+    if mat_id == 0 {
+        return false;
+    }
+    let phase = ca_types::mat_phase(materials, mat_id);
+    phase == 2
+}
+
+/// Checks if a voxel is non-air (can support liquid above).
+fn is_support(voxel: u32) -> bool {
+    ca_types::voxel_material_id(voxel) != 0
+}
+
+/// Tries to spread a liquid voxel in the +X direction within the same chunk.
+/// Returns true if spread occurred.
+fn try_spread_plus_x(
+    chunk_pool: &mut [u32],
+    slot_id: u32,
+    x: u32,
+    y: u32,
+    z: u32,
+    voxel: u32,
+    metadata: &[u32],
+) -> bool {
+    if x + 1 < ca_types::CA_CHUNK_SIZE {
+        let neighbor = read_voxel(chunk_pool, slot_id, x + 1, y, z);
+        if ca_types::voxel_material_id(neighbor) == 0 {
+            write_voxel(chunk_pool, slot_id, x + 1, y, z, voxel);
+            write_voxel(chunk_pool, slot_id, x, y, z, 0);
+            return true;
+        }
+        return false;
+    }
+    // Cross-chunk: +X neighbor is direction 0
+    try_spread_cross_chunk(chunk_pool, metadata, slot_id, 0, 0, y, z, x, y, z, voxel)
+}
+
+/// Tries to spread a liquid voxel in the -X direction within the same chunk.
+/// Returns true if spread occurred.
+fn try_spread_minus_x(
+    chunk_pool: &mut [u32],
+    slot_id: u32,
+    x: u32,
+    y: u32,
+    z: u32,
+    voxel: u32,
+    metadata: &[u32],
+) -> bool {
+    if x > 0 {
+        let neighbor = read_voxel(chunk_pool, slot_id, x - 1, y, z);
+        if ca_types::voxel_material_id(neighbor) == 0 {
+            write_voxel(chunk_pool, slot_id, x - 1, y, z, voxel);
+            write_voxel(chunk_pool, slot_id, x, y, z, 0);
+            return true;
+        }
+        return false;
+    }
+    // Cross-chunk: -X neighbor is direction 1
+    try_spread_cross_chunk(chunk_pool, metadata, slot_id, 1, 31, y, z, x, y, z, voxel)
+}
+
+/// Tries to spread a liquid voxel in the +Z direction within the same chunk.
+/// Returns true if spread occurred.
+fn try_spread_plus_z(
+    chunk_pool: &mut [u32],
+    slot_id: u32,
+    x: u32,
+    y: u32,
+    z: u32,
+    voxel: u32,
+    metadata: &[u32],
+) -> bool {
+    if z + 1 < ca_types::CA_CHUNK_SIZE {
+        let neighbor = read_voxel(chunk_pool, slot_id, x, y, z + 1);
+        if ca_types::voxel_material_id(neighbor) == 0 {
+            write_voxel(chunk_pool, slot_id, x, y, z + 1, voxel);
+            write_voxel(chunk_pool, slot_id, x, y, z, 0);
+            return true;
+        }
+        return false;
+    }
+    // Cross-chunk: +Z neighbor is direction 4
+    try_spread_cross_chunk(chunk_pool, metadata, slot_id, 4, x, y, 0, x, y, z, voxel)
+}
+
+/// Tries to spread a liquid voxel in the -Z direction within the same chunk.
+/// Returns true if spread occurred.
+fn try_spread_minus_z(
+    chunk_pool: &mut [u32],
+    slot_id: u32,
+    x: u32,
+    y: u32,
+    z: u32,
+    voxel: u32,
+    metadata: &[u32],
+) -> bool {
+    if z > 0 {
+        let neighbor = read_voxel(chunk_pool, slot_id, x, y, z - 1);
+        if ca_types::voxel_material_id(neighbor) == 0 {
+            write_voxel(chunk_pool, slot_id, x, y, z - 1, voxel);
+            write_voxel(chunk_pool, slot_id, x, y, z, 0);
+            return true;
+        }
+        return false;
+    }
+    // Cross-chunk: -Z neighbor is direction 5
+    try_spread_cross_chunk(chunk_pool, metadata, slot_id, 5, x, y, 31, x, y, z, voxel)
+}
+
+/// Attempts a cross-chunk spread in the given direction.
+///
+/// `direction`: 0=+X, 1=-X, 4=+Z, 5=-Z
+/// `dst_x/y/z`: coordinates in the neighbor chunk to write liquid into
+/// `src_x/y/z`: coordinates in this chunk to clear (write air)
+fn try_spread_cross_chunk(
+    chunk_pool: &mut [u32],
+    metadata: &[u32],
+    slot_id: u32,
+    direction: u32,
+    dst_x: u32,
+    dst_y: u32,
+    dst_z: u32,
+    src_x: u32,
+    src_y: u32,
+    src_z: u32,
+    voxel: u32,
+) -> bool {
+    let neighbor_slot = ca_types::meta_neighbor_id(metadata, slot_id, direction);
+    if neighbor_slot == 0xFFFFFFFF {
+        return false;
+    }
+    let neighbor_voxel = read_voxel(chunk_pool, neighbor_slot, dst_x, dst_y, dst_z);
+    if ca_types::voxel_material_id(neighbor_voxel) == 0 {
+        write_voxel(chunk_pool, neighbor_slot, dst_x, dst_y, dst_z, voxel);
+        write_voxel(chunk_pool, slot_id, src_x, src_y, src_z, 0);
+        return true;
+    }
+    false
+}
+
+/// Processes one column, spreading the first supported liquid horizontally.
+fn process_column(
+    chunk_pool: &mut [u32],
+    materials: &[u32],
+    metadata: &[u32],
+    slot_id: u32,
+    x: u32,
+    z: u32,
+    frame: u32,
+) {
+    let dir = ca_types::hash_position(x, 0, z, frame) % 4;
+    let mut y: u32 = 0;
+    loop {
+        if y >= ca_types::CA_CHUNK_SIZE {
+            return;
+        }
+        let voxel = read_voxel(chunk_pool, slot_id, x, y, z);
+        let liquid = is_liquid(materials, voxel);
+
+        if liquid {
+            // Check if supported (non-air below or at y=0)
+            let supported = check_support(chunk_pool, metadata, slot_id, x, y, z);
+            if supported {
+                let did_spread = try_spread_dir(chunk_pool, metadata, slot_id, x, y, z, voxel, dir);
+                if did_spread {
+                    return; // One spread per column per tick
+                }
+            }
+        }
+        y += 1;
+    }
+}
+
+/// Checks if a voxel at (x, y, z) is supported (non-air below or y==0).
+fn check_support(
+    chunk_pool: &[u32],
+    metadata: &[u32],
+    slot_id: u32,
+    x: u32,
+    y: u32,
+    z: u32,
+) -> bool {
+    if y == 0 {
+        // Check cross-chunk: -Y neighbor (direction 3)
+        let below_slot = ca_types::meta_neighbor_id(metadata, slot_id, 3);
+        if below_slot == 0xFFFFFFFF {
+            return true; // Edge of world = supported
+        }
+        let below_voxel = read_voxel(chunk_pool, below_slot, x, 31, z);
+        return is_support(below_voxel);
+    }
+    let below = read_voxel(chunk_pool, slot_id, x, y - 1, z);
+    is_support(below)
+}
+
+/// Attempts spread in a given direction (0=+X, 1=-X, 2=+Z, 3=-Z).
+fn try_spread_dir(
+    chunk_pool: &mut [u32],
+    metadata: &[u32],
+    slot_id: u32,
+    x: u32,
+    y: u32,
+    z: u32,
+    voxel: u32,
+    dir: u32,
+) -> bool {
+    if dir == 0 {
+        return try_spread_plus_x(chunk_pool, slot_id, x, y, z, voxel, metadata);
+    }
+    if dir == 1 {
+        return try_spread_minus_x(chunk_pool, slot_id, x, y, z, voxel, metadata);
+    }
+    if dir == 2 {
+        return try_spread_plus_z(chunk_pool, slot_id, x, y, z, voxel, metadata);
+    }
+    // dir == 3
+    try_spread_minus_z(chunk_pool, slot_id, x, y, z, voxel, metadata)
+}
+
+/// Main spread logic: maps thread to chunk + column, then processes.
+fn spread_impl(
+    wg_id: UVec3,
+    local_id: UVec3,
+    chunk_pool: &mut [u32],
+    metadata: &[u32],
+    dirty_list: &[u32],
+    materials: &[u32],
+    frame: u32,
+) {
+    let wg_per_chunk = ca_types::SPREAD_WG_PER_CHUNK; // 16
+    let chunk_index = wg_id.x / wg_per_chunk;
+    let local_wg = wg_id.x % wg_per_chunk;
+
+    // Read dirty count from header
+    let dirty_count = dirty_list[0];
+    if chunk_index >= dirty_count {
+        return;
+    }
+
+    // Get slot_id from dirty list (offset by header)
+    let slot_id = dirty_list[(DIRTY_LIST_HEADER + chunk_index) as usize];
+
+    // Decompose local_wg into 2D workgroup position (4x4 grid of workgroups)
+    let wg_z = local_wg / 4;
+    let wg_x = local_wg % 4;
+
+    // Compute column (x, z) within chunk
+    let col_x = wg_x * 8 + local_id.x;
+    let col_z = wg_z * 8 + local_id.z;
+
+    // Bounds check
+    if col_x >= ca_types::CA_CHUNK_SIZE {
+        return;
+    }
+    if col_z >= ca_types::CA_CHUNK_SIZE {
+        return;
+    }
+
+    process_column(chunk_pool, materials, metadata, slot_id, col_x, col_z, frame);
+}
+
+/// Compute shader entry point: horizontal liquid spread on dirty chunks.
+///
+/// Descriptor set 0:
+/// - binding 0: chunk_pool (voxel gigabuffer, read/write)
+/// - binding 1: metadata (ChunkGpuMeta array as `&[u32]`, read)
+/// - binding 2: dirty_list (dirty chunk IDs with header, read)
+/// - binding 3: materials (MaterialPropertiesCA array as `&[u32]`, read)
+///
+/// Dispatched indirectly: X = dirty_count * 16, Y = 1, Z = 1.
+#[spirv(compute(threads(8, 1, 8)))]
+pub fn ca_spread(
+    #[spirv(local_invocation_id)] local_id: UVec3,
+    #[spirv(workgroup_id)] wg_id: UVec3,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] chunk_pool: &mut [u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] metadata: &[u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] dirty_list: &[u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] materials: &[u32],
+    #[spirv(push_constant)] push: &CaSpreadPush,
+) {
+    // Entry point must call a helper function (trap #4a)
+    spread_impl(
+        wg_id,
+        local_id,
+        chunk_pool,
+        metadata,
+        dirty_list,
+        materials,
+        push.frame_number,
+    );
+}

--- a/crates/shaders/src/compute/ca_support.rs
+++ b/crates/shaders/src/compute/ca_support.rs
@@ -1,0 +1,213 @@
+//! Structural integrity compute shader for the CA substrate.
+//!
+//! Runs BEFORE gravity. Scans each (x, z) column bottom to top, tracking
+//! support state. Solid voxels (phase=0) that lack support below are
+//! converted to rubble (mat_id=10, phase=1) so gravity can drop them.
+//!
+//! Support rules:
+//! - y=0 with no chunk below (world edge): always supported
+//! - y=0 with chunk below: supported if the voxel at y=31 of chunk below is solid
+//! - y>0: supported if y-1 is solid AND y-1 was itself supported
+//! - Non-solid voxels (air, liquid, powder, gas) break the support chain
+//!
+//! Workgroup layout: (8, 1, 8) = 64 threads per workgroup.
+//! Each thread processes one column (x, z) within a chunk.
+//! 32/8 = 4 workgroups per axis -> 4*4 = 16 workgroups per chunk.
+//! Dispatched indirectly: X = dirty_count * 16, Y = 1, Z = 1.
+
+use spirv_std::glam::UVec3;
+use spirv_std::spirv;
+
+use crate::ca_types;
+
+/// Push constants for the support pass.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct CaSupportPush {
+    /// Current frame number.
+    pub frame_number: u32,
+    /// Padding to 16-byte alignment.
+    pub _pad: [u32; 3],
+}
+
+/// Rubble material ID. Must match the CPU-side `default_ca_materials()` index.
+const RUBBLE_MAT_ID: u32 = 10;
+
+/// Dirty list header size in u32s: [dirty_count, dispatch_x, dispatch_y, dispatch_z].
+const DIRTY_LIST_HEADER: u32 = 4;
+
+/// Reads a voxel from the chunk pool. Returns 0 (air) for out-of-bounds.
+fn read_voxel(chunk_pool: &[u32], slot_id: u32, x: u32, y: u32, z: u32) -> u32 {
+    if y >= ca_types::CA_CHUNK_SIZE {
+        return 0;
+    }
+    let addr = ca_types::voxel_addr(slot_id, x, y, z);
+    chunk_pool[addr as usize]
+}
+
+/// Writes a voxel to the chunk pool.
+fn write_voxel(chunk_pool: &mut [u32], slot_id: u32, x: u32, y: u32, z: u32, voxel: u32) {
+    let addr = ca_types::voxel_addr(slot_id, x, y, z);
+    chunk_pool[addr as usize] = voxel;
+}
+
+/// Checks if a voxel is solid (phase == 0) and non-air.
+fn is_solid(materials: &[u32], voxel: u32) -> bool {
+    let mat_id = ca_types::voxel_material_id(voxel);
+    if mat_id == 0 {
+        return false;
+    }
+    let phase = ca_types::mat_phase(materials, mat_id);
+    phase == 0
+}
+
+/// Determines initial support state from the chunk below.
+///
+/// If no chunk below exists (world edge), returns true (ground level).
+/// Otherwise checks if the voxel at y=31 in the chunk below is solid.
+fn initial_support(
+    chunk_pool: &[u32],
+    materials: &[u32],
+    metadata: &[u32],
+    slot_id: u32,
+    x: u32,
+    z: u32,
+) -> bool {
+    // -Y neighbor is direction 3
+    let below_slot = ca_types::meta_neighbor_id(metadata, slot_id, 3);
+    if below_slot == 0xFFFFFFFF {
+        return true; // No chunk below = world edge = supported
+    }
+    let below_voxel = read_voxel(chunk_pool, below_slot, x, 31, z);
+    is_solid(materials, below_voxel)
+}
+
+/// Converts an unsupported solid voxel to rubble by changing its material ID.
+///
+/// Preserves temperature, bonds, oxygen, and flags.
+fn convert_to_rubble(chunk_pool: &mut [u32], slot_id: u32, x: u32, y: u32, z: u32, voxel: u32) {
+    let new_voxel = ca_types::voxel_set_material(voxel, RUBBLE_MAT_ID);
+    write_voxel(chunk_pool, slot_id, x, y, z, new_voxel);
+}
+
+/// Processes one column, converting unsupported solids to rubble.
+fn process_column(
+    chunk_pool: &mut [u32],
+    materials: &[u32],
+    metadata: &[u32],
+    slot_id: u32,
+    x: u32,
+    z: u32,
+) {
+    let mut supported = initial_support(chunk_pool, materials, metadata, slot_id, x, z);
+
+    let mut y: u32 = 0;
+    loop {
+        if y >= ca_types::CA_CHUNK_SIZE {
+            return;
+        }
+        let voxel = read_voxel(chunk_pool, slot_id, x, y, z);
+        let mat_id = ca_types::voxel_material_id(voxel);
+
+        if mat_id == 0 {
+            // Air: breaks the support chain
+            supported = false;
+        } else {
+            let phase = ca_types::mat_phase(materials, mat_id);
+            let solid = phase == 0;
+            supported = update_support(chunk_pool, slot_id, x, y, z, voxel, solid, supported);
+        }
+
+        y += 1;
+    }
+}
+
+/// Updates support state for a single voxel.
+///
+/// If the voxel is solid and unsupported, converts it to rubble and returns false.
+/// If the voxel is solid and supported, returns true (chain continues).
+/// If the voxel is non-solid (liquid/powder/gas), returns false (chain breaks).
+fn update_support(
+    chunk_pool: &mut [u32],
+    slot_id: u32,
+    x: u32,
+    y: u32,
+    z: u32,
+    voxel: u32,
+    solid: bool,
+    supported: bool,
+) -> bool {
+    if solid {
+        if !supported {
+            convert_to_rubble(chunk_pool, slot_id, x, y, z, voxel);
+            return false;
+        }
+        return true;
+    }
+    // Non-solid non-air (liquid, powder, gas): breaks support chain
+    false
+}
+
+/// Main support logic: maps thread to chunk + column, then processes.
+fn support_impl(
+    wg_id: UVec3,
+    local_id: UVec3,
+    chunk_pool: &mut [u32],
+    metadata: &[u32],
+    dirty_list: &[u32],
+    materials: &[u32],
+) {
+    let wg_per_chunk = ca_types::SUPPORT_WG_PER_CHUNK; // 16
+    let chunk_index = wg_id.x / wg_per_chunk;
+    let local_wg = wg_id.x % wg_per_chunk;
+
+    // Read dirty count from header
+    let dirty_count = dirty_list[0];
+    if chunk_index >= dirty_count {
+        return;
+    }
+
+    // Get slot_id from dirty list (offset by header)
+    let slot_id = dirty_list[(DIRTY_LIST_HEADER + chunk_index) as usize];
+
+    // Decompose local_wg into 2D workgroup position (4x4 grid of workgroups)
+    let wg_z = local_wg / 4;
+    let wg_x = local_wg % 4;
+
+    // Compute column (x, z) within chunk
+    let col_x = wg_x * 8 + local_id.x;
+    let col_z = wg_z * 8 + local_id.z;
+
+    // Bounds check
+    if col_x >= ca_types::CA_CHUNK_SIZE {
+        return;
+    }
+    if col_z >= ca_types::CA_CHUNK_SIZE {
+        return;
+    }
+
+    process_column(chunk_pool, materials, metadata, slot_id, col_x, col_z);
+}
+
+/// Compute shader entry point: structural integrity check on dirty chunks.
+///
+/// Descriptor set 0:
+/// - binding 0: chunk_pool (voxel gigabuffer, read/write)
+/// - binding 1: metadata (ChunkGpuMeta array as `&[u32]`, read)
+/// - binding 2: dirty_list (dirty chunk IDs with header, read)
+/// - binding 3: materials (MaterialPropertiesCA array as `&[u32]`, read)
+///
+/// Dispatched indirectly: X = dirty_count * 16, Y = 1, Z = 1.
+#[spirv(compute(threads(8, 1, 8)))]
+pub fn ca_support(
+    #[spirv(local_invocation_id)] local_id: UVec3,
+    #[spirv(workgroup_id)] wg_id: UVec3,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] chunk_pool: &mut [u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] metadata: &[u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] dirty_list: &[u32],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 3)] materials: &[u32],
+    #[spirv(push_constant)] _push: &CaSupportPush,
+) {
+    // Entry point must call a helper function (trap #4a)
+    support_impl(wg_id, local_id, chunk_pool, metadata, dirty_list, materials);
+}

--- a/crates/shaders/src/compute/mod.rs
+++ b/crates/shaders/src/compute/mod.rs
@@ -12,6 +12,8 @@
 pub mod ca_compact;
 pub mod ca_gravity;
 pub mod ca_margolus;
+pub mod ca_spread;
+pub mod ca_support;
 pub mod ca_thermal;
 pub mod ca_to_render;
 pub mod clear_grid;


### PR DESCRIPTION
## Summary
- **Horizontal water spreading** (`ca_spread` shader): Liquids now spread sideways into adjacent air when supported from below. Runs after gravity, one spread per column per tick with frame-based direction hashing for natural flow. Cross-chunk spreading supported.
- **Structural integrity** (`ca_support` shader): Unsupported solid voxels (no solid column beneath) are converted to rubble (mat_id=10, powder phase) and dropped by gravity. Runs before gravity in the pipeline.
- **Rubble material** (id=10): Powder-phase stone with same density/conductivity as stone, for falling debris.
- **Pipeline order**: compact -> thermal -> margolus -> **support** -> gravity -> **spread**

## Test plan
- [x] `cargo build` succeeds (shader compilation passes)
- [x] `cargo test -p server -- --test-threads=1` — all 33 tests pass
- [x] `cargo test -p shared -p sim-cpu -p protocol -p content` — all CPU tests pass
- [ ] Visual test: place water on flat surface, verify it spreads horizontally
- [ ] Visual test: remove base block under stone column, verify blocks fall as rubble

🤖 Generated with [Claude Code](https://claude.com/claude-code)