### PR TITLE
feat: scale sim2 from 64 to 4096 chunks

### DIFF
--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -12,6 +12,7 @@ use client::{Camera, PlayerController, Renderer, renderer::required_instance_ext
 use content::MaterialDatabase;
 use glam::Vec3;
 use gpu_core::VulkanContext;
+use gpu_core::vram_budget::{self, VramBudget};
 use server::{GpuSimulation, ToolbarPushConstants, TOOLBAR_MAX_MATERIALS};
 use server::ca_simulation::CaSimulation;
 use server::pbmpm_zones::ActivationTrigger;
@@ -85,6 +86,8 @@ pub(crate) struct App {
     use_ca_sim: bool,
     /// CaSimulation instance (when `--sim2` is used).
     ca_sim: Option<CaSimulation>,
+    /// If true, fire a laser beam stress test after scene load.
+    laser: bool,
 }
 
 impl App {
@@ -103,6 +106,7 @@ impl App {
         model_pos: Option<(f32, f32, f32)>,
         use_world: bool,
         use_ca_sim: bool,
+        laser: bool,
     ) -> Self {
         // Try loading materials from RON file, fall back to hardcoded defaults
         let material_db = match content::load_material_database("assets/materials.ron") {
@@ -248,6 +252,7 @@ impl App {
             current_chunk: start_chunk,
             use_ca_sim,
             ca_sim: None,
+            laser,
         }
     }
 
@@ -514,31 +519,78 @@ impl ApplicationHandler for App {
             Err(e) => { tracing::error!("Failed to create Renderer: {}", e); event_loop.exit(); return; }
         };
         if self.use_ca_sim {
-            // Create CaSimulation (sim2)
+            // Query VRAM budget for chunk pool sizing
+            let vram_mb = vram_budget::query_vram_mb(&ctx.memory_properties);
+            let budget = VramBudget::from_available_vram(vram_mb);
+            tracing::info!(
+                "VRAM: {} MB, chunk_pool_slots={}, chunk_table_max_entries={}",
+                vram_mb, budget.chunk_pool_slots, budget.chunk_table_max_entries,
+            );
+
+            // Create CaSimulation (sim2) with VRAM-budget-derived slot count
             let ca_mats = server::ca_simulation::default_ca_materials();
             let ca_reactions = server::ca_simulation::default_ca_reactions();
-            let mut ca_sim = match CaSimulation::new(&ctx, &ca_mats, &ca_reactions, 64) {
+            let mut ca_sim = match CaSimulation::new(&ctx, &ca_mats, &ca_reactions, budget.chunk_pool_slots) {
                 Ok(s) => s,
                 Err(e) => { tracing::error!("Failed to create CaSimulation: {}", e); event_loop.exit(); return; }
             };
 
-            // Generate and load test scene
-            let scene = server::ca_simulation::generate_test_scene();
-            tracing::info!("Loading {} CA chunks for test scene", scene.len());
-            for (coord, voxel_data) in &scene {
+            // Determine scene size based on budget
+            let (scene_cx, scene_cy, scene_cz) = if budget.chunk_pool_slots >= 4096 {
+                (32i32, 4, 32)  // 1024x128x1024 voxels
+            } else if budget.chunk_pool_slots >= 2048 {
+                (16i32, 4, 16)  // 512x128x512 voxels
+            } else if budget.chunk_pool_slots >= 1024 {
+                (8i32, 4, 8)    // 256x128x256 voxels
+            } else {
+                (4i32, 4, 4)    // 128x128x128 voxels
+            };
+
+            let scene = server::ca_simulation::generate_test_scene_sized(scene_cx, scene_cy, scene_cz);
+            tracing::info!("Loading {} CA chunks for test scene ({}x{}x{} chunks = {}x{}x{} voxels)",
+                scene.len(), scene_cx, scene_cy, scene_cz,
+                scene_cx * 32, scene_cy * 32, scene_cz * 32);
+            for (i, (coord, voxel_data)) in scene.iter().enumerate() {
                 if let Err(e) = ca_sim.load_chunk(&ctx, *coord, voxel_data, [-1; 6]) {
                     tracing::error!("Failed to load chunk {:?}: {}", coord, e);
+                }
+                if i % 500 == 0 && i > 0 {
+                    tracing::info!("Loading chunks: {}/{}", i, scene.len());
                 }
             }
             ca_sim.update_neighbor_metadata(&ctx);
             tracing::info!("CaSimulation initialized with {} chunks", ca_sim.loaded_count());
 
-            // Place camera above and behind the terrain, looking at the center
-            // Terrain center is at (64, ~40, 64), volcano peak around y=90
-            self.player = PlayerController::new(Camera::look_at(
-                Vec3::new(64.0, 110.0, 0.0),
-                Vec3::new(64.0, 95.0, 20.0),
-            ));
+            // Place camera based on world size
+            let world_cx = (scene_cx * 32 / 2) as f32;
+            let world_cz = (scene_cz * 32 / 2) as f32;
+            if scene_cx > 4 {
+                // Large world: camera at center, high up, looking down
+                self.player = PlayerController::new(Camera::look_at(
+                    Vec3::new(world_cx, 160.0, world_cz - 200.0),
+                    Vec3::new(world_cx, 40.0, world_cz),
+                ));
+            } else {
+                // Small world: original camera placement
+                self.player = PlayerController::new(Camera::look_at(
+                    Vec3::new(64.0, 110.0, 0.0),
+                    Vec3::new(64.0, 95.0, 20.0),
+                ));
+            }
+
+            // Laser beam stress test (--laser flag)
+            if self.laser {
+                let world_width = scene_cx * 32;
+                let beam_end = world_width / 3;
+                let beam_y = 50;
+                let beam_z = scene_cz * 32 / 2;
+                match ca_sim.laser_beam(&ctx, 0, beam_end, beam_y, beam_z, 5) {
+                    Ok(removed) => tracing::info!(
+                        "Laser beam stress test: carved {} voxels across x=0..{}", removed, beam_end
+                    ),
+                    Err(e) => tracing::error!("Laser beam failed: {}", e),
+                }
+            }
 
             self.ca_sim = Some(ca_sim);
         } else {

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -35,6 +35,8 @@ struct Args {
     world: bool,
     /// If true, use CaSimulation (sim2) instead of GpuSimulation.
     sim2: bool,
+    /// If true, fire a laser beam across 1/3 of the map after scene load (stress test).
+    laser: bool,
 }
 
 fn parse_args() -> Args {
@@ -67,6 +69,7 @@ fn parse_args() -> Args {
     let big = args.contains(&"--big".to_string());
     let world = args.contains(&"--world".to_string());
     let sim2 = args.contains(&"--sim2".to_string());
+    let laser = args.contains(&"--laser".to_string());
     let model_pos = args
         .iter()
         .position(|a| a == "--model-pos")
@@ -83,7 +86,7 @@ fn parse_args() -> Args {
                 None
             }
         });
-    Args { headless, frames, output, substeps, scene, big, model, model_pos, world, sim2 }
+    Args { headless, frames, output, substeps, scene, big, model, model_pos, world, sim2, laser }
 }
 
 fn main() -> Result<()> {
@@ -97,7 +100,7 @@ fn main() -> Result<()> {
     if args.headless { return headless::run_headless(&args); }
 
     let event_loop = EventLoop::new()?;
-    let mut application = app::App::new(args.substeps, args.scene.as_deref(), args.big, args.model.as_deref(), args.model_pos, args.world, args.sim2);
+    let mut application = app::App::new(args.substeps, args.scene.as_deref(), args.big, args.model.as_deref(), args.model_pos, args.world, args.sim2, args.laser);
     event_loop.run_app(&mut application)?;
     tracing::info!("VOX Engine shut down");
     Ok(())

--- a/crates/gpu-core/src/vram_budget.rs
+++ b/crates/gpu-core/src/vram_budget.rs
@@ -25,6 +25,8 @@ pub struct VramBudget {
     pub render_height: u32,
     /// Number of chunk pool slots for the gigabuffer allocator.
     pub chunk_pool_slots: u32,
+    /// Maximum entries in the chunk table (3D lookup from coord to slot).
+    pub chunk_table_max_entries: u32,
 }
 
 impl VramBudget {
@@ -36,7 +38,7 @@ impl VramBudget {
     /// - 12 GB: 1M particles,   2M grid slots,   1280x720
     /// - 24 GB: 2M particles,   4M grid slots,   1920x1080
     pub fn from_available_vram(vram_mb: u32) -> Self {
-        let (max_particles, hash_grid_capacity, render_width, render_height, chunk_pool_slots) =
+        let (max_particles, hash_grid_capacity, render_width, render_height, chunk_pool_slots, chunk_table_max_entries) =
             budget_for_tier(vram_mb);
 
         Self {
@@ -46,6 +48,7 @@ impl VramBudget {
             render_width,
             render_height,
             chunk_pool_slots,
+            chunk_table_max_entries,
         }
     }
 }
@@ -54,11 +57,11 @@ impl VramBudget {
 ///
 /// Separated from [`VramBudget::from_available_vram`] to keep branch count
 /// manageable (trap #15) and satisfy trap #4a for testability.
-fn budget_for_tier(vram_mb: u32) -> (u32, u32, u32, u32, u32) {
+fn budget_for_tier(vram_mb: u32) -> (u32, u32, u32, u32, u32, u32) {
     if vram_mb >= 20_000 {
         // 24 GB+ tier (RTX 4090, A6000, etc.)
-        // 2048 chunk slots ~= 264 MB gigabuffer
-        return (2_000_000, 4_194_304, 1920, 1080, 2048);
+        // 4096 chunk slots ~= 528 MB gigabuffer
+        return (2_000_000, 4_194_304, 1920, 1080, 4096, 4096);
     }
     budget_for_lower_tier(vram_mb)
 }
@@ -66,19 +69,19 @@ fn budget_for_tier(vram_mb: u32) -> (u32, u32, u32, u32, u32) {
 /// Select budget for VRAM below 20 GB.
 ///
 /// Split helper to avoid >3 if/else branches per function (trap #15).
-fn budget_for_lower_tier(vram_mb: u32) -> (u32, u32, u32, u32, u32) {
+fn budget_for_lower_tier(vram_mb: u32) -> (u32, u32, u32, u32, u32, u32) {
     if vram_mb >= 10_000 {
         // 12 GB tier (RTX 4070 Ti, etc.)
-        // 1536 chunk slots ~= 198 MB gigabuffer
-        (1_000_000, 2_097_152, 1280, 720, 1536)
+        // 2048 chunk slots ~= 264 MB gigabuffer
+        (1_000_000, 2_097_152, 1280, 720, 2048, 2048)
     } else if vram_mb >= 7_000 {
         // 8 GB tier (RTX 4060, etc.)
         // 1024 chunk slots ~= 132 MB gigabuffer
-        (500_000, 1_048_576, 1280, 720, 1024)
+        (500_000, 1_048_576, 1280, 720, 1024, 1024)
     } else {
         // 6 GB or less
         // 512 chunk slots ~= 66 MB gigabuffer
-        (200_000, 524_288, 960, 540, 512)
+        (200_000, 524_288, 960, 540, 512, 512)
     }
 }
 
@@ -114,6 +117,7 @@ mod tests {
         assert_eq!(budget.render_width, 960);
         assert_eq!(budget.render_height, 540);
         assert_eq!(budget.chunk_pool_slots, 512);
+        assert_eq!(budget.chunk_table_max_entries, 512);
     }
 
     #[test]
@@ -124,6 +128,7 @@ mod tests {
         assert_eq!(budget.render_width, 1280);
         assert_eq!(budget.render_height, 720);
         assert_eq!(budget.chunk_pool_slots, 1024);
+        assert_eq!(budget.chunk_table_max_entries, 1024);
     }
 
     #[test]
@@ -133,7 +138,8 @@ mod tests {
         assert_eq!(budget.hash_grid_capacity, 2_097_152);
         assert_eq!(budget.render_width, 1280);
         assert_eq!(budget.render_height, 720);
-        assert_eq!(budget.chunk_pool_slots, 1536);
+        assert_eq!(budget.chunk_pool_slots, 2048);
+        assert_eq!(budget.chunk_table_max_entries, 2048);
     }
 
     #[test]
@@ -143,7 +149,8 @@ mod tests {
         assert_eq!(budget.hash_grid_capacity, 4_194_304);
         assert_eq!(budget.render_width, 1920);
         assert_eq!(budget.render_height, 1080);
-        assert_eq!(budget.chunk_pool_slots, 2048);
+        assert_eq!(budget.chunk_pool_slots, 4096);
+        assert_eq!(budget.chunk_table_max_entries, 4096);
     }
 
     #[test]
@@ -152,6 +159,7 @@ mod tests {
         assert_eq!(budget.max_particles, 200_000);
         assert_eq!(budget.render_width, 960);
         assert_eq!(budget.chunk_pool_slots, 512);
+        assert_eq!(budget.chunk_table_max_entries, 512);
     }
 
     #[test]

--- a/crates/server/src/ca_simulation.rs
+++ b/crates/server/src/ca_simulation.rs
@@ -179,6 +179,8 @@ pub struct CaSimulation {
     loaded_chunks: HashMap<[i32; 3], u32>,
     frame_number: u32,
     num_reactions: u32,
+    /// Maximum number of entries in the chunk table buffer.
+    chunk_table_max_entries: u32,
 
     // Cached device handle for recording commands
     device: ash::Device,
@@ -386,17 +388,16 @@ impl CaSimulation {
         buffer::upload(ctx, &render_materials, &material_render_buffer)?;
 
         // Chunk table buffer: 3D lookup from chunk coord -> slot_id
-        // Start with a default 4x4x4 table (resized in build_chunk_table)
-        let default_chunks_per_axis = 4u32;
-        let chunk_table_entries = default_chunks_per_axis.pow(3) as usize;
+        // Pre-allocate at full capacity (same as pool slots) to avoid reallocation.
+        let chunk_table_max_entries = chunk_slots;
         let chunk_table_buffer = buffer::create_device_local_buffer(
             ctx,
-            (chunk_table_entries * 4) as vk::DeviceSize,
+            (chunk_table_max_entries as u64) * 4,
             vk::BufferUsageFlags::STORAGE_BUFFER | vk::BufferUsageFlags::TRANSFER_DST,
             "ca-chunk-table-buffer",
         )?;
         // Initialize with 0xFFFFFFFF (not loaded)
-        let empty_table = vec![0xFFFFFFFFu32; chunk_table_entries];
+        let empty_table = vec![0xFFFFFFFFu32; chunk_table_max_entries as usize];
         buffer::upload(ctx, &empty_table, &chunk_table_buffer)?;
 
         // 8. Create chunk-aware render pass
@@ -447,12 +448,13 @@ impl CaSimulation {
             material_render_buffer,
             chunk_table_buffer,
             ca_render_pass,
-            chunks_x: default_chunks_per_axis,
-            chunks_y: default_chunks_per_axis,
-            chunks_z: default_chunks_per_axis,
+            chunks_x: 0,
+            chunks_y: 0,
+            chunks_z: 0,
             loaded_chunks: HashMap::new(),
             frame_number: 0,
             num_reactions: reactions.len() as u32,
+            chunk_table_max_entries,
             device: ctx.device.clone(),
         })
     }
@@ -1283,24 +1285,14 @@ impl CaSimulation {
             table[idx] = slot_id;
         }
 
-        // Recreate chunk table buffer if size changed
-        let needed_bytes = (table_size * 4) as vk::DeviceSize;
-        if needed_bytes > self.chunk_table_buffer.size {
-            // Need a larger buffer — destroy old one, create new one
-            // Note: we can't easily resize here because the descriptor set
-            // still references the old buffer. For now, we allocated enough
-            // initially (4^3 = 64 entries). If world is larger, log a warning.
-            tracing::warn!(
-                "Chunk table needs {} entries but buffer only has {} — some chunks may not render",
-                table_size,
-                self.chunk_table_buffer.size / 4,
-            );
-            // Upload what fits
-            let max_entries = (self.chunk_table_buffer.size / 4) as usize;
-            if table_size > max_entries {
-                table.truncate(max_entries);
-            }
-        }
+        // Assert table fits in pre-allocated buffer (sized at chunk_table_max_entries).
+        assert!(
+            table_size <= self.chunk_table_max_entries as usize,
+            "Chunk table needs {} entries but buffer was pre-allocated for {} — \
+             increase chunk_pool_slots or reduce world size",
+            table_size,
+            self.chunk_table_max_entries,
+        );
 
         if let Err(e) = buffer::upload(ctx, &table, &self.chunk_table_buffer) {
             tracing::error!("Failed to upload chunk table: {}", e);
@@ -1620,6 +1612,78 @@ impl CaSimulation {
     /// Returns the current frame number.
     pub fn frame_number(&self) -> u32 {
         self.frame_number
+    }
+
+    /// Carve a horizontal beam across the world for stress testing.
+    ///
+    /// Removes voxels in a line from `(start_x, y, z)` to `(end_x, y, z)` with
+    /// the given `radius`. Returns the total number of voxels removed.
+    pub fn laser_beam(
+        &mut self,
+        ctx: &VulkanContext,
+        start_x: i32,
+        end_x: i32,
+        y: i32,
+        z: i32,
+        radius: i32,
+    ) -> anyhow::Result<u32> {
+        let mut total_removed = 0u32;
+        let cs = 32i32;
+        let cx_min = (start_x - radius).div_euclid(cs);
+        let cx_max = (end_x + radius).div_euclid(cs);
+        let cy_min = (y - radius).div_euclid(cs);
+        let cy_max = (y + radius).div_euclid(cs);
+        let cz_min = (z - radius).div_euclid(cs);
+        let cz_max = (z + radius).div_euclid(cs);
+
+        for cx in cx_min..=cx_max {
+            for cy in cy_min..=cy_max {
+                for cz in cz_min..=cz_max {
+                    let coord = [cx, cy, cz];
+                    let slot_id = match self.loaded_chunks.get(&coord) {
+                        Some(&s) => s,
+                        None => continue,
+                    };
+                    let mut data = self.chunk_pool.download_chunk_voxels(ctx, slot_id)?;
+                    let chunk_origin = [cx * 32, cy * 32, cz * 32];
+                    let mut modified = false;
+
+                    for lz in 0..32i32 {
+                        for ly in 0..32i32 {
+                            for lx in 0..32i32 {
+                                let wx = chunk_origin[0] + lx;
+                                let wy = chunk_origin[1] + ly;
+                                let wz = chunk_origin[2] + lz;
+
+                                if wx < start_x || wx > end_x { continue; }
+                                let dy = wy - y;
+                                let dz = wz - z;
+                                if dy * dy + dz * dz > radius * radius { continue; }
+
+                                let idx = lz as usize * 32 * 32 + ly as usize * 32 + lx as usize;
+                                if data[idx] != 0 {
+                                    data[idx] = 0;
+                                    total_removed += 1;
+                                    modified = true;
+                                }
+                            }
+                        }
+                    }
+
+                    if modified {
+                        self.chunk_pool.upload_chunk_voxels(
+                            ctx, vk::CommandBuffer::null(), slot_id, &data,
+                        )?;
+                    }
+                }
+            }
+        }
+
+        tracing::info!(
+            "Laser beam removed {} voxels across x={}..{}",
+            total_removed, start_x, end_x,
+        );
+        Ok(total_removed)
     }
 
     /// Free all GPU resources.
@@ -1964,12 +2028,21 @@ fn generate_voxel(wx: usize, wy: usize, wz: usize, height: usize) -> Voxel {
 /// Returns chunks as `(coord, voxel_data)` pairs for a 4x4x4 grid
 /// (128x128x128 voxels).
 pub fn generate_test_scene() -> Vec<([i32; 3], Vec<u32>)> {
-    let mut chunks = Vec::new();
+    generate_test_scene_sized(4, 4, 4)
+}
 
-    // Generate 4x4x4 = 64 chunks covering 128x128x128 voxels
-    for cx in 0..4i32 {
-        for cy in 0..4i32 {
-            for cz in 0..4i32 {
+/// Generate a terrain scene of arbitrary size.
+///
+/// `cx_count`, `cy_count`, `cz_count` specify the number of 32-voxel chunks
+/// along each axis. The terrain noise tiles naturally, so any size works.
+/// Returns chunks as `(coord, voxel_data)` pairs.
+pub fn generate_test_scene_sized(cx_count: i32, cy_count: i32, cz_count: i32) -> Vec<([i32; 3], Vec<u32>)> {
+    let total = (cx_count as u64) * (cy_count as u64) * (cz_count as u64);
+    let mut chunks = Vec::with_capacity(total as usize);
+
+    for cx in 0..cx_count {
+        for cy in 0..cy_count {
+            for cz in 0..cz_count {
                 let mut data = vec![0u32; CA_CHUNK_VOXELS];
 
                 for lz in 0..32usize {
@@ -1992,6 +2065,12 @@ pub fn generate_test_scene() -> Vec<([i32; 3], Vec<u32>)> {
                 chunks.push(([cx, cy, cz], data));
             }
         }
+    }
+
+    if total > 100 {
+        tracing::info!("Generated {} chunks ({}x{}x{} = {}x{}x{} voxels)",
+            chunks.len(), cx_count, cy_count, cz_count,
+            cx_count * 32, cy_count * 32, cz_count * 32);
     }
 
     chunks

--- a/crates/shaders/src/compute/ca_render.rs
+++ b/crates/shaders/src/compute/ca_render.rs
@@ -68,6 +68,15 @@ fn ca_temperature(voxel: u32) -> u32 {
     (voxel >> TEMPERATURE_SHIFT) & TEMPERATURE_MASK
 }
 
+/// Compute max DDA steps with a cap for large worlds.
+///
+/// For worlds wider than 256 voxels, caps at 512 steps to avoid
+/// excessive per-pixel iteration cost.
+fn compute_max_steps(max_dim: u32, multiplier: u32) -> u32 {
+    let raw = max_dim * multiplier;
+    if raw > 512 { 512 } else { raw }
+}
+
 /// Remap CA material ID to render material ID.
 ///
 /// CA IDs: 0=air, 1=stone, 2=sand, 3=water, 4=lava, 5=steam, 6=ice
@@ -284,9 +293,9 @@ fn march_shadow_chunked(
     let mut t_max_y = if dir.y.abs() > 1e-8 { (next_y - start.y) / dir.y } else { 1e20 };
     let mut t_max_z = if dir.z.abs() > 1e-8 { (next_z - start.z) / dir.z } else { 1e20 };
 
-    // Use a reasonable max step count based on max world dimension
+    // Use a reasonable max step count based on max world dimension (capped for large worlds)
     let max_dim = world_size_x.max(world_size_y).max(world_size_z);
-    let max_steps = max_dim * 2;
+    let max_steps = compute_max_steps(max_dim, 2);
     let mut i: u32 = 0;
 
     // Skip start voxel
@@ -651,7 +660,7 @@ fn render_pixel_chunked(
     let mut t_max_z = if ray_dir.z.abs() > 1e-8 { (next_z - entry.z) / ray_dir.z } else { 1e20 };
 
     let max_dim = push.world_size_x.max(push.world_size_y).max(push.world_size_z);
-    let max_steps = max_dim * 3;
+    let max_steps = compute_max_steps(max_dim, 3);
     let mut last_axis: u32 = 0;
     let mut i: u32 = 0;
     let mut hit = false;

--- a/crates/shared/src/constants.rs
+++ b/crates/shared/src/constants.rs
@@ -123,7 +123,7 @@ pub const CA_CHUNK_DIRTY_BITMASK_BYTES: usize = CA_CHUNK_DIRTY_BITMASK_U32S * 4;
 pub const CA_SLOT_BYTES: usize = CA_CHUNK_BYTES + CA_CHUNK_DIRTY_BITMASK_BYTES; // 135168
 
 /// Maximum number of loaded CA chunks.
-pub const CA_MAX_CHUNKS: usize = 2048;
+pub const CA_MAX_CHUNKS: usize = 4096;
 
 /// Maximum number of material types in the CA system.
 pub const CA_MAX_MATERIALS: usize = 1024;


### PR DESCRIPTION
## Summary
- **VramBudget**: Added `chunk_table_max_entries` field. Updated all tiers: 6GB=512, 8GB=1024, 12GB=2048, 24GB=4096 chunk slots (up from 512/1024/1536/2048).
- **CaSimulation**: Pre-allocate chunk table buffer at full capacity (`chunk_slots` entries). Replaced truncation warning with assert. Added `generate_test_scene_sized(cx, cy, cz)` parameterized scene generator and `laser_beam()` stress test method.
- **Constants**: `CA_MAX_CHUNKS` raised from 2048 to 4096.
- **Shader DDA**: Capped `max_steps` at 512 via `compute_max_steps()` helper to prevent excessive iteration on large worlds.
- **App**: Scene size auto-scales with VRAM budget (4x4x4 to 32x4x32 chunks). Camera auto-positions for large worlds. Added `--laser` CLI flag.

## Test plan
- [x] `cargo test -p gpu-core` — all 27 tests pass (including updated vram_budget asserts)
- [x] `cargo test -p server -- --test-threads=1` — all 36 tests pass
- [x] `cargo test -p shared` — all 89 tests pass
- [x] `cargo build -p app` — clean build
- [ ] Manual: `cargo run -p app -- --sim2` (should auto-detect 24GB and load 4096 chunks)
- [ ] Manual: `cargo run -p app -- --sim2 --laser` (should carve beam + render)

🤖 Generated with [Claude Code](https://claude.com/claude-code)