### PR TITLE
fix: PB-MPM physics quality — APIC transfer + better impulse

### DIFF
--- a/crates/server/src/pbmpm_zones.rs
+++ b/crates/server/src/pbmpm_zones.rs
@@ -27,7 +27,8 @@ const SHADER_BYTES: &[u8] = include_bytes!(env!("SHADERS_SPV_PATH"));
 const MAX_ZONES: usize = 4;
 
 /// PB-MPM iterations per frame (PB-MPM iterates the full loop for stability).
-const PBMPM_ITERATIONS: u32 = 2;
+/// 4 iterations provides better constraint convergence and more stable physics.
+const PBMPM_ITERATIONS: u32 = 4;
 
 /// Frames below velocity threshold before sleeping a zone.
 const SLEEP_FRAMES: u32 = 30;
@@ -378,15 +379,32 @@ impl PbmpmZoneManager {
                     let py = y as f32 + 0.5;
                     let pz = z as f32 + 0.5;
 
-                    // Velocity: radial impulse from trigger center
+                    // Velocity: radial impulse from trigger center, scaled by distance
                     let dx = px - (trigger.center[0] - zone.world_origin[0] as f32);
                     let dy = py - (trigger.center[1] - zone.world_origin[1] as f32);
                     let dz = pz - (trigger.center[2] - zone.world_origin[2] as f32);
                     let dist = (dx * dx + dy * dy + dz * dz).sqrt().max(0.001);
-                    let impulse_scale = trigger.impulse / dist;
-                    let vx = dx * impulse_scale;
-                    let vy = dy * impulse_scale;
-                    let vz = dz * impulse_scale;
+
+                    // Inverse-square falloff: stronger near center, weaker far away
+                    // Normalize direction, then scale by impulse / (1 + dist^2)
+                    let inv_dist = 1.0 / dist;
+                    let dir_x = dx * inv_dist;
+                    let dir_y = dy * inv_dist;
+                    let dir_z = dz * inv_dist;
+                    let falloff = trigger.impulse / (1.0 + dist * dist * 0.1);
+
+                    // Hash-based per-particle speed variation (+-20%)
+                    let hash = ((x.wrapping_mul(73856093))
+                        ^ (y.wrapping_mul(19349663))
+                        ^ (z.wrapping_mul(83492791)))
+                        & 0xFF;
+                    let variation = 0.8 + 0.4 * (hash as f32 / 255.0);
+
+                    let speed = falloff * variation;
+                    let vx = dir_x * speed;
+                    // Upward bias: add 50% of impulse magnitude as vertical boost
+                    let vy = dir_y * speed + trigger.impulse * 0.5;
+                    let vz = dir_z * speed;
 
                     let mass = 1.0_f32;
                     let temp = v.temperature() as f32;
@@ -396,12 +414,12 @@ impl PbmpmZoneManager {
                     particles.extend_from_slice(&[px, py, pz, mass]);
                     // vel_temp
                     particles.extend_from_slice(&[vx, vy, vz, temp]);
-                    // F_col0: identity
-                    particles.extend_from_slice(&[1.0, 0.0, 0.0, 0.0]);
-                    // F_col1: identity
-                    particles.extend_from_slice(&[0.0, 1.0, 0.0, 0.0]);
-                    // F_col2: identity
-                    particles.extend_from_slice(&[0.0, 0.0, 1.0, 0.0]);
+                    // C_col0: zero (APIC affine momentum matrix, no initial rotation)
+                    particles.extend_from_slice(&[0.0, 0.0, 0.0, 0.0]);
+                    // C_col1: zero
+                    particles.extend_from_slice(&[0.0, 0.0, 0.0, 0.0]);
+                    // C_col2: zero
+                    particles.extend_from_slice(&[0.0, 0.0, 0.0, 0.0]);
                     // ids: material_id, phase, flags, padding (as u32 bits)
                     let mat_id = v.material_id() as u32;
                     let phase = 1u32; // treat as liquid for PB-MPM
@@ -836,12 +854,12 @@ mod tests {
                 p.extend_from_slice(&[x, y, z, 1.0]);
                 // vel_temp
                 p.extend_from_slice(&[0.0, 0.0, 0.0, 128.0]);
-                // F_col0 (identity)
-                p.extend_from_slice(&[1.0, 0.0, 0.0, 0.0]);
-                // F_col1 (identity)
-                p.extend_from_slice(&[0.0, 1.0, 0.0, 0.0]);
-                // F_col2 (identity)
-                p.extend_from_slice(&[0.0, 0.0, 1.0, 0.0]);
+                // C_col0 (APIC affine momentum, zero initially)
+                p.extend_from_slice(&[0.0, 0.0, 0.0, 0.0]);
+                // C_col1 (zero)
+                p.extend_from_slice(&[0.0, 0.0, 0.0, 0.0]);
+                // C_col2 (zero)
+                p.extend_from_slice(&[0.0, 0.0, 0.0, 0.0]);
                 // ids
                 p.extend_from_slice(&[
                     f32::from_bits(1), // material_id = 1

--- a/crates/shaders/src/compute/pbmpm_g2p.rs
+++ b/crates/shaders/src/compute/pbmpm_g2p.rs
@@ -1,13 +1,15 @@
 //! PB-MPM Grid-to-Particle (G2P) compute shader.
 //!
-//! Each thread processes one particle, gathering velocity from the 3x3x3
-//! neighborhood of grid cells using quadratic B-spline weights, then
-//! updating position and velocity.
+//! Each thread processes one particle, gathering velocity and APIC affine
+//! momentum matrix C from the 3x3x3 neighborhood of grid cells using
+//! quadratic B-spline weights, then updating position and velocity.
 //!
-//! PB-MPM key differences from MLS-MPM:
-//! - No APIC affine momentum term (pure PIC gather for POC)
-//! - No stress/deformation gradient update (handled by constraint projection)
-//! - Iterative: this runs 2-4 times per frame, refining the solution each time
+//! Uses APIC (Affine Particle-In-Cell) transfer to preserve angular momentum
+//! and produce cohesive, physically correct fluid motion. The C matrix captures
+//! the local velocity gradient which is fed back into P2G for the next iteration.
+//!
+//! PB-MPM iterates the entire P2G->grid_update->G2P loop 2-4 times per frame
+//! for stability at any timestep.
 //!
 //! Dispatch: `(ceil(particle_count / 256), 1, 1)` workgroups.
 
@@ -18,15 +20,13 @@ use super::pbmpm_clear_grid::PbmpmPush;
 use super::quadratic_bspline_weights;
 use crate::pbmpm_types;
 
-/// Gather velocity from grid and update one particle.
+/// Gather velocity and APIC C matrix from grid, update one particle.
 ///
 /// 1. Compute B-spline weights from particle position
-/// 2. Accumulate weighted grid velocity from 3x3x3 neighborhood
+/// 2. Accumulate weighted grid velocity and APIC outer products from 3x3x3 neighborhood
 /// 3. Update position: pos += new_vel * dt
 /// 4. Clamp position to grid bounds (with margin)
-///
-/// For this POC, uses pure PIC (no APIC affine term). Material-specific
-/// constraint projection will be added in a later PR.
+/// 5. Store new velocity and C matrix for next P2G pass
 fn gather_and_update_particle(
     particles: &mut [u32],
     grid: &[u32],
@@ -53,22 +53,42 @@ fn gather_and_update_particle(
     let wy = quadratic_bspline_weights(fy);
     let wz = quadratic_bspline_weights(fz);
 
-    // Gather weighted velocity from 3x3x3 neighborhood
+    // Gather weighted velocity and APIC C matrix from 3x3x3 neighborhood
+    // result: [vx, vy, vz, c00, c10, c20, c01, c11, c21, c02, c12, c22]
     let mut new_vx = 0.0_f32;
     let mut new_vy = 0.0_f32;
     let mut new_vz = 0.0_f32;
+    // C matrix (column-major): 9 elements
+    let mut c00 = 0.0_f32;
+    let mut c10 = 0.0_f32;
+    let mut c20 = 0.0_f32;
+    let mut c01 = 0.0_f32;
+    let mut c11 = 0.0_f32;
+    let mut c21 = 0.0_f32;
+    let mut c02 = 0.0_f32;
+    let mut c12 = 0.0_f32;
+    let mut c22 = 0.0_f32;
 
     let mut di = 0u32;
     while di < 3 {
         let mut dj = 0u32;
         while dj < 3 {
-            let result = gather_inner_loop(
-                grid, di, dj, base_x, base_y, base_z,
+            let result = gather_inner_loop_apic(
+                grid, di, dj, base_x, base_y, base_z, px, py, pz,
                 &wx, &wy, &wz, push.grid_size, push.grid_offset,
             );
             new_vx += result[0];
             new_vy += result[1];
             new_vz += result[2];
+            c00 += result[3];
+            c10 += result[4];
+            c20 += result[5];
+            c01 += result[6];
+            c11 += result[7];
+            c21 += result[8];
+            c02 += result[9];
+            c12 += result[10];
+            c22 += result[11];
             dj += 1;
         }
         di += 1;
@@ -86,31 +106,40 @@ fn gather_and_update_particle(
     new_py = clamp_f32(new_py, margin, upper);
     new_pz = clamp_f32(new_pz, margin, upper);
 
-    // Write back position and velocity
+    // Write back position, velocity, and APIC C matrix
     pbmpm_types::set_particle_pos(particles, abs_idx, new_px, new_py, new_pz);
     pbmpm_types::set_particle_vel(particles, abs_idx, new_vx, new_vy, new_vz);
+    pbmpm_types::set_particle_c_matrix(
+        particles,
+        abs_idx,
+        &[c00, c10, c20, c01, c11, c21, c02, c12, c22],
+    );
 }
 
-/// Inner loop of the G2P gather: iterates over Z axis for a given (di, dj).
+/// Inner loop of the G2P APIC gather: iterates over Z axis for a given (di, dj).
 ///
-/// Returns [accumulated_vx, accumulated_vy, accumulated_vz] for this row.
+/// Returns [vx, vy, vz, c00, c10, c20, c01, c11, c21, c02, c12, c22] for this row.
+/// The C matrix terms are the weighted outer product: 4 * w * outer(grid_vel, offset).
+/// The factor 4 comes from 4/dx^2 where dx=1 in grid units (standard APIC formulation).
+///
 /// Separated to keep branch count per function low (trap #15).
-fn gather_inner_loop(
+fn gather_inner_loop_apic(
     grid: &[u32],
     di: u32,
     dj: u32,
     base_x: u32,
     base_y: u32,
     base_z: u32,
+    px: f32,
+    py: f32,
+    pz: f32,
     wx: &[f32; 3],
     wy: &[f32; 3],
     wz: &[f32; 3],
     grid_size: u32,
     grid_offset: u32,
-) -> [f32; 3] {
-    let mut acc_vx = 0.0_f32;
-    let mut acc_vy = 0.0_f32;
-    let mut acc_vz = 0.0_f32;
+) -> [f32; 12] {
+    let mut acc = [0.0_f32; 12];
 
     let mut dk = 0u32;
     while dk < 3 {
@@ -129,14 +158,35 @@ fn gather_inner_loop(
             let gvy = pbmpm_types::grid_velocity_y(grid, cell_idx);
             let gvz = pbmpm_types::grid_velocity_z(grid, cell_idx);
 
-            acc_vx += w * gvx;
-            acc_vy += w * gvy;
-            acc_vz += w * gvz;
+            // Velocity gather
+            acc[0] += w * gvx;
+            acc[1] += w * gvy;
+            acc[2] += w * gvz;
+
+            // APIC: offset from particle to cell center
+            let ox = ci as f32 + 0.5 - px;
+            let oy = cj as f32 + 0.5 - py;
+            let oz = ck as f32 + 0.5 - pz;
+
+            // C += 4 * w * outer(grid_vel, offset)  (4/dx^2 where dx=1)
+            let w4 = 4.0 * w;
+            // Column 0 of C: grid_vel * ox
+            acc[3] += w4 * gvx * ox;
+            acc[4] += w4 * gvy * ox;
+            acc[5] += w4 * gvz * ox;
+            // Column 1 of C: grid_vel * oy
+            acc[6] += w4 * gvx * oy;
+            acc[7] += w4 * gvy * oy;
+            acc[8] += w4 * gvz * oy;
+            // Column 2 of C: grid_vel * oz
+            acc[9] += w4 * gvx * oz;
+            acc[10] += w4 * gvy * oz;
+            acc[11] += w4 * gvz * oz;
         }
         dk += 1;
     }
 
-    [acc_vx, acc_vy, acc_vz]
+    acc
 }
 
 /// Clamp a f32 value to [min, max].

--- a/crates/shaders/src/compute/pbmpm_p2g.rs
+++ b/crates/shaders/src/compute/pbmpm_p2g.rs
@@ -1,16 +1,14 @@
 //! PB-MPM Particle-to-Grid (P2G) compute shader.
 //!
-//! Each thread processes one particle, scattering mass and momentum to the
-//! 3x3x3 neighborhood of grid cells using quadratic B-spline weights.
-//! Uses `spirv_std::arch::atomic_f_add()` for concurrent float accumulation.
+//! Each thread processes one particle, scattering mass and momentum (with APIC
+//! affine term) to the 3x3x3 neighborhood of grid cells using quadratic B-spline
+//! weights. Uses `spirv_std::arch::atomic_f_add()` for concurrent float accumulation.
 //!
-//! This is the PB-MPM variant: simpler than MLS-MPM (no stress tensor scatter,
-//! no APIC affine term). PB-MPM iterates the entire P2G->grid_update->G2P loop
-//! 2-4 times per frame for stability at any timestep.
+//! The APIC affine momentum term (C * offset) preserves angular momentum across
+//! grid transfers, producing cohesive fluid motion instead of pure PIC dissipation.
 //!
-//! The grid buffer is bound as `&mut [f32]` (same physical buffer as the `&mut [u32]`
-//! used by other passes) to enable float atomics without pointer casts. This matches
-//! the existing MLS-MPM P2G pattern.
+//! PB-MPM iterates the entire P2G->grid_update->G2P loop multiple times per frame
+//! for stability at any timestep.
 //!
 //! Dispatch: `(ceil(particle_count / 256), 1, 1)` workgroups.
 
@@ -24,12 +22,13 @@ use crate::pbmpm_types;
 /// Number of f32 values per PB-MPM grid cell (32 bytes / 4 = 8 floats).
 const FLOATS_PER_CELL: u32 = pbmpm_types::PBMPM_GRID_CELL_SIZE_U32;
 
-/// Scatter one particle's mass and momentum to the grid.
+/// Scatter one particle's mass and APIC momentum to the grid.
 ///
 /// For each of the 27 neighboring grid cells:
 /// 1. Compute quadratic B-spline weight
 /// 2. Atomically add weighted mass
-/// 3. Atomically add weighted momentum (mass * velocity)
+/// 3. Atomically add weighted momentum: mass * (velocity + C * offset)
+///    where C is the APIC affine momentum matrix and offset is cell-particle distance.
 ///
 /// Grid cells are indexed with `grid_offset` to support multiple zones
 /// sharing the same grid buffer.
@@ -39,7 +38,7 @@ fn scatter_particle_to_grid(
     p_idx: u32,
     push: &PbmpmPush,
 ) {
-    // Read particle position and velocity into locals (trap #21)
+    // Read particle position, velocity, and C matrix into locals (trap #21)
     let abs_idx = push.particle_offset + p_idx;
     let px = pbmpm_types::particle_pos_x(particles, abs_idx);
     let py = pbmpm_types::particle_pos_y(particles, abs_idx);
@@ -48,6 +47,11 @@ fn scatter_particle_to_grid(
     let vx = pbmpm_types::particle_vel_x(particles, abs_idx);
     let vy = pbmpm_types::particle_vel_y(particles, abs_idx);
     let vz = pbmpm_types::particle_vel_z(particles, abs_idx);
+
+    // Read APIC C matrix columns into locals (trap #21)
+    let c_col0 = pbmpm_types::particle_c_col0(particles, abs_idx);
+    let c_col1 = pbmpm_types::particle_c_col1(particles, abs_idx);
+    let c_col2 = pbmpm_types::particle_c_col2(particles, abs_idx);
 
     // Base cell: floor(pos - 0.5) clamped to 0
     let base_x = (px - 0.5).max(0.0) as u32;
@@ -70,23 +74,34 @@ fn scatter_particle_to_grid(
     while di < 3 {
         let mut dj = 0u32;
         while dj < 3 {
-            scatter_inner_loop(grid, di, dj, base_x, base_y, base_z, &wx, &wy, &wz, gs, mass, vx, vy, vz, push.grid_offset);
+            scatter_inner_loop_apic(
+                grid, di, dj, base_x, base_y, base_z,
+                px, py, pz,
+                &wx, &wy, &wz, gs, mass, vx, vy, vz,
+                &c_col0, &c_col1, &c_col2,
+                push.grid_offset,
+            );
             dj += 1;
         }
         di += 1;
     }
 }
 
-/// Inner loop of the P2G scatter: iterates over the Z axis for a given (di, dj).
+/// Inner loop of the P2G APIC scatter: iterates over the Z axis for a given (di, dj).
 ///
+/// Scatters momentum with APIC affine term: mom = mass * (vel + C * offset).
 /// Separated to keep branch count per function low (trap #15).
-fn scatter_inner_loop(
+#[allow(clippy::too_many_arguments)]
+fn scatter_inner_loop_apic(
     grid: &mut [f32],
     di: u32,
     dj: u32,
     base_x: u32,
     base_y: u32,
     base_z: u32,
+    px: f32,
+    py: f32,
+    pz: f32,
     wx: &[f32; 3],
     wy: &[f32; 3],
     wz: &[f32; 3],
@@ -95,6 +110,9 @@ fn scatter_inner_loop(
     vx: f32,
     vy: f32,
     vz: f32,
+    c_col0: &[f32; 3],
+    c_col1: &[f32; 3],
+    c_col2: &[f32; 3],
     grid_offset: u32,
 ) {
     let mut dk = 0u32;
@@ -107,6 +125,21 @@ fn scatter_inner_loop(
             let w = wx[di as usize] * wy[dj as usize] * wz[dk as usize];
             let weighted_mass = w * mass;
 
+            // APIC: offset from particle to cell center
+            let ox = ci as f32 + 0.5 - px;
+            let oy = cj as f32 + 0.5 - py;
+            let oz = ck as f32 + 0.5 - pz;
+
+            // C * offset (column-major: result = col0*ox + col1*oy + col2*oz)
+            let cx = c_col0[0] * ox + c_col1[0] * oy + c_col2[0] * oz;
+            let cy = c_col0[1] * ox + c_col1[1] * oy + c_col2[1] * oz;
+            let cz = c_col0[2] * ox + c_col1[2] * oy + c_col2[2] * oz;
+
+            // Momentum with APIC affine term: mass * (vel + C * offset)
+            let mom_x = (vx + cx) * weighted_mass;
+            let mom_y = (vy + cy) * weighted_mass;
+            let mom_z = (vz + cz) * weighted_mass;
+
             // Flat cell index with offset for multi-zone support
             let cell_idx = grid_offset
                 + pbmpm_types::grid_cell_index(ci, cj, ck, grid_size);
@@ -115,9 +148,9 @@ fn scatter_inner_loop(
             // Atomically accumulate momentum and mass
             // Grid layout per cell: [mom_x, mom_y, mom_z, mass, force_x, force_y, force_z, pad]
             unsafe {
-                pbmpm_types::grid_atomic_add_f32(grid, base, vx * weighted_mass);
-                pbmpm_types::grid_atomic_add_f32(grid, base + 1, vy * weighted_mass);
-                pbmpm_types::grid_atomic_add_f32(grid, base + 2, vz * weighted_mass);
+                pbmpm_types::grid_atomic_add_f32(grid, base, mom_x);
+                pbmpm_types::grid_atomic_add_f32(grid, base + 1, mom_y);
+                pbmpm_types::grid_atomic_add_f32(grid, base + 2, mom_z);
                 pbmpm_types::grid_atomic_add_f32(grid, base + 3, weighted_mass);
             }
         }

--- a/crates/shaders/src/pbmpm_types.rs
+++ b/crates/shaders/src/pbmpm_types.rs
@@ -216,6 +216,97 @@ pub fn set_particle_f_identity(particles: &mut [u32], idx: u32) {
     write_particle_f32(particles, idx, P_F2_X + 3, 0.0); // pad
 }
 
+// ---- APIC C matrix accessors ----
+//
+// The APIC affine momentum matrix C is stored in the F_col fields.
+// For PB-MPM POC we don't use elastic deformation gradient, so F_col0/1/2
+// are repurposed as C_col0/1/2.
+//
+// C is a 3x3 matrix stored column-major:
+//   C_col0 = (C00, C10, C20) at offsets P_F0_X, P_F0_Y, P_F0_Z
+//   C_col1 = (C01, C11, C21) at offsets P_F1_X, P_F1_Y, P_F1_Z
+//   C_col2 = (C02, C12, C22) at offsets P_F2_X, P_F2_Y, P_F2_Z
+
+/// Reads C matrix element at (row, col) from particle.
+///
+/// C is the APIC affine momentum matrix, stored in F_col fields.
+/// Row/col must be 0, 1, or 2.
+pub fn particle_c_element(particles: &[u32], idx: u32, row: u32, col: u32) -> f32 {
+    let col_offset = match col {
+        0 => P_F0_X,
+        1 => P_F1_X,
+        _ => P_F2_X,
+    };
+    read_particle_f32(particles, idx, col_offset + row)
+}
+
+/// Reads C matrix column 0: (C00, C10, C20).
+pub fn particle_c_col0(particles: &[u32], idx: u32) -> [f32; 3] {
+    [
+        read_particle_f32(particles, idx, P_F0_X),
+        read_particle_f32(particles, idx, P_F0_Y),
+        read_particle_f32(particles, idx, P_F0_Z),
+    ]
+}
+
+/// Reads C matrix column 1: (C01, C11, C21).
+pub fn particle_c_col1(particles: &[u32], idx: u32) -> [f32; 3] {
+    [
+        read_particle_f32(particles, idx, P_F1_X),
+        read_particle_f32(particles, idx, P_F1_Y),
+        read_particle_f32(particles, idx, P_F1_Z),
+    ]
+}
+
+/// Reads C matrix column 2: (C02, C12, C22).
+pub fn particle_c_col2(particles: &[u32], idx: u32) -> [f32; 3] {
+    [
+        read_particle_f32(particles, idx, P_F2_X),
+        read_particle_f32(particles, idx, P_F2_Y),
+        read_particle_f32(particles, idx, P_F2_Z),
+    ]
+}
+
+/// Sets the full C matrix (3x3, column-major) for a particle.
+///
+/// `c` is laid out as [c00, c10, c20, c01, c11, c21, c02, c12, c22].
+pub fn set_particle_c_matrix(particles: &mut [u32], idx: u32, c: &[f32; 9]) {
+    // Column 0
+    write_particle_f32(particles, idx, P_F0_X, c[0]);
+    write_particle_f32(particles, idx, P_F0_Y, c[1]);
+    write_particle_f32(particles, idx, P_F0_Z, c[2]);
+    // Column 1
+    write_particle_f32(particles, idx, P_F1_X, c[3]);
+    write_particle_f32(particles, idx, P_F1_Y, c[4]);
+    write_particle_f32(particles, idx, P_F1_Z, c[5]);
+    // Column 2
+    write_particle_f32(particles, idx, P_F2_X, c[6]);
+    write_particle_f32(particles, idx, P_F2_Y, c[7]);
+    write_particle_f32(particles, idx, P_F2_Z, c[8]);
+}
+
+/// Zeros the APIC C matrix for a particle.
+///
+/// Used on initialization when no affine momentum is present.
+pub fn set_particle_c_zero(particles: &mut [u32], idx: u32) {
+    set_particle_c_matrix(particles, idx, &[0.0; 9]);
+}
+
+/// Computes C * offset, where C is the particle's APIC affine matrix and
+/// offset is a 3D vector. Returns [result_x, result_y, result_z].
+///
+/// C is column-major: result = col0*ox + col1*oy + col2*oz.
+pub fn apply_c_matrix(particles: &[u32], idx: u32, ox: f32, oy: f32, oz: f32) -> [f32; 3] {
+    let c0 = particle_c_col0(particles, idx);
+    let c1 = particle_c_col1(particles, idx);
+    let c2 = particle_c_col2(particles, idx);
+    [
+        c0[0] * ox + c1[0] * oy + c2[0] * oz,
+        c0[1] * ox + c1[1] * oy + c2[1] * oz,
+        c0[2] * ox + c1[2] * oy + c2[2] * oz,
+    ]
+}
+
 // ---- Grid cell accessors ----
 
 /// Reads a f32 from the grid buffer at the given cell index and field offset.


### PR DESCRIPTION
## Summary
- **APIC affine momentum transfer** replaces pure PIC in both G2P and P2G passes. The C matrix (stored in repurposed F_col fields) captures local velocity gradients, preserving angular momentum and producing cohesive fluid motion instead of "cockroaches scattering"
- **Increased PB-MPM iterations** from 2 to 4 for better constraint convergence and stability
- **Improved explosion impulse distribution**: inverse-square distance falloff (stronger near center), upward bias for parabolic arcs, hash-based per-particle speed variation (+-20%)

## Changes
| File | What |
|------|------|
| `crates/shaders/src/pbmpm_types.rs` | Added APIC C matrix accessors (read/write columns, apply C*offset) |
| `crates/shaders/src/compute/pbmpm_g2p.rs` | G2P now gathers both velocity AND C matrix via weighted outer products |
| `crates/shaders/src/compute/pbmpm_p2g.rs` | P2G now scatters momentum with APIC term: `mass * (vel + C * offset)` |
| `crates/server/src/pbmpm_zones.rs` | Iterations 2->4, improved impulse, zero C matrix init |

## Test plan
- [x] `cargo build` succeeds (clean shader rebuild)
- [x] `cargo test -p server -- --test-threads=1` — all 35+1 tests pass
- [ ] Visual smoke test: `cargo run -p app` — verify particles form cohesive arcs instead of scattering

🤖 Generated with [Claude Code](https://claude.com/claude-code)